### PR TITLE
refactor: migrate database schema handling to backend service

### DIFF
--- a/.github/workflows/deploy-pipeline.yml
+++ b/.github/workflows/deploy-pipeline.yml
@@ -65,7 +65,6 @@ jobs:
       - name: Copy files to server
         run: |
           scp .env docker-compose.yml Caddyfile healthcheck.sh githubuser@fov.ee:~/
-          scp -r src/main/resources/db/migration githubuser@fov.ee:~/
       - name: Deploy with Docker Compose
         run: |
           ssh githubuser@fov.ee "\

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,22 +29,6 @@ services:
       retries: 5
     restart: always
 
-  db-migrate:
-    container_name: db-migrate
-    image: flyway/flyway:11-alpine
-    environment:
-      FLYWAY_USER: ${POSTGRES_USER}
-      FLYWAY_PASSWORD: ${POSTGRES_PASSWORD}
-      FLYWAY_URL: jdbc:postgresql://postgres:5432/portfolio
-      FLYWAY_LOCATIONS: filesystem:/migrations
-    volumes:
-      - ./src/main/resources/db/migration:/migrations:ro
-    depends_on:
-      postgres:
-        condition: service_healthy
-    command: migrate
-    restart: "no"
-
   backend:
     container_name: backend
     environment:
@@ -52,7 +36,7 @@ services:
       SPRING_DATASOURCE_USERNAME: ${POSTGRES_USER}
       SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
       SPRING_PROFILES_ACTIVE: default
-      SPRING_FLYWAY_ENABLED: "false"
+      SPRING_FLYWAY_ENABLED: "true"
       VISION_BASE64_ENCODED_KEY: ${VISION_BASE64_ENCODED_KEY}
       TELEGRAM_BOT_TOKEN: ${TELEGRAM_BOT_TOKEN}
       VISION_ENABLED: true
@@ -63,8 +47,10 @@ services:
     ports:
       - '8080:8080'
     depends_on:
-      - postgres
-      - redis
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_started
     restart: always
     mem_limit: 2048m
     healthcheck:


### PR DESCRIPTION
Remove separate db-migrate service and enable Flyway in backend:
- Remove standalone Flyway container from docker-compose.yml
- Enable SPRING_FLYWAY_ENABLED in backend service
- Add postgres health check dependency to backend
- Remove migration folder copy from deployment pipeline

Migrations are now handled by Spring Boot backend on startup, simplifying deployment and reducing service dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)