### PR TITLE
Fix Feign decoder to handle String return types

### DIFF
--- a/src/main/kotlin/ee/tenman/portfolio/configuration/JacksonFeignDecoder.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/configuration/JacksonFeignDecoder.kt
@@ -5,6 +5,7 @@ import feign.codec.DecodeException
 import feign.codec.Decoder
 import tools.jackson.databind.ObjectMapper
 import java.lang.reflect.Type
+import java.nio.charset.StandardCharsets
 
 class JacksonFeignDecoder(
   private val objectMapper: ObjectMapper,
@@ -18,6 +19,11 @@ class JacksonFeignDecoder(
     }
     if (response.body() == null) {
       return null
+    }
+    if (type == String::class.java) {
+      return response.body().asInputStream().use { inputStream ->
+        inputStream.readAllBytes().toString(StandardCharsets.UTF_8)
+      }
     }
     runCatching {
       response.body().asInputStream().use { inputStream ->


### PR DESCRIPTION
## Summary

- Fix `JacksonFeignDecoder` to handle `String` return types directly without JSON parsing
- This fixes the `LightyearHoldingsClient` which returns HTML content

## Problem

The decoder was trying to parse ALL responses as JSON, causing failures when Feign clients declare `String` as return type. The Lightyear API returns HTML which starts with `<`, causing Jackson to fail with "Unexpected character '<'".

## Test plan

- [x] Verified Lightyear holdings fetch now works
- [x] Backend compiles successfully