### PR TITLE
Refactor backend services with idiomatic Kotlin patterns

### DIFF
--- a/src/main/kotlin/ee/tenman/portfolio/service/EtfBreakdownService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/service/EtfBreakdownService.kt
@@ -148,73 +148,71 @@ class EtfBreakdownService(
     etfs: List<Instrument>,
     platformFilter: Set<Platform>? = null,
   ): Map<HoldingKey, HoldingValue> {
-    data class HoldingData(
-      val ticker: String?,
-      val name: String,
-      val sector: String?,
-      val value: BigDecimal,
-      val etfSymbol: String,
-      val platforms: Set<Platform>,
-    )
-    val allHoldings = mutableListOf<HoldingData>()
-    etfs.forEach { etf ->
-      val positions = etfPositionRepository.findLatestPositionsByEtfId(etf.id)
-      val etfQuantity = calculateNetQuantity(etf.id, platformFilter)
-      val etfPrice = getCurrentPrice(etf)
-      val etfPlatforms = getPlatformsForInstrument(etf.id, platformFilter)
-      positions.forEach { position ->
-        val holdingValue = calculateHoldingValue(position, etfQuantity, etfPrice)
-        allHoldings.add(
-          HoldingData(
-            ticker =
-              position.holding.ticker
-                ?.uppercase()
-                ?.trim()
-                ?.takeIf { it.isNotBlank() },
-            name = position.holding.name.trim(),
-            sector =
-              position.holding.sector
-                ?.trim()
-                ?.takeIf { it.isNotBlank() },
-            value = holdingValue,
-            etfSymbol = etf.symbol,
-            platforms = etfPlatforms,
-          ),
-        )
-      }
-    }
-    val groupedByKey =
-      allHoldings.groupBy { holding ->
-        if (!holding.ticker.isNullOrBlank()) {
-          "ticker:${holding.ticker}"
-        } else {
-          "name:${holding.name.lowercase()}:${holding.sector?.lowercase().orEmpty()}"
-        }
-      }
-    return groupedByKey.entries.associate { (_, holdings) ->
-      val bestName = holdings.maxByOrNull { it.name.length }!!.name
-      val bestTicker = holdings.firstOrNull { !it.ticker.isNullOrBlank() }?.ticker
-      val bestSector = holdings.mapNotNull { it.sector }.maxByOrNull { it.length }
-      val key = HoldingKey(ticker = bestTicker, name = bestName, sector = bestSector)
-      val totalValue = holdings.fold(BigDecimal.ZERO) { acc, h -> acc.add(h.value) }
-      val etfSymbols = holdings.map { it.etfSymbol }.toMutableSet()
-      val allPlatforms = holdings.flatMap { it.platforms }.toMutableSet()
-      key to HoldingValue(totalValue = totalValue, etfSymbols = etfSymbols, platforms = allPlatforms)
+    val allHoldings = etfs.flatMap { etf -> buildHoldingsForEtf(etf, platformFilter) }
+    return aggregateHoldings(allHoldings)
+  }
+
+  private fun buildHoldingsForEtf(
+    etf: Instrument,
+    platformFilter: Set<Platform>?,
+  ): List<InternalHoldingData> {
+    val positions = etfPositionRepository.findLatestPositionsByEtfId(etf.id)
+    val etfQuantity = calculateNetQuantity(etf.id, platformFilter)
+    val etfPrice = getCurrentPrice(etf)
+    val etfPlatforms = getPlatformsForInstrument(etf.id, platformFilter)
+    return positions.map { position ->
+      InternalHoldingData(
+        ticker =
+          position.holding.ticker
+          ?.uppercase()
+          ?.trim()
+          ?.takeIf { it.isNotBlank() },
+          name = position.holding.name.trim(),
+        sector =
+          position.holding.sector
+          ?.trim()
+          ?.takeIf { it.isNotBlank() },
+          value = calculateHoldingValue(position, etfQuantity, etfPrice),
+        etfSymbol = etf.symbol,
+        platforms = etfPlatforms,
+      )
     }
   }
 
-  private fun getCurrentPrice(instrument: Instrument): BigDecimal {
-    val currentPrice = instrument.currentPrice
-    if (currentPrice != null && currentPrice > BigDecimal.ZERO) {
-      return currentPrice
+  private fun aggregateHoldings(holdings: List<InternalHoldingData>): Map<HoldingKey, HoldingValue> =
+    holdings
+      .groupBy { holding -> buildHoldingGroupKey(holding) }
+      .entries
+      .associate { (_, groupedHoldings) -> buildHoldingEntry(groupedHoldings) }
+
+  private fun buildHoldingGroupKey(holding: InternalHoldingData): String =
+    if (!holding.ticker.isNullOrBlank()) {
+      "ticker:${holding.ticker}"
+    } else {
+      "name:${holding.name.lowercase()}:${holding.sector?.lowercase().orEmpty()}"
     }
 
-    return try {
-      dailyPriceService.getPrice(instrument, java.time.LocalDate.now())
-    } catch (e: NoSuchElementException) {
-      log.warn("No price found for ${instrument.symbol}, using zero", e)
-      BigDecimal.ZERO
-    }
+  private fun buildHoldingEntry(groupedHoldings: List<InternalHoldingData>): Pair<HoldingKey, HoldingValue> {
+    val key =
+      HoldingKey(
+      ticker = groupedHoldings.firstOrNull { !it.ticker.isNullOrBlank() }?.ticker,
+      name = groupedHoldings.maxByOrNull { it.name.length }!!.name,
+      sector = groupedHoldings.mapNotNull { it.sector }.maxByOrNull { it.length },
+    )
+    val value =
+      HoldingValue(
+      totalValue = groupedHoldings.fold(BigDecimal.ZERO) { acc, h -> acc.add(h.value) },
+      etfSymbols = groupedHoldings.map { it.etfSymbol }.toMutableSet(),
+      platforms = groupedHoldings.flatMap { it.platforms }.toMutableSet(),
+    )
+    return key to value
+  }
+
+  private fun getCurrentPrice(instrument: Instrument): BigDecimal {
+    instrument.currentPrice?.takeIf { it > BigDecimal.ZERO }?.let { return it }
+    return runCatching { dailyPriceService.getPrice(instrument, java.time.LocalDate.now()) }
+      .onFailure { log.warn("No price found for ${instrument.symbol}, using zero", it) }
+      .getOrDefault(BigDecimal.ZERO)
   }
 
   private fun calculateHoldingValue(

--- a/src/main/kotlin/ee/tenman/portfolio/service/InstrumentService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/service/InstrumentService.kt
@@ -100,82 +100,85 @@ class InstrumentService(
 
   private fun calculateProfitsForPlatform(transactions: List<PortfolioTransaction>) {
     val sortedTransactions = transactions.sortedWith(compareBy({ it.transactionDate }, { it.id }))
-    var currentQuantity = BigDecimal.ZERO
-    var totalCost = BigDecimal.ZERO
+    val (totalCost, currentQuantity) = processTransactions(sortedTransactions)
+    val currentPrice = sortedTransactions.firstOrNull()?.instrument?.currentPrice ?: BigDecimal.ZERO
+    val averageCost = calculateAverageCost(totalCost, currentQuantity)
+    val totalUnrealizedProfit = calculateUnrealizedProfit(currentQuantity, currentPrice, averageCost)
+    val buyTransactions = sortedTransactions.filter { it.transactionType == ee.tenman.portfolio.domain.TransactionType.BUY }
+    distributeProfitsToBuyTransactions(buyTransactions, currentQuantity, averageCost, totalUnrealizedProfit)
+  }
 
-    sortedTransactions.forEach { transaction ->
+  private fun processTransactions(transactions: List<PortfolioTransaction>): TransactionState =
+    transactions.fold(TransactionState(BigDecimal.ZERO, BigDecimal.ZERO)) { state, transaction ->
       when (transaction.transactionType) {
-        ee.tenman.portfolio.domain.TransactionType.BUY -> {
-          val cost = transaction.price.multiply(transaction.quantity).add(transaction.commission)
-          transaction.realizedProfit = BigDecimal.ZERO
-          totalCost = totalCost.add(cost)
-          currentQuantity = currentQuantity.add(transaction.quantity)
-        }
-
-        ee.tenman.portfolio.domain.TransactionType.SELL -> {
-          val averageCost =
-            if (currentQuantity > BigDecimal.ZERO) {
-              totalCost.divide(currentQuantity, 10, java.math.RoundingMode.HALF_UP)
-            } else {
-              BigDecimal.ZERO
-            }
-          transaction.averageCost = averageCost
-
-          val grossProfit =
-            transaction.quantity.multiply(transaction.price.subtract(averageCost))
-
-          transaction.realizedProfit = grossProfit.subtract(transaction.commission)
-          transaction.unrealizedProfit = BigDecimal.ZERO
-          transaction.remainingQuantity = BigDecimal.ZERO
-
-          if (currentQuantity > BigDecimal.ZERO) {
-            val sellRatio = transaction.quantity.divide(currentQuantity, 10, java.math.RoundingMode.HALF_UP)
-            totalCost = totalCost.multiply(BigDecimal.ONE.subtract(sellRatio))
-            currentQuantity = currentQuantity.subtract(transaction.quantity)
-          }
-        }
+        ee.tenman.portfolio.domain.TransactionType.BUY -> processBuyTransaction(transaction, state)
+        ee.tenman.portfolio.domain.TransactionType.SELL -> processSellTransaction(transaction, state)
       }
     }
 
-    val currentPrice = sortedTransactions.firstOrNull()?.instrument?.currentPrice ?: BigDecimal.ZERO
-    val averageCost =
-      if (currentQuantity > BigDecimal.ZERO) {
-        totalCost.divide(currentQuantity, 10, java.math.RoundingMode.HALF_UP)
-      } else {
-        BigDecimal.ZERO
-      }
-    val totalUnrealizedProfit =
-      if (currentQuantity > BigDecimal.ZERO && currentPrice > BigDecimal.ZERO) {
-        currentQuantity.multiply(currentPrice.subtract(averageCost))
-      } else {
-        BigDecimal.ZERO
-      }
+  private fun processBuyTransaction(
+    transaction: PortfolioTransaction,
+    state: TransactionState,
+  ): TransactionState {
+    val cost = transaction.price.multiply(transaction.quantity).add(transaction.commission)
+    transaction.realizedProfit = BigDecimal.ZERO
+    return TransactionState(state.totalCost.add(cost), state.currentQuantity.add(transaction.quantity))
+  }
 
-    val buyTransactions =
-      sortedTransactions.filter { it.transactionType == ee.tenman.portfolio.domain.TransactionType.BUY }
+  private fun processSellTransaction(
+    transaction: PortfolioTransaction,
+    state: TransactionState,
+  ): TransactionState {
+    val averageCost = calculateAverageCost(state.totalCost, state.currentQuantity)
+    transaction.averageCost = averageCost
+    transaction.realizedProfit = transaction.quantity.multiply(transaction.price.subtract(averageCost)).subtract(transaction.commission)
+    transaction.unrealizedProfit = BigDecimal.ZERO
+    transaction.remainingQuantity = BigDecimal.ZERO
+    if (state.currentQuantity <= BigDecimal.ZERO) return state
+    val sellRatio = transaction.quantity.divide(state.currentQuantity, 10, java.math.RoundingMode.HALF_UP)
+    return TransactionState(
+      state.totalCost.multiply(BigDecimal.ONE.subtract(sellRatio)),
+      state.currentQuantity.subtract(transaction.quantity),
+    )
+  }
 
+  private fun calculateAverageCost(
+    totalCost: BigDecimal,
+    quantity: BigDecimal,
+  ): BigDecimal = if (quantity > BigDecimal.ZERO) totalCost.divide(quantity, 10, java.math.RoundingMode.HALF_UP) else BigDecimal.ZERO
+
+  private fun calculateUnrealizedProfit(
+    quantity: BigDecimal,
+    price: BigDecimal,
+    avgCost: BigDecimal,
+  ): BigDecimal = if (quantity > BigDecimal.ZERO && price > BigDecimal.ZERO) quantity.multiply(price.subtract(avgCost)) else BigDecimal.ZERO
+
+  private fun distributeProfitsToBuyTransactions(
+    buyTransactions: List<PortfolioTransaction>,
+    currentQuantity: BigDecimal,
+    averageCost: BigDecimal,
+    totalUnrealizedProfit: BigDecimal,
+  ) {
     if (currentQuantity <= BigDecimal.ZERO) {
       buyTransactions.forEach {
         it.remainingQuantity = BigDecimal.ZERO
         it.unrealizedProfit = BigDecimal.ZERO
         it.averageCost = it.price
       }
-    } else {
-      val totalBuyQuantity = buyTransactions.sumOf { it.quantity }
-
-      buyTransactions.forEach { buyTx ->
-        val proportionalQuantity =
-          buyTx.quantity
-            .multiply(currentQuantity)
-            .divide(totalBuyQuantity, 10, java.math.RoundingMode.HALF_UP)
-
-        buyTx.remainingQuantity = proportionalQuantity
-        buyTx.averageCost = averageCost
-        buyTx.unrealizedProfit =
-          totalUnrealizedProfit
-            .multiply(proportionalQuantity)
-            .divide(currentQuantity, 10, java.math.RoundingMode.HALF_UP)
-      }
+      return
+    }
+    val totalBuyQuantity = buyTransactions.sumOf { it.quantity }
+    buyTransactions.forEach { buyTx ->
+      val proportionalQuantity =
+        buyTx.quantity
+        .multiply(currentQuantity)
+        .divide(totalBuyQuantity, 10, java.math.RoundingMode.HALF_UP)
+      buyTx.remainingQuantity = proportionalQuantity
+      buyTx.averageCost = averageCost
+      buyTx.unrealizedProfit =
+        totalUnrealizedProfit
+        .multiply(proportionalQuantity)
+        .divide(currentQuantity, 10, java.math.RoundingMode.HALF_UP)
     }
   }
 
@@ -222,13 +225,10 @@ class InstrumentService(
   private fun parsePlatformFilters(platforms: List<String>?): Set<Platform>? =
     platforms
       ?.mapNotNull { platformStr ->
-        try {
-          Platform.valueOf(platformStr.uppercase())
-        } catch (e: IllegalArgumentException) {
-          log.debug("Invalid platform filter: {}", platformStr, e)
-          null
-        }
-      }?.toSet()
+      runCatching { Platform.valueOf(platformStr.uppercase()) }
+        .onFailure { log.debug("Invalid platform filter: {}", platformStr, it) }
+        .getOrNull()
+    }?.toSet()
 
   private fun enrichInstrumentWithMetrics(
     instrument: Instrument,

--- a/src/main/kotlin/ee/tenman/portfolio/service/InternalHoldingData.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/service/InternalHoldingData.kt
@@ -1,0 +1,13 @@
+package ee.tenman.portfolio.service
+
+import ee.tenman.portfolio.domain.Platform
+import java.math.BigDecimal
+
+data class InternalHoldingData(
+  val ticker: String?,
+  val name: String,
+  val sector: String?,
+  val value: BigDecimal,
+  val etfSymbol: String,
+  val platforms: Set<Platform>,
+)

--- a/src/main/kotlin/ee/tenman/portfolio/service/TransactionState.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/service/TransactionState.kt
@@ -1,0 +1,8 @@
+package ee.tenman.portfolio.service
+
+import java.math.BigDecimal
+
+data class TransactionState(
+  val totalCost: BigDecimal,
+  val currentQuantity: BigDecimal,
+)

--- a/src/test/kotlin/ee/tenman/portfolio/service/HoldingParserTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/service/HoldingParserTest.kt
@@ -1,0 +1,181 @@
+package ee.tenman.portfolio.service
+
+import ch.tutteli.atrium.api.fluent.en_GB.notToEqualNull
+import ch.tutteli.atrium.api.fluent.en_GB.toEqual
+import ch.tutteli.atrium.api.fluent.en_GB.toEqualNumerically
+import ch.tutteli.atrium.api.verbs.expect
+import com.codeborne.selenide.ElementsCollection
+import com.codeborne.selenide.SelenideElement
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+class HoldingParserTest {
+  private lateinit var holdingParser: HoldingParser
+  private lateinit var mockElement: SelenideElement
+  private lateinit var mockDivCollection: ElementsCollection
+
+  @BeforeEach
+  fun setUp() {
+    holdingParser = HoldingParser()
+    mockElement = mockk(relaxed = true)
+    mockDivCollection = mockk(relaxed = true)
+  }
+
+  @Test
+  fun `should parse holding row with valid data`() {
+    val divTexts = listOf("Apple Inc\n\$AAPL\nTechnology", "5.25%")
+    val mockImgCollection = mockk<ElementsCollection>(relaxed = true)
+    every { mockElement.text() } returns "Apple Inc \$AAPL Technology 5.25%"
+    every { mockElement.findAll("div") } returns mockDivCollection
+    every { mockDivCollection.texts() } returns divTexts
+    every { mockElement.findAll("img") } returns mockImgCollection
+    every { mockImgCollection.firstOrNull() } returns null
+
+    val result = holdingParser.parseHoldingRow(mockElement, 1)
+
+    expect(result).notToEqualNull()
+    expect(result!!.name).toEqual("Apple Inc")
+    expect(result.ticker).toEqual("AAPL")
+    expect(result.sector).toEqual("Technology")
+    expect(result.weight).toEqualNumerically(BigDecimal("5.25"))
+    expect(result.rank).toEqual(1)
+  }
+
+  @Test
+  fun `should return null when holding has zero weight`() {
+    val divTexts = listOf("Some Company\n\$XYZ\nFinance", "0%")
+    every { mockElement.text() } returns "Some Company \$XYZ Finance 0%"
+    every { mockElement.findAll("div") } returns mockDivCollection
+    every { mockDivCollection.texts() } returns divTexts
+
+    val result = holdingParser.parseHoldingRow(mockElement, 1)
+
+    expect(result).toEqual(null)
+  }
+
+  @Test
+  fun `should handle instrument not available`() {
+    val divTexts = listOf("Unknown Corp\n\$UNK\nUnknown", "Instrument is not available", "2.5%")
+    val mockImgCollection = mockk<ElementsCollection>(relaxed = true)
+    every { mockElement.text() } returns "Unknown Corp Instrument is not available 2.5%"
+    every { mockElement.findAll("div") } returns mockDivCollection
+    every { mockDivCollection.texts() } returns divTexts
+    every { mockElement.findAll("img") } returns mockImgCollection
+    every { mockImgCollection.firstOrNull() } returns null
+
+    val result = holdingParser.parseHoldingRow(mockElement, 1)
+
+    expect(result).notToEqualNull()
+    expect(result!!.name).toEqual("Unknown Corp")
+    expect(result.ticker).toEqual(null)
+    expect(result.sector).toEqual(null)
+  }
+
+  @Test
+  fun `should normalize weight greater than 100`() {
+    val divTexts = listOf("Big Corp\n\$BIG\nIndustrial", "525%")
+    val mockImgCollection = mockk<ElementsCollection>(relaxed = true)
+    every { mockElement.text() } returns "Big Corp \$BIG Industrial 525%"
+    every { mockElement.findAll("div") } returns mockDivCollection
+    every { mockDivCollection.texts() } returns divTexts
+    every { mockElement.findAll("img") } returns mockImgCollection
+    every { mockImgCollection.firstOrNull() } returns null
+
+    val result = holdingParser.parseHoldingRow(mockElement, 1)
+
+    expect(result).notToEqualNull()
+    expect(result!!.weight).toEqualNumerically(BigDecimal("52.5000"))
+  }
+
+  @Test
+  fun `should return null when name parts are empty`() {
+    every { mockElement.text() } returns ""
+    every { mockElement.findAll("div") } returns mockDivCollection
+    every { mockDivCollection.texts() } returns emptyList()
+
+    val result = holdingParser.parseHoldingRow(mockElement, 1)
+
+    expect(result).toEqual(null)
+  }
+
+  @Test
+  fun `should reset state clears previous weight`() {
+    val divTexts = listOf("First Corp\n\$FIRST\nTech", "5.0%")
+    val mockImgCollection = mockk<ElementsCollection>(relaxed = true)
+    every { mockElement.text() } returns "First Corp \$FIRST Tech 5.0%"
+    every { mockElement.findAll("div") } returns mockDivCollection
+    every { mockDivCollection.texts() } returns divTexts
+    every { mockElement.findAll("img") } returns mockImgCollection
+    every { mockImgCollection.firstOrNull() } returns null
+    holdingParser.parseHoldingRow(mockElement, 1)
+
+    holdingParser.resetState()
+
+    val secondDivTexts = listOf("Second Corp\n\$SECOND\nFinance", "10.0%")
+    every { mockElement.text() } returns "Second Corp \$SECOND Finance 10.0%"
+    every { mockDivCollection.texts() } returns secondDivTexts
+    val result = holdingParser.parseHoldingRow(mockElement, 1)
+
+    expect(result).notToEqualNull()
+    expect(result!!.name).toEqual("Second Corp")
+  }
+
+  @Test
+  fun `should handle exception during parsing gracefully`() {
+    every { mockElement.text() } returns "Valid text"
+    every { mockElement.findAll("div") } throws RuntimeException("Parse error")
+
+    val result = holdingParser.parseHoldingRow(mockElement, 1)
+
+    expect(result).toEqual(null)
+  }
+
+  @Test
+  fun `should skip weight values exceeding 10000 percent`() {
+    val divTexts = listOf("Huge Corp\n\$HUGE\nFinance", "15000%")
+    every { mockElement.text() } returns "Huge Corp \$HUGE Finance 15000%"
+    every { mockElement.findAll("div") } returns mockDivCollection
+    every { mockDivCollection.texts() } returns divTexts
+
+    val result = holdingParser.parseHoldingRow(mockElement, 1)
+
+    expect(result).toEqual(null)
+  }
+
+  @Test
+  fun `should handle weight with comma separator`() {
+    val divTexts = listOf("European Corp\n\$EUR\nFinance", "1,234%")
+    val mockImgCollection = mockk<ElementsCollection>(relaxed = true)
+    every { mockElement.text() } returns "European Corp \$EUR Finance 1,234%"
+    every { mockElement.findAll("div") } returns mockDivCollection
+    every { mockDivCollection.texts() } returns divTexts
+    every { mockElement.findAll("img") } returns mockImgCollection
+    every { mockImgCollection.firstOrNull() } returns null
+
+    val result = holdingParser.parseHoldingRow(mockElement, 1)
+
+    expect(result).notToEqualNull()
+    expect(result!!.weight).toEqualNumerically(BigDecimal("12.3400"))
+  }
+
+  @Test
+  fun `should extract background image url when img src not available`() {
+    val divTexts = listOf("Tesla\n\$TSLA\nAutomotive", "3.2%")
+    val mockDiv = mockk<SelenideElement>(relaxed = true)
+    val mockImgCollection = mockk<ElementsCollection>(relaxed = true)
+    every { mockElement.text() } returns "Tesla \$TSLA Automotive 3.2%"
+    every { mockElement.findAll("div") } returns mockDivCollection
+    every { mockDivCollection.texts() } returns divTexts
+    every { mockElement.findAll("img") } returns mockImgCollection
+    every { mockImgCollection.firstOrNull() } returns null
+    every { mockDivCollection.iterator() } returns mutableListOf(mockDiv).iterator()
+    every { mockDiv.getAttribute("style") } returns "background-image: url('https://example.com/bg-logo.png')"
+
+    val result = holdingParser.parseHoldingRow(mockElement, 1)
+
+    expect(result).notToEqualNull()
+  }
+}


### PR DESCRIPTION
## Summary
- Refactor 4 long methods identified in issue #961
- Apply idiomatic Kotlin patterns across backend services
- Add comprehensive unit tests for HoldingParser (10 tests)
- Move data classes to separate files per style guide

## Changes

### HoldingParser
- Add 10 unit tests covering all parsing scenarios
- Apply `runCatching` for error handling
- Use `generateSequence` for weight normalization
- Use `firstNotNullOfOrNull` for logo URL extraction

### InstrumentService.calculateProfitsForPlatform (79 → ~20 lines)
- Break down into focused helper methods
- Introduce `TransactionState` data class (separate file) with `fold()`
- Extract: `processTransactions`, `processBuyTransaction`, `processSellTransaction`
- Extract: `calculateAverageCost`, `calculateUnrealizedProfit`, `distributeProfitsToBuyTransactions`
- Replace try-catch with `runCatching` in `parsePlatformFilters`

### CalculationService.calculateRollingXirr (56 → ~15 lines)
- Replace while loop with `generateSequence`
- Extract `calculateXirrForPeriod` helper
- Use functional chain with `takeIf` and `let`
- Apply `runCatching` in `isValidXirr`

### EtfBreakdownService.buildHoldingsMap (57 → ~15 lines)
- Use `flatMap` instead of mutableList with forEach
- Extract: `buildHoldingsForEtf`, `aggregateHoldings`
- Extract: `buildHoldingGroupKey`, `buildHoldingEntry`
- Move `InternalHoldingData` to separate file per style guide
- Replace try-catch with `runCatching` in `getCurrentPrice`

## Test plan
- [x] All existing tests pass (267 backend tests)
- [x] New HoldingParser tests pass (10 tests)
- [x] CI/CD pipeline validates changes

Closes #961