### PR TITLE
Implement JollyDay library for automatic Easter holiday calculation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,6 +60,8 @@ dependencies {
     exclude(group = "commons-logging", module = "commons-logging")
   }
   implementation(libs.minio)
+  implementation(libs.jollyday.core)
+  runtimeOnly(libs.jollyday.jaxb)
 
   developmentOnly(libs.spring.boot.docker.compose)
   runtimeOnly(libs.postgresql)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,7 @@ datafaker = "2.5.3"
 postgresql = "42.7.8"
 grpcNettyShaded = "1.77.0"
 minio = "8.6.0"
+jollyday = "1.8.0"
 
 [libraries]
 # Spring Boot
@@ -92,6 +93,10 @@ grpc-netty-shaded = { module = "io.grpc:grpc-netty-shaded", version.ref = "grpcN
 
 # MinIO
 minio = { module = "io.minio:minio", version.ref = "minio" }
+
+# JollyDay - Public holidays library
+jollyday-core = { module = "de.focus-shift:jollyday-core", version.ref = "jollyday" }
+jollyday-jaxb = { module = "de.focus-shift:jollyday-jaxb", version.ref = "jollyday" }
 
 # Code Quality
 detekt-formatting = { module = "dev.detekt:detekt-rules-ktlint-wrapper", version.ref = "detekt" }

--- a/src/main/kotlin/ee/tenman/portfolio/scheduler/MarketPhaseDetectionService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/scheduler/MarketPhaseDetectionService.kt
@@ -1,11 +1,14 @@
 package ee.tenman.portfolio.scheduler
 
+import de.focus_shift.jollyday.core.HolidayManager
+import de.focus_shift.jollyday.core.ManagerParameters
 import org.springframework.stereotype.Service
 import java.time.Clock
 import java.time.DayOfWeek
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalTime
+import java.time.Year
 import java.time.ZoneId
 import java.time.ZonedDateTime
 
@@ -14,44 +17,15 @@ class MarketPhaseDetectionService(
   private val clock: Clock = Clock.systemDefaultZone(),
 ) {
   private val nyseZone = ZoneId.of("America/New_York")
-
-  private val xetraHolidays =
-    setOf(
-    LocalDate.of(2025, 1, 1),
-    LocalDate.of(2025, 4, 18),
-    LocalDate.of(2025, 4, 21),
-    LocalDate.of(2025, 5, 1),
-    LocalDate.of(2025, 12, 24),
-    LocalDate.of(2025, 12, 25),
-    LocalDate.of(2025, 12, 26),
-    LocalDate.of(2025, 12, 31),
-    LocalDate.of(2026, 1, 1),
-    LocalDate.of(2026, 4, 3),
-    LocalDate.of(2026, 4, 6),
-    LocalDate.of(2026, 5, 1),
-    LocalDate.of(2026, 12, 24),
-    LocalDate.of(2026, 12, 25),
-    LocalDate.of(2026, 12, 26),
-    LocalDate.of(2026, 12, 31),
-    LocalDate.of(2027, 1, 1),
-    LocalDate.of(2027, 3, 26),
-    LocalDate.of(2027, 3, 29),
-    LocalDate.of(2027, 5, 1),
-    LocalDate.of(2027, 12, 24),
-    LocalDate.of(2027, 12, 25),
-    LocalDate.of(2027, 12, 26),
-    LocalDate.of(2027, 12, 31),
-  )
+  private val holidayManager: HolidayManager =
+    HolidayManager.getInstance(ManagerParameters.create("de"))
 
   fun detectMarketPhase(timestamp: Instant = Instant.now(clock)): MarketPhase {
     val nyseTime = ZonedDateTime.ofInstant(timestamp, nyseZone)
-
     if (isWeekend(nyseTime) || isXetraHoliday(nyseTime.toLocalDate())) {
       return MarketPhase.WEEKEND
     }
-
     val localTime = nyseTime.toLocalTime()
-
     return when {
       isMainMarketHours(localTime) -> MarketPhase.MAIN_MARKET_HOURS
       isPrePostMarketHours(localTime) -> MarketPhase.PRE_POST_MARKET
@@ -64,7 +38,21 @@ class MarketPhaseDetectionService(
   private fun isWeekend(dateTime: ZonedDateTime): Boolean =
     dateTime.dayOfWeek == DayOfWeek.SATURDAY || dateTime.dayOfWeek == DayOfWeek.SUNDAY
 
-  private fun isXetraHoliday(date: LocalDate): Boolean = xetraHolidays.contains(date)
+  private fun isXetraHoliday(date: LocalDate): Boolean = isFixedXetraHoliday(date) || isEasterHoliday(date)
+
+  private fun isFixedXetraHoliday(date: LocalDate): Boolean {
+    val month = date.monthValue
+    val day = date.dayOfMonth
+    return (month == 1 && day == 1) ||
+      (month == 5 && day == 1) ||
+      (month == 12 && day in listOf(24, 25, 26, 31))
+  }
+
+  private fun isEasterHoliday(date: LocalDate): Boolean =
+    holidayManager
+      .getHolidays(Year.of(date.year))
+      .filter { it.propertiesKey in setOf("christian.GOOD_FRIDAY", "christian.EASTER_MONDAY") }
+      .any { it.date == date }
 
   private fun isMainMarketHours(time: LocalTime): Boolean {
     val marketOpen = LocalTime.of(10, 30)
@@ -77,7 +65,6 @@ class MarketPhaseDetectionService(
     val preMarketEnd = LocalTime.of(10, 30)
     val afterMarketStart = LocalTime.of(17, 30)
     val afterMarketEnd = LocalTime.of(20, 0)
-
     return (!time.isBefore(preMarketStart) && time.isBefore(preMarketEnd)) ||
       (!time.isBefore(afterMarketStart) && time.isBefore(afterMarketEnd))
   }

--- a/src/test/kotlin/ee/tenman/portfolio/scheduler/MarketPhaseDetectionServiceTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/scheduler/MarketPhaseDetectionServiceTest.kt
@@ -215,6 +215,60 @@ class MarketPhaseDetectionServiceTest {
     expect(result).toEqual(false)
   }
 
+  @ParameterizedTest
+  @CsvSource(
+    "2028, 4, 14, Good Friday 2028",
+    "2028, 4, 17, Easter Monday 2028",
+    "2029, 3, 30, Good Friday 2029",
+    "2029, 4, 2, Easter Monday 2029",
+    "2030, 4, 19, Good Friday 2030",
+    "2030, 4, 22, Easter Monday 2030",
+    "2031, 4, 11, Good Friday 2031",
+    "2031, 4, 14, Easter Monday 2031",
+    "2032, 3, 26, Good Friday 2032",
+    "2032, 3, 29, Easter Monday 2032",
+    "2033, 4, 15, Good Friday 2033",
+    "2033, 4, 18, Easter Monday 2033",
+    "2034, 4, 7, Good Friday 2034",
+    "2034, 4, 10, Easter Monday 2034",
+    "2035, 3, 23, Good Friday 2035",
+    "2035, 3, 26, Easter Monday 2035",
+  )
+  fun `should detect WEEKEND on Easter holidays in future years via JollyDay`(
+    year: Int,
+    month: Int,
+    day: Int,
+    @Suppress("UNUSED_PARAMETER") _holidayName: String,
+  ) {
+    val holiday = createNyTime(year, month, day, 12, 0)
+
+    val result = service.detectMarketPhase(holiday)
+
+    expect(result).toEqual(MarketPhase.WEEKEND)
+  }
+
+  @ParameterizedTest
+  @CsvSource(
+    "2025, 5, 29, Ascension Day 2025",
+    "2025, 6, 9, Whit Monday 2025",
+    "2025, 10, 3, German Unity Day 2025",
+    "2026, 5, 14, Ascension Day 2026",
+    "2026, 5, 25, Whit Monday 2026",
+    "2028, 10, 3, German Unity Day 2028",
+  )
+  fun `should detect MAIN_MARKET_HOURS on German holidays where XETRA is open`(
+    year: Int,
+    month: Int,
+    day: Int,
+    @Suppress("UNUSED_PARAMETER") _holidayName: String,
+  ) {
+    val holiday = createNyTime(year, month, day, 12, 0)
+
+    val result = service.detectMarketPhase(holiday)
+
+    expect(result).toEqual(MarketPhase.MAIN_MARKET_HOURS)
+  }
+
   private fun createNyTime(
     year: Int,
     month: Int,


### PR DESCRIPTION
## Summary
- Integrate JollyDay library (1.8.0) to automatically calculate Good Friday and Easter Monday dates for XETRA trading calendar
- Remove hardcoded Easter holiday dates that required manual updates each year
- Keep fixed XETRA holidays (Jan 1, May 1, Dec 24-26, Dec 31) hardcoded as they don't vary
- Add comprehensive tests for Easter dates from 2025 through 2035
- Add tests confirming XETRA remains open on German holidays not observed by XETRA (Ascension Day, Whit Monday, German Unity Day)

## Test plan
- [x] All 63 MarketPhaseDetectionServiceTest tests pass
- [x] Future year Easter dates verified via JollyDay (2028-2035)
- [x] Negative tests confirm XETRA stays open on German Unity Day, Ascension Day, Whit Monday
- [x] ktlint and detekt checks pass
- [x] Build successful

Closes #971