### PR TITLE
Refactor backend services with idiomatic Kotlin patterns

### DIFF
--- a/src/main/kotlin/ee/tenman/portfolio/service/HoldingParser.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/service/HoldingParser.kt
@@ -15,20 +15,15 @@ class HoldingParser {
     element: SelenideElement,
     rank: Int,
   ): HoldingData? =
-    try {
+    runCatching {
       log.debug("Parsing Holding data from row: {}", element.text())
-      val holding = extractHoldingData(element, rank)
-
-      if (holding != null) {
+      extractHoldingData(element, rank)?.also { holding ->
         validateWeightSequence(holding.weight, rank)
         previousWeight = holding.weight
       }
-
-      holding
-    } catch (e: Exception) {
+    }.onFailure { e ->
       log.warn("Failed to parse holding row: ${element.text()}", e)
-      null
-    }
+    }.getOrNull()
 
   fun resetState() {
     previousWeight = null
@@ -89,104 +84,66 @@ class HoldingParser {
     weight: BigDecimal,
     name: String,
   ): BigDecimal? {
-    if (weight == BigDecimal.ZERO) {
-      log.debug("Skipping holding with zero weight: {}", name)
-      return null
-    }
+    if (weight == BigDecimal.ZERO) return null.also { log.debug("Skipping holding with zero weight: {}", name) }
     return normalizeWeight(weight, name)
   }
 
-  private fun extractLogoUrl(element: SelenideElement): String? {
-    val logoUrl =
-      try {
-        val imgSrc =
-          element
-            .findAll("img")
-            .firstOrNull()
-            ?.getAttribute("src")
-            ?.takeIf { it.isNotEmpty() }
-
-        imgSrc ?: extractBackgroundImageUrl(element)
-      } catch (e: Exception) {
-        log.debug("Failed to extract logo URL: ${e.message}")
-        null
-      }
-
-    logoUrl?.let { log.debug("Found logo URL: $it") }
-      ?: log.debug("No logo found in element")
-
-    return logoUrl
-  }
+  private fun extractLogoUrl(element: SelenideElement): String? =
+    runCatching {
+      element
+        .findAll("img")
+        .firstOrNull()
+        ?.getAttribute("src")
+        ?.takeIf { it.isNotEmpty() }
+        ?: extractBackgroundImageUrl(element)
+    }.onFailure { e ->
+      log.debug("Failed to extract logo URL: ${e.message}")
+    }.getOrNull()
+      ?.also { log.debug("Found logo URL: $it") }
+      ?: null.also { log.debug("No logo found in element") }
 
   private fun extractBackgroundImageUrl(element: SelenideElement): String? {
-    val divs = element.findAll("div")
-
-    for (div in divs) {
-      val style = div.getAttribute("style") ?: continue
-      if (style.contains("background-image")) {
-        val urlPattern = Regex("""url\(['"]?([^'"()]+)['"]?\)""")
-        val match = urlPattern.find(style)
-        if (match != null) {
-          return match.groupValues[1]
-        }
-      }
+    val urlPattern = Regex("""url\(['"]?([^'"()]+)['"]?\)""")
+    return element.findAll("div").firstNotNullOfOrNull { div ->
+      div
+        .getAttribute("style")
+        ?.takeIf { it.contains("background-image") }
+        ?.let { urlPattern.find(it)?.groupValues?.get(1) }
     }
-
-    return null
   }
 
   private fun extractWeightFromAllDivs(allDivs: List<String>): BigDecimal {
     val weightText =
-      allDivs
-        .firstOrNull { it.contains("%") && !it.contains("$") && !it.contains("\n") }
-        ?: return BigDecimal.ZERO
-
-    val cleanedText =
-      weightText
-        .replace("%", "")
-        .replace(",", "")
-        .trim()
-
-    return try {
-      val parsedWeight = BigDecimal(cleanedText)
-
-      if (parsedWeight > BigDecimal(10000)) {
-        log.warn(
-          "Parsed weight {} from '{}' exceeds 10000%, likely incorrect data (market cap/volume). Returning ZERO.",
-          parsedWeight,
-          weightText,
-        )
-        return BigDecimal.ZERO
+      allDivs.firstOrNull { it.contains("%") && !it.contains("$") && !it.contains("\n") }
+      ?: return BigDecimal.ZERO
+    val cleanedText = weightText.replace("%", "").replace(",", "").trim()
+    return runCatching { BigDecimal(cleanedText) }
+      .onFailure { log.warn("Failed to parse weight from: '$weightText'", it) }
+      .getOrNull()
+      ?.takeIf { it <= BigDecimal(10000) }
+      ?: BigDecimal.ZERO.also {
+        if (cleanedText.toBigDecimalOrNull()?.let { parsed -> parsed > BigDecimal(10000) } == true) {
+          log.warn("Parsed weight from '{}' exceeds 10000%, likely incorrect data", weightText)
+        }
       }
-
-      parsedWeight
-    } catch (e: NumberFormatException) {
-      log.warn("Failed to parse weight from: '$weightText'", e)
-      BigDecimal.ZERO
-    }
   }
 
   private fun normalizeWeight(
     weight: BigDecimal,
     name: String,
   ): BigDecimal? {
-    if (weight <= BigDecimal(100)) {
-      return weight
+    if (weight <= BigDecimal(100)) return weight
+    val maxDivisor = 1_000_000_000
+    val result =
+      generateSequence(10) { it * 10 }
+      .takeWhile { it <= maxDivisor }
+      .map { divisor -> divisor to weight.divide(BigDecimal(divisor), 4, java.math.RoundingMode.HALF_UP) }
+      .firstOrNull { (_, normalized) -> normalized <= BigDecimal(100) }
+    if (result == null) {
+      log.warn("Unable to normalize weight {} for holding {}, skipping", weight, name)
+      return null
     }
-
-    var normalized = weight
-    var divisor = 1
-
-    while (normalized > BigDecimal(100)) {
-      divisor *= 10
-      normalized = weight.divide(BigDecimal(divisor), 4, java.math.RoundingMode.HALF_UP)
-
-      if (divisor > 1_000_000_000) {
-        log.warn("Unable to normalize weight {} for holding {}, skipping", weight, name)
-        return null
-      }
-    }
-
+    val (divisor, normalized) = result
     log.info("Normalized weight {} to {} for holding {} (divided by {})", weight, normalized, name, divisor)
     return normalized
   }

--- a/src/test/kotlin/ee/tenman/portfolio/service/HoldingParserTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/service/HoldingParserTest.kt
@@ -1,0 +1,164 @@
+package ee.tenman.portfolio.service
+
+import ch.tutteli.atrium.api.fluent.en_GB.notToEqualNull
+import ch.tutteli.atrium.api.fluent.en_GB.toEqual
+import ch.tutteli.atrium.api.fluent.en_GB.toEqualNumerically
+import ch.tutteli.atrium.api.verbs.expect
+import com.codeborne.selenide.ElementsCollection
+import com.codeborne.selenide.SelenideElement
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+class HoldingParserTest {
+  private lateinit var holdingParser: HoldingParser
+  private lateinit var mockElement: SelenideElement
+  private lateinit var mockDivCollection: ElementsCollection
+
+  @BeforeEach
+  fun setUp() {
+    holdingParser = HoldingParser()
+    mockElement = mockk(relaxed = true)
+    mockDivCollection = mockk(relaxed = true)
+  }
+
+  @Test
+  fun `should parse holding row with valid data`() {
+    val divTexts = listOf("Apple Inc\n\$AAPL\nTechnology", "5.25%")
+    val mockImgCollection = mockk<ElementsCollection>(relaxed = true)
+    every { mockElement.text() } returns "Apple Inc \$AAPL Technology 5.25%"
+    every { mockElement.findAll("div") } returns mockDivCollection
+    every { mockDivCollection.texts() } returns divTexts
+    every { mockElement.findAll("img") } returns mockImgCollection
+    every { mockImgCollection.firstOrNull() } returns null
+
+    val result = holdingParser.parseHoldingRow(mockElement, 1)
+
+    expect(result).notToEqualNull()
+    expect(result!!.name).toEqual("Apple Inc")
+    expect(result.ticker).toEqual("AAPL")
+    expect(result.sector).toEqual("Technology")
+    expect(result.weight).toEqualNumerically(BigDecimal("5.25"))
+    expect(result.rank).toEqual(1)
+  }
+
+  @Test
+  fun `should return null when holding has zero weight`() {
+    val divTexts = listOf("Some Company\n\$XYZ\nFinance", "0%")
+    every { mockElement.text() } returns "Some Company \$XYZ Finance 0%"
+    every { mockElement.findAll("div") } returns mockDivCollection
+    every { mockDivCollection.texts() } returns divTexts
+
+    val result = holdingParser.parseHoldingRow(mockElement, 1)
+
+    expect(result).toEqual(null)
+  }
+
+  @Test
+  fun `should handle instrument not available`() {
+    val divTexts = listOf("Unknown Corp\n\$UNK\nUnknown", "Instrument is not available", "2.5%")
+    val mockImgCollection = mockk<ElementsCollection>(relaxed = true)
+    every { mockElement.text() } returns "Unknown Corp Instrument is not available 2.5%"
+    every { mockElement.findAll("div") } returns mockDivCollection
+    every { mockDivCollection.texts() } returns divTexts
+    every { mockElement.findAll("img") } returns mockImgCollection
+    every { mockImgCollection.firstOrNull() } returns null
+
+    val result = holdingParser.parseHoldingRow(mockElement, 1)
+
+    expect(result).notToEqualNull()
+    expect(result!!.name).toEqual("Unknown Corp")
+    expect(result.ticker).toEqual(null)
+    expect(result.sector).toEqual(null)
+  }
+
+  @Test
+  fun `should normalize weight greater than 100`() {
+    val divTexts = listOf("Big Corp\n\$BIG\nIndustrial", "525%")
+    val mockImgCollection = mockk<ElementsCollection>(relaxed = true)
+    every { mockElement.text() } returns "Big Corp \$BIG Industrial 525%"
+    every { mockElement.findAll("div") } returns mockDivCollection
+    every { mockDivCollection.texts() } returns divTexts
+    every { mockElement.findAll("img") } returns mockImgCollection
+    every { mockImgCollection.firstOrNull() } returns null
+
+    val result = holdingParser.parseHoldingRow(mockElement, 1)
+
+    expect(result).notToEqualNull()
+    expect(result!!.weight).toEqualNumerically(BigDecimal("52.5000"))
+  }
+
+  @Test
+  fun `should return null when name parts are empty`() {
+    every { mockElement.text() } returns ""
+    every { mockElement.findAll("div") } returns mockDivCollection
+    every { mockDivCollection.texts() } returns emptyList()
+
+    val result = holdingParser.parseHoldingRow(mockElement, 1)
+
+    expect(result).toEqual(null)
+  }
+
+  @Test
+  fun `should reset state clears previous weight`() {
+    holdingParser.resetState()
+  }
+
+  @Test
+  fun `should handle exception during parsing gracefully`() {
+    every { mockElement.text() } returns "Valid text"
+    every { mockElement.findAll("div") } throws RuntimeException("Parse error")
+
+    val result = holdingParser.parseHoldingRow(mockElement, 1)
+
+    expect(result).toEqual(null)
+  }
+
+  @Test
+  fun `should skip weight values exceeding 10000 percent`() {
+    val divTexts = listOf("Huge Corp\n\$HUGE\nFinance", "15000%")
+    every { mockElement.text() } returns "Huge Corp \$HUGE Finance 15000%"
+    every { mockElement.findAll("div") } returns mockDivCollection
+    every { mockDivCollection.texts() } returns divTexts
+
+    val result = holdingParser.parseHoldingRow(mockElement, 1)
+
+    expect(result).toEqual(null)
+  }
+
+  @Test
+  fun `should handle weight with comma separator`() {
+    val divTexts = listOf("European Corp\n\$EUR\nFinance", "1,234%")
+    val mockImgCollection = mockk<ElementsCollection>(relaxed = true)
+    every { mockElement.text() } returns "European Corp \$EUR Finance 1,234%"
+    every { mockElement.findAll("div") } returns mockDivCollection
+    every { mockDivCollection.texts() } returns divTexts
+    every { mockElement.findAll("img") } returns mockImgCollection
+    every { mockImgCollection.firstOrNull() } returns null
+
+    val result = holdingParser.parseHoldingRow(mockElement, 1)
+
+    expect(result).notToEqualNull()
+    expect(result!!.weight).toEqualNumerically(BigDecimal("12.3400"))
+  }
+
+  @Test
+  fun `should extract background image url when img src not available`() {
+    val divTexts = listOf("Tesla\n\$TSLA\nAutomotive", "3.2%")
+    val mockDiv = mockk<SelenideElement>(relaxed = true)
+    val mockImgCollection = mockk<ElementsCollection>(relaxed = true)
+    every { mockElement.text() } returns "Tesla \$TSLA Automotive 3.2%"
+    every { mockElement.findAll("div") } returns mockDivCollection
+    every { mockDivCollection.texts() } returns divTexts
+    every { mockElement.findAll("img") } returns mockImgCollection
+    every { mockImgCollection.firstOrNull() } returns null
+    every { mockDivCollection.iterator() } returns mutableListOf(mockDiv).iterator()
+    every { mockDiv.getAttribute("style") } returns "background-image: url('https://example.com/bg-logo.png')"
+
+    val result = holdingParser.parseHoldingRow(mockElement, 1)
+
+    expect(result).notToEqualNull()
+  }
+}


### PR DESCRIPTION
## Summary
- Refactor 4 long methods identified in issue #961
- Apply idiomatic Kotlin patterns across backend services
- Add comprehensive unit tests for HoldingParser (10 tests)

## Changes

### HoldingParser
- Add 10 unit tests covering all parsing scenarios
- Apply `runCatching` for error handling
- Use `generateSequence` for weight normalization
- Use `firstNotNullOfOrNull` for logo URL extraction

### InstrumentService.calculateProfitsForPlatform (79 → ~20 lines)
- Break down into focused helper methods
- Introduce `TransactionState` data class with `fold()`
- Extract: `processTransactions`, `processBuyTransaction`, `processSellTransaction`
- Extract: `calculateAverageCost`, `calculateUnrealizedProfit`, `distributeProfitsToBuyTransactions`
- Replace try-catch with `runCatching` in `parsePlatformFilters`

### CalculationService.calculateRollingXirr (56 → ~15 lines)
- Replace while loop with `generateSequence`
- Extract `calculateXirrForPeriod` helper
- Use functional chain with `takeIf` and `let`
- Apply `runCatching` in `isValidXirr`

### EtfBreakdownService.buildHoldingsMap (57 → ~15 lines)
- Use `flatMap` instead of mutableList with forEach
- Extract: `buildHoldingsForEtf`, `aggregateHoldings`
- Extract: `buildHoldingGroupKey`, `buildHoldingEntry`
- Move inner class to `InternalHoldingData`
- Replace try-catch with `runCatching` in `getCurrentPrice`

## Test plan
- [x] All existing tests pass (267 backend tests)
- [x] New HoldingParser tests pass (10 tests)
- [x] CI/CD pipeline validates changes

Closes #961