### PR TITLE
fix: align EtfPosition schema with deployed entity model

### DIFF
--- a/src/main/resources/db/migration/V202510241200__update_etf_position_schema.sql
+++ b/src/main/resources/db/migration/V202510241200__update_etf_position_schema.sql
@@ -1,0 +1,26 @@
+-- Rename etf_positions to etf_position to match entity
+ALTER TABLE etf_positions RENAME TO etf_position;
+
+-- Add id column as primary key
+ALTER TABLE etf_position ADD COLUMN id BIGSERIAL;
+
+-- Add updated_at and version columns (required by BaseEntity)
+ALTER TABLE etf_position ADD COLUMN updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP NOT NULL;
+ALTER TABLE etf_position ADD COLUMN version BIGINT DEFAULT 0 NOT NULL;
+
+-- Drop the old composite primary key
+ALTER TABLE etf_position DROP CONSTRAINT etf_positions_pkey;
+
+-- Set id as the new primary key
+ALTER TABLE etf_position ADD PRIMARY KEY (id);
+
+-- Re-create the unique constraint for the composite key
+ALTER TABLE etf_position ADD CONSTRAINT etf_position_unique_key
+  UNIQUE (etf_instrument_id, holding_id, snapshot_date);
+
+-- Update indexes to use new table name
+DROP INDEX IF EXISTS idx_etf_positions_snapshot;
+DROP INDEX IF EXISTS idx_etf_positions_weight;
+
+CREATE INDEX idx_etf_position_snapshot ON etf_position (etf_instrument_id, snapshot_date);
+CREATE INDEX idx_etf_position_weight ON etf_position (weight_percentage DESC);


### PR DESCRIPTION
Create migration to transform etf_positions table to match the BaseEntity model:
- Rename table from etf_positions (plural) to etf_position (singular)
- Add id column as primary key (required by BaseEntity)
- Add updated_at and version columns (required by BaseEntity)
- Convert composite primary key to unique constraint
- Update entity to extend BaseEntity (aligning with deployed code)
- Update repository to use Long ID type instead of composite key
- Update service to use save() instead of upsertPosition()
- Delete unused EtfPositionId class

This fixes the schema mismatch where the deployed Docker image (built from main) expects the BaseEntity schema, but migrations were creating a different schema with composite keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)