### PR TITLE
Move data classes from service to model and dto packages

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
   alias(libs.plugins.ktlint)
   alias(libs.plugins.detekt)
   alias(libs.plugins.typescript.generator)
+  alias(libs.plugins.pitest)
 }
 
 group = "ee.tenman"
@@ -85,6 +86,8 @@ dependencies {
     exclude("org.jetbrains.kotlin")
   }
   testImplementation(libs.datafaker)
+  testImplementation(libs.kotest.property)
+  testImplementation(libs.kotest.runner.junit5)
   testRuntimeOnly(libs.junit.platform.launcher)
   testRuntimeOnly(libs.junit.jupiter.engine)
 }
@@ -242,4 +245,36 @@ tasks.withType<dev.detekt.gradle.Detekt>().configureEach {
     sarif.required.set(false)
     markdown.required.set(false)
   }
+}
+
+pitest {
+  junit5PluginVersion.set("1.2.1")
+  pitestVersion.set(libs.versions.pitest.get())
+  targetClasses.set(
+    listOf(
+      "ee.tenman.portfolio.service.XirrCalculationService",
+      "ee.tenman.portfolio.service.HoldingsCalculationService",
+      "ee.tenman.portfolio.service.InvestmentMetricsService",
+      "ee.tenman.portfolio.service.TransactionService",
+      "ee.tenman.portfolio.service.xirr.*",
+    ),
+  )
+  targetTests.set(
+    listOf(
+      "ee.tenman.portfolio.service.*Test",
+      "ee.tenman.portfolio.service.*PropertyTest",
+    ),
+  )
+  threads.set(4)
+  outputFormats.set(listOf("HTML", "XML"))
+  mutationThreshold.set(80)
+  coverageThreshold.set(80)
+  timestampedReports.set(false)
+  useClasspathFile.set(true)
+  excludedClasses.set(
+    listOf(
+      "ee.tenman.portfolio.service.*IT",
+      "ee.tenman.portfolio.service.*IntegrationTest",
+    ),
+  )
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,9 @@ postgresql = "42.7.8"
 grpcNettyShaded = "1.77.0"
 minio = "8.6.0"
 jollyday = "1.8.0"
+pitest = "1.17.4"
+pitestPlugin = "1.15.0"
+kotest = "6.0.0.M2"
 
 [libraries]
 # Spring Boot
@@ -116,6 +119,8 @@ spring-mockk = { module = "com.ninja-squad:springmockk", version = "5.0.1" }
 archunit-junit5 = { module = "com.tngtech.archunit:archunit-junit5", version.ref = "archUnit" }
 atrium-fluent = { module = "ch.tutteli.atrium:atrium-fluent", version.ref = "atrium" }
 datafaker = { module = "net.datafaker:datafaker", version.ref = "datafaker" }
+kotest-property = { module = "io.kotest:kotest-property-jvm", version.ref = "kotest" }
+kotest-runner-junit5 = { module = "io.kotest:kotest-runner-junit5-jvm", version.ref = "kotest" }
 
 [plugins]
 spring-boot = { id = "org.springframework.boot", version.ref = "springBoot" }
@@ -126,3 +131,4 @@ kotlin-jpa = { id = "org.jetbrains.kotlin.plugin.jpa", version.ref = "kotlin" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlintPlugin" }
 detekt = { id = "dev.detekt", version.ref = "detekt" }
 typescript-generator = { id = "cz.habarta.typescript-generator", version.ref = "typescriptGenerator" }
+pitest = { id = "info.solidsoft.pitest", version.ref = "pitestPlugin" }

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -11,14 +11,14 @@ ENV BUILD_HASH=${BUILD_HASH}
 ENV BUILD_TIME=${BUILD_TIME}
 
 # Copy necessary files
-COPY build.gradle.kts settings.gradle.kts ./
+COPY build.gradle.kts settings.gradle.kts gradlew ./
 COPY .editorconfig ./
 COPY detekt.yml ./
 COPY gradle ./gradle
 COPY src ./src
 
-# Build with optimizations
-RUN gradle clean build -x test --no-daemon \
+# Build with optimizations using Gradle wrapper for version consistency
+RUN chmod +x gradlew && ./gradlew clean build -x test --no-daemon \
     --build-cache \
     -Dorg.gradle.caching=true \
     -Dorg.gradle.parallel=true \

--- a/src/main/kotlin/ee/tenman/portfolio/controller/CalculatorController.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/controller/CalculatorController.kt
@@ -1,6 +1,6 @@
 package ee.tenman.portfolio.controller
 
-import ee.tenman.portfolio.service.CalculationResult
+import ee.tenman.portfolio.dto.CalculationResult
 import ee.tenman.portfolio.service.CalculationService
 import ee.tenman.portfolio.service.SummaryService
 import org.springframework.validation.annotation.Validated

--- a/src/main/kotlin/ee/tenman/portfolio/dto/CalculationResult.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/dto/CalculationResult.kt
@@ -1,4 +1,4 @@
-package ee.tenman.portfolio.service
+package ee.tenman.portfolio.dto
 
 import ee.tenman.portfolio.service.xirr.Transaction
 import java.io.Serializable

--- a/src/main/kotlin/ee/tenman/portfolio/dto/InstrumentEnrichmentContext.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/dto/InstrumentEnrichmentContext.kt
@@ -1,4 +1,4 @@
-package ee.tenman.portfolio.service
+package ee.tenman.portfolio.dto
 
 import ee.tenman.portfolio.domain.Platform
 import ee.tenman.portfolio.domain.PriceChangePeriod

--- a/src/main/kotlin/ee/tenman/portfolio/model/PriceChange.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/model/PriceChange.kt
@@ -1,4 +1,4 @@
-package ee.tenman.portfolio.service
+package ee.tenman.portfolio.model
 
 import java.math.BigDecimal
 

--- a/src/main/kotlin/ee/tenman/portfolio/model/ProcessResult.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/model/ProcessResult.kt
@@ -1,0 +1,7 @@
+package ee.tenman.portfolio.model
+
+enum class ProcessResult {
+  SUCCESS_WITH_DAILY_PRICE,
+  SUCCESS_WITHOUT_DAILY_PRICE,
+  FAILED,
+}

--- a/src/main/kotlin/ee/tenman/portfolio/model/TransactionState.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/model/TransactionState.kt
@@ -1,4 +1,4 @@
-package ee.tenman.portfolio.service
+package ee.tenman.portfolio.model
 
 import java.math.BigDecimal
 

--- a/src/main/kotlin/ee/tenman/portfolio/model/XirrCalculationResult.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/model/XirrCalculationResult.kt
@@ -1,4 +1,4 @@
-package ee.tenman.portfolio.service
+package ee.tenman.portfolio.model
 
 data class XirrCalculationResult(
   val processedDates: Int,

--- a/src/main/kotlin/ee/tenman/portfolio/model/holding/HoldingKey.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/model/holding/HoldingKey.kt
@@ -1,4 +1,4 @@
-package ee.tenman.portfolio.service
+package ee.tenman.portfolio.model.holding
 
 data class HoldingKey(
   val ticker: String?,

--- a/src/main/kotlin/ee/tenman/portfolio/model/holding/HoldingValue.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/model/holding/HoldingValue.kt
@@ -1,4 +1,4 @@
-package ee.tenman.portfolio.service
+package ee.tenman.portfolio.model.holding
 
 import ee.tenman.portfolio.domain.Platform
 import java.math.BigDecimal

--- a/src/main/kotlin/ee/tenman/portfolio/model/holding/HoldingsAccumulator.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/model/holding/HoldingsAccumulator.kt
@@ -1,4 +1,4 @@
-package ee.tenman.portfolio.service
+package ee.tenman.portfolio.model.holding
 
 import ee.tenman.portfolio.domain.PortfolioTransaction
 import java.math.BigDecimal

--- a/src/main/kotlin/ee/tenman/portfolio/model/holding/InternalHoldingData.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/model/holding/InternalHoldingData.kt
@@ -1,4 +1,4 @@
-package ee.tenman.portfolio.service
+package ee.tenman.portfolio.model.holding
 
 import ee.tenman.portfolio.domain.Platform
 import java.math.BigDecimal

--- a/src/main/kotlin/ee/tenman/portfolio/model/metrics/InstrumentMetrics.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/model/metrics/InstrumentMetrics.kt
@@ -1,4 +1,4 @@
-package ee.tenman.portfolio.service
+package ee.tenman.portfolio.model.metrics
 
 import java.math.BigDecimal
 

--- a/src/main/kotlin/ee/tenman/portfolio/model/metrics/PortfolioMetrics.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/model/metrics/PortfolioMetrics.kt
@@ -1,4 +1,4 @@
-package ee.tenman.portfolio.service
+package ee.tenman.portfolio.model.metrics
 
 import ee.tenman.portfolio.service.xirr.Transaction
 import java.math.BigDecimal

--- a/src/main/kotlin/ee/tenman/portfolio/service/CalculationService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/service/CalculationService.kt
@@ -1,6 +1,8 @@
 package ee.tenman.portfolio.service
 
 import ee.tenman.portfolio.configuration.RedisConfiguration.Companion.ONE_DAY_CACHE
+import ee.tenman.portfolio.dto.CalculationResult
+import ee.tenman.portfolio.model.XirrCalculationResult
 import ee.tenman.portfolio.repository.InstrumentRepository
 import ee.tenman.portfolio.service.xirr.Transaction
 import ee.tenman.portfolio.service.xirr.Xirr

--- a/src/main/kotlin/ee/tenman/portfolio/service/DailyPriceService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/service/DailyPriceService.kt
@@ -3,6 +3,7 @@ package ee.tenman.portfolio.service
 import ee.tenman.portfolio.domain.DailyPrice
 import ee.tenman.portfolio.domain.Instrument
 import ee.tenman.portfolio.domain.PriceChangePeriod
+import ee.tenman.portfolio.model.PriceChange
 import ee.tenman.portfolio.repository.DailyPriceRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional

--- a/src/main/kotlin/ee/tenman/portfolio/service/EtfBreakdownService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/service/EtfBreakdownService.kt
@@ -6,6 +6,9 @@ import ee.tenman.portfolio.domain.Platform
 import ee.tenman.portfolio.domain.ProviderName
 import ee.tenman.portfolio.domain.TransactionType
 import ee.tenman.portfolio.dto.EtfHoldingBreakdownDto
+import ee.tenman.portfolio.model.holding.HoldingKey
+import ee.tenman.portfolio.model.holding.HoldingValue
+import ee.tenman.portfolio.model.holding.InternalHoldingData
 import ee.tenman.portfolio.repository.EtfPositionRepository
 import ee.tenman.portfolio.repository.InstrumentRepository
 import ee.tenman.portfolio.repository.PortfolioTransactionRepository

--- a/src/main/kotlin/ee/tenman/portfolio/service/HoldingsCalculationService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/service/HoldingsCalculationService.kt
@@ -1,0 +1,62 @@
+package ee.tenman.portfolio.service
+
+import ee.tenman.portfolio.domain.PortfolioTransaction
+import ee.tenman.portfolio.domain.TransactionType
+import ee.tenman.portfolio.model.holding.HoldingsAccumulator
+import org.springframework.stereotype.Service
+import java.math.BigDecimal
+import java.math.RoundingMode
+
+@Service
+class HoldingsCalculationService {
+  fun calculateCurrentHoldings(transactions: List<PortfolioTransaction>): Pair<BigDecimal, BigDecimal> {
+    val (quantity, totalCost) =
+      transactions
+        .sortedWith(compareBy({ it.transactionDate }, { it.id }))
+        .fold(HoldingsAccumulator()) { acc, tx ->
+          when (tx.transactionType) {
+            TransactionType.BUY -> acc.applyBuy(tx)
+            TransactionType.SELL -> acc.applySell(tx)
+          }
+        }
+    val averageCost =
+      quantity
+        .takeIf { it > BigDecimal.ZERO }
+        ?.let { totalCost.divide(it, 10, RoundingMode.HALF_UP) }
+        ?: BigDecimal.ZERO
+    return quantity to averageCost
+  }
+
+  fun calculateAggregatedHoldings(transactions: List<PortfolioTransaction>): Pair<BigDecimal, BigDecimal> =
+    transactions
+      .groupBy { it.platform }
+      .values
+      .map { calculateCurrentHoldings(it) }
+      .filter { (quantity, _) -> quantity > BigDecimal.ZERO }
+      .fold(BigDecimal.ZERO to BigDecimal.ZERO) { (totalHoldings, totalInvestment), (quantity, avgCost) ->
+        totalHoldings.add(quantity) to totalInvestment.add(quantity.multiply(avgCost))
+      }
+
+  fun calculateNetQuantity(transactions: List<PortfolioTransaction>): BigDecimal =
+    transactions.fold(BigDecimal.ZERO) { acc, tx ->
+      when (tx.transactionType) {
+        TransactionType.BUY -> acc.add(tx.quantity)
+        TransactionType.SELL -> acc.subtract(tx.quantity)
+      }
+    }
+
+  fun calculateCurrentValue(
+    holdings: BigDecimal,
+    currentPrice: BigDecimal,
+  ): BigDecimal = holdings.multiply(currentPrice)
+
+  fun calculateProfit(
+    holdings: BigDecimal,
+    averageCost: BigDecimal,
+    currentPrice: BigDecimal,
+  ): BigDecimal {
+    val currentValue = holdings.multiply(currentPrice)
+    val investment = holdings.multiply(averageCost)
+    return currentValue.subtract(investment)
+  }
+}

--- a/src/main/kotlin/ee/tenman/portfolio/service/InstrumentService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/service/InstrumentService.kt
@@ -8,7 +8,10 @@ import ee.tenman.portfolio.domain.Instrument
 import ee.tenman.portfolio.domain.Platform
 import ee.tenman.portfolio.domain.PortfolioTransaction
 import ee.tenman.portfolio.domain.PriceChangePeriod
+import ee.tenman.portfolio.dto.InstrumentEnrichmentContext
 import ee.tenman.portfolio.exception.EntityNotFoundException
+import ee.tenman.portfolio.model.PriceChange
+import ee.tenman.portfolio.model.TransactionState
 import ee.tenman.portfolio.repository.InstrumentRepository
 import ee.tenman.portfolio.repository.PortfolioTransactionRepository
 import org.slf4j.LoggerFactory

--- a/src/main/kotlin/ee/tenman/portfolio/service/LightyearPriceUpdateService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/service/LightyearPriceUpdateService.kt
@@ -3,6 +3,7 @@ package ee.tenman.portfolio.service
 import ee.tenman.portfolio.domain.DailyPrice
 import ee.tenman.portfolio.domain.Instrument
 import ee.tenman.portfolio.domain.ProviderName
+import ee.tenman.portfolio.model.ProcessResult
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Propagation

--- a/src/main/kotlin/ee/tenman/portfolio/service/PriceUpdateProcessor.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/service/PriceUpdateProcessor.kt
@@ -1,18 +1,13 @@
 package ee.tenman.portfolio.service
 
 import ee.tenman.portfolio.domain.Platform
+import ee.tenman.portfolio.model.ProcessResult
 import ee.tenman.portfolio.scheduler.MarketPhaseDetectionService
 import org.slf4j.Logger
 import org.springframework.stereotype.Component
 import java.math.BigDecimal
 import java.time.Clock
 import java.time.LocalDate
-
-enum class ProcessResult {
-  SUCCESS_WITH_DAILY_PRICE,
-  SUCCESS_WITHOUT_DAILY_PRICE,
-  FAILED,
-}
 
 @Component
 class PriceUpdateProcessor(

--- a/src/main/kotlin/ee/tenman/portfolio/service/SummaryService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/service/SummaryService.kt
@@ -18,6 +18,7 @@ class SummaryService(
   private val transactionService: TransactionService,
   private val cacheManager: CacheManager,
   private val investmentMetricsService: InvestmentMetricsService,
+  private val xirrCalculationService: XirrCalculationService,
   private val clock: Clock,
   private val summaryBatchProcessor: SummaryBatchProcessorService,
   private val summaryDeletionService: SummaryDeletionService,
@@ -208,7 +209,7 @@ class SummaryService(
     val instrumentGroups = transactions.groupBy { it.instrument }
     val results = investmentMetricsService.calculatePortfolioMetrics(instrumentGroups, date)
 
-    val xirr = investmentMetricsService.calculateAdjustedXirr(results.xirrTransactions, date)
+    val xirr = xirrCalculationService.calculateAdjustedXirr(results.xirrTransactions, date)
     val earningsPerDay = calculateEarningsPerDay(results.totalValue, BigDecimal(xirr))
 
     return PortfolioDailySummary(

--- a/src/main/kotlin/ee/tenman/portfolio/service/Trading212PriceUpdateService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/service/Trading212PriceUpdateService.kt
@@ -2,7 +2,7 @@ package ee.tenman.portfolio.service
 
 import ee.tenman.portfolio.domain.DailyPrice
 import ee.tenman.portfolio.domain.ProviderName
-import ee.tenman.portfolio.service.ProcessResult
+import ee.tenman.portfolio.model.ProcessResult
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Propagation

--- a/src/main/kotlin/ee/tenman/portfolio/service/XirrCalculationService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/service/XirrCalculationService.kt
@@ -1,0 +1,80 @@
+package ee.tenman.portfolio.service
+
+import ee.tenman.portfolio.domain.PortfolioTransaction
+import ee.tenman.portfolio.domain.TransactionType
+import ee.tenman.portfolio.service.xirr.Transaction
+import ee.tenman.portfolio.service.xirr.Xirr
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit
+import kotlin.math.min
+
+@Service
+class XirrCalculationService {
+  private val log = LoggerFactory.getLogger(javaClass)
+
+  fun buildXirrTransactions(
+    transactions: List<PortfolioTransaction>,
+    currentValue: BigDecimal,
+    calculationDate: LocalDate = LocalDate.now(),
+  ): List<Transaction> {
+    val cashflows = transactions.map(::convertToXirrTransaction)
+    val finalValue =
+      currentValue
+        .takeIf { it > BigDecimal.ZERO }
+        ?.let { listOf(Transaction(it.toDouble(), calculationDate)) }
+        ?: emptyList()
+    return cashflows + finalValue
+  }
+
+  fun calculateAdjustedXirr(
+    transactions: List<Transaction>,
+    calculationDate: LocalDate = LocalDate.now(),
+  ): Double {
+    if (transactions.size < 2) return 0.0
+    return runCatching {
+      val xirrResult = Xirr(transactions).calculate()
+      val cashFlows = transactions.filter { it.amount < 0 }
+      if (cashFlows.isEmpty()) return@runCatching 0.0
+      val weightedDays = calculateWeightedInvestmentAge(cashFlows, calculationDate)
+      val dampingFactor = min(1.0, weightedDays / 60.0)
+      xirrResult.coerceIn(-10.0, 10.0) * dampingFactor
+    }.getOrElse {
+      log.error("Error calculating adjusted XIRR", it)
+      0.0
+    }
+  }
+
+  fun convertToXirrTransaction(tx: PortfolioTransaction): Transaction {
+    val amount =
+      when (tx.transactionType) {
+        TransactionType.BUY -> -(tx.price.multiply(tx.quantity).add(tx.commission))
+        TransactionType.SELL -> tx.price.multiply(tx.quantity).subtract(tx.commission)
+      }
+    return Transaction(amount.toDouble(), tx.transactionDate)
+  }
+
+  fun addXirrTransactions(
+    xirrList: MutableList<Transaction>,
+    transactions: List<PortfolioTransaction>,
+    currentValue: BigDecimal,
+    date: LocalDate,
+  ) {
+    xirrList += transactions.map(::convertToXirrTransaction)
+    xirrList += Transaction(currentValue.toDouble(), date)
+  }
+
+  private fun calculateWeightedInvestmentAge(
+    cashFlows: List<Transaction>,
+    calculationDate: LocalDate,
+  ): Double {
+    val totalInvestment = cashFlows.sumOf { -it.amount }
+    return cashFlows.sumOf { transaction ->
+      val weight = -transaction.amount / totalInvestment
+      val days = ChronoUnit.DAYS.between(transaction.date, calculationDate).toDouble()
+      days * weight
+    }
+  }
+}

--- a/src/test/kotlin/ee/tenman/portfolio/ArchitectureTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/ArchitectureTest.kt
@@ -59,12 +59,14 @@ class ArchitectureTest {
       .definedBy("..scheduler..")
       .layer("DTOs")
       .definedBy("..dto..")
+      .layer("Model")
+      .definedBy("..model..")
       .whereLayer("API")
       .mayOnlyBeAccessedByLayers("Configuration")
       .whereLayer("Application")
-      .mayOnlyBeAccessedByLayers("API", "Jobs", "Scheduler", "Configuration", "Application")
+      .mayOnlyBeAccessedByLayers("API", "Jobs", "Scheduler", "Configuration", "Application", "Model", "DTOs")
       .whereLayer("Domain")
-      .mayOnlyBeAccessedByLayers("Application", "Infrastructure", "API", "DTOs", "Jobs", "Configuration")
+      .mayOnlyBeAccessedByLayers("Application", "Infrastructure", "API", "DTOs", "Jobs", "Configuration", "Model")
       .whereLayer("Infrastructure")
       .mayOnlyBeAccessedByLayers("Application", "Jobs", "Configuration")
       .whereLayer("Jobs")
@@ -73,6 +75,8 @@ class ArchitectureTest {
       .mayOnlyBeAccessedByLayers("Jobs", "Configuration", "Application")
       .whereLayer("DTOs")
       .mayOnlyBeAccessedByLayers("API", "Application", "Infrastructure")
+      .whereLayer("Model")
+      .mayOnlyBeAccessedByLayers("API", "Application", "Infrastructure", "DTOs", "Jobs")
       .whereLayer("Configuration")
       .mayOnlyBeAccessedByLayers("API", "Application", "Infrastructure", "Jobs")
       .ignoreDependency(
@@ -371,15 +375,13 @@ class ArchitectureTest {
           ).because("API should expose DTOs for decoupling and versioning")
 
   @ArchTest
-  val `data classes should not be nested inside service classes`: ArchRule =
-    classes()
+  val `data classes should be in model package not service package`: ArchRule =
+    noClasses()
       .that()
-      .resideInAPackage("ee.tenman.portfolio.service")
-      .and()
       .haveSimpleNameEndingWith("Metrics")
       .should()
-      .beTopLevelClasses()
-      .because("Data classes should be in separate files for better organization and testability")
+      .resideInAPackage("ee.tenman.portfolio.service")
+      .because("Data classes like *Metrics should be in model package for better organization")
 
   @ArchTest
   fun eachSourceFileShouldContainOnlyOneTopLevelClass(classes: JavaClasses) {

--- a/src/test/kotlin/ee/tenman/portfolio/service/FinancialCalculationEdgeCaseTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/service/FinancialCalculationEdgeCaseTest.kt
@@ -1,0 +1,286 @@
+package ee.tenman.portfolio.service
+
+import ch.tutteli.atrium.api.fluent.en_GB.toBeGreaterThanOrEqualTo
+import ch.tutteli.atrium.api.fluent.en_GB.toBeLessThanOrEqualTo
+import ch.tutteli.atrium.api.fluent.en_GB.toEqual
+import ch.tutteli.atrium.api.fluent.en_GB.toEqualNumerically
+import ch.tutteli.atrium.api.verbs.expect
+import ee.tenman.portfolio.domain.Instrument
+import ee.tenman.portfolio.domain.Platform
+import ee.tenman.portfolio.domain.PortfolioTransaction
+import ee.tenman.portfolio.domain.ProviderName
+import ee.tenman.portfolio.domain.TransactionType
+import ee.tenman.portfolio.service.xirr.Transaction
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+
+class FinancialCalculationEdgeCaseTest {
+  private lateinit var xirrCalculationService: XirrCalculationService
+  private lateinit var holdingsCalculationService: HoldingsCalculationService
+  private lateinit var testInstrument: Instrument
+
+  @BeforeEach
+  fun setUp() {
+    xirrCalculationService = XirrCalculationService()
+    holdingsCalculationService = HoldingsCalculationService()
+    testInstrument = createTestInstrument()
+  }
+
+  @Nested
+  inner class SingleTransactionXirrEdgeCases {
+    @Test
+    fun `should return zero XIRR for single buy transaction`() {
+      val transaction = Transaction(-1000.0, LocalDate.now().minusDays(30))
+      val xirr = xirrCalculationService.calculateAdjustedXirr(listOf(transaction), LocalDate.now())
+      expect(xirr).toEqual(0.0)
+    }
+
+    @Test
+    fun `should return zero XIRR for single sell transaction`() {
+      val transaction = Transaction(1000.0, LocalDate.now().minusDays(30))
+      val xirr = xirrCalculationService.calculateAdjustedXirr(listOf(transaction), LocalDate.now())
+      expect(xirr).toEqual(0.0)
+    }
+
+    @Test
+    fun `should handle very recent transaction with small time delta`() {
+      val transactions =
+        listOf(
+        Transaction(-1000.0, LocalDate.now().minusDays(1)),
+        Transaction(1010.0, LocalDate.now()),
+      )
+      val xirr = xirrCalculationService.calculateAdjustedXirr(transactions, LocalDate.now())
+      expect(xirr).toBeGreaterThanOrEqualTo(-10.0)
+      expect(xirr).toBeLessThanOrEqualTo(10.0)
+    }
+  }
+
+  @Nested
+  inner class NegativeValueEdgeCases {
+    @Test
+    fun `should handle sell exceeding buy quantity`() {
+      val transactions =
+        listOf(
+        createTransaction(TransactionType.BUY, BigDecimal("10"), BigDecimal("100")),
+        createTransaction(TransactionType.SELL, BigDecimal("15"), BigDecimal("120")),
+      )
+      val netQuantity = holdingsCalculationService.calculateNetQuantity(transactions)
+      expect(netQuantity).toEqualNumerically(BigDecimal("-5"))
+    }
+
+    @Test
+    fun `should calculate zero holdings when all sold`() {
+      val transactions =
+        listOf(
+        createTransaction(TransactionType.BUY, BigDecimal("10"), BigDecimal("100")),
+        createTransaction(TransactionType.SELL, BigDecimal("10"), BigDecimal("120")),
+      )
+      val (quantity, _) = holdingsCalculationService.calculateCurrentHoldings(transactions)
+      expect(quantity).toEqualNumerically(BigDecimal.ZERO)
+    }
+
+    @Test
+    fun `should handle zero price transaction`() {
+      val transaction = createTransaction(TransactionType.BUY, BigDecimal("10"), BigDecimal.ZERO)
+      val (quantity, averageCost) = holdingsCalculationService.calculateCurrentHoldings(listOf(transaction))
+      expect(quantity).toEqualNumerically(BigDecimal("10"))
+      expect(averageCost).toEqualNumerically(BigDecimal("0.05"))
+    }
+  }
+
+  @Nested
+  inner class YearBoundaryEdgeCases {
+    @Test
+    fun `should handle year boundary December 31 to January 1`() {
+      val transactions =
+        listOf(
+        Transaction(-1000.0, LocalDate.of(2023, 12, 31)),
+        Transaction(1050.0, LocalDate.of(2024, 1, 1)),
+      )
+      val xirr = xirrCalculationService.calculateAdjustedXirr(transactions, LocalDate.of(2024, 1, 1))
+      expect(xirr).toBeGreaterThanOrEqualTo(-10.0)
+      expect(xirr).toBeLessThanOrEqualTo(10.0)
+    }
+
+    @Test
+    fun `should handle leap year February 29`() {
+      val transactions =
+        listOf(
+        Transaction(-1000.0, LocalDate.of(2024, 2, 28)),
+        Transaction(1005.0, LocalDate.of(2024, 2, 29)),
+      )
+      val xirr = xirrCalculationService.calculateAdjustedXirr(transactions, LocalDate.of(2024, 2, 29))
+      expect(xirr).toBeGreaterThanOrEqualTo(-10.0)
+      expect(xirr).toBeLessThanOrEqualTo(10.0)
+    }
+  }
+
+  @Nested
+  inner class FarFutureDateEdgeCases {
+    @Test
+    fun `should handle far future date 2050`() {
+      val futureDate = LocalDate.of(2050, 6, 15)
+      val transactions =
+        listOf(
+        Transaction(-1000.0, LocalDate.of(2024, 1, 1)),
+        Transaction(5000.0, futureDate),
+      )
+      val xirr = xirrCalculationService.calculateAdjustedXirr(transactions, futureDate)
+      expect(xirr).toBeGreaterThanOrEqualTo(-10.0)
+      expect(xirr).toBeLessThanOrEqualTo(10.0)
+    }
+
+    @Test
+    fun `should handle very long holding period`() {
+      val transactions =
+        listOf(
+        Transaction(-1000.0, LocalDate.of(2000, 1, 1)),
+        Transaction(10000.0, LocalDate.of(2024, 12, 31)),
+      )
+      val xirr = xirrCalculationService.calculateAdjustedXirr(transactions, LocalDate.of(2024, 12, 31))
+      expect(xirr).toBeGreaterThanOrEqualTo(-10.0)
+      expect(xirr).toBeLessThanOrEqualTo(10.0)
+    }
+  }
+
+  @Nested
+  inner class ZeroQuantityEdgeCases {
+    @Test
+    fun `should handle empty transaction list for holdings`() {
+      val (quantity, averageCost) = holdingsCalculationService.calculateCurrentHoldings(emptyList())
+      expect(quantity).toEqualNumerically(BigDecimal.ZERO)
+      expect(averageCost).toEqualNumerically(BigDecimal.ZERO)
+    }
+
+    @Test
+    fun `should handle zero quantity buy transaction`() {
+      val transaction = createTransaction(TransactionType.BUY, BigDecimal.ZERO, BigDecimal("100"))
+      val (quantity, _) = holdingsCalculationService.calculateCurrentHoldings(listOf(transaction))
+      expect(quantity).toEqualNumerically(BigDecimal.ZERO)
+    }
+
+    @Test
+    fun `should calculate profit correctly when holdings become zero`() {
+      val profit =
+        holdingsCalculationService.calculateProfit(
+        BigDecimal.ZERO,
+        BigDecimal("100"),
+        BigDecimal("150"),
+      )
+      expect(profit).toEqualNumerically(BigDecimal.ZERO)
+    }
+  }
+
+  @Nested
+  inner class PrecisionEdgeCases {
+    @Test
+    fun `should handle very small quantities`() {
+      val transactions =
+        listOf(
+        createTransaction(TransactionType.BUY, BigDecimal("0.00000001"), BigDecimal("100")),
+      )
+      val (quantity, _) = holdingsCalculationService.calculateCurrentHoldings(transactions)
+      expect(quantity).toEqualNumerically(BigDecimal("0.00000001"))
+    }
+
+    @Test
+    fun `should handle very large quantities`() {
+      val transactions =
+        listOf(
+        createTransaction(TransactionType.BUY, BigDecimal("999999999.99"), BigDecimal("100")),
+      )
+      val (quantity, _) = holdingsCalculationService.calculateCurrentHoldings(transactions)
+      expect(quantity).toEqualNumerically(BigDecimal("999999999.99"))
+    }
+
+    @Test
+    fun `should handle very large prices`() {
+      val currentValue =
+        holdingsCalculationService.calculateCurrentValue(
+        BigDecimal("1"),
+        BigDecimal("999999999999.99"),
+      )
+      expect(currentValue).toEqualNumerically(BigDecimal("999999999999.99"))
+    }
+  }
+
+  @Nested
+  inner class XirrTransactionBuildingEdgeCases {
+    @Test
+    fun `should build empty XIRR transaction list when current value is zero`() {
+      val transactions =
+        listOf(
+        createTransaction(TransactionType.BUY, BigDecimal("10"), BigDecimal("100")),
+        createTransaction(TransactionType.SELL, BigDecimal("10"), BigDecimal("100")),
+      )
+      val xirrTransactions =
+        xirrCalculationService.buildXirrTransactions(
+        transactions,
+        BigDecimal.ZERO,
+        LocalDate.now(),
+      )
+      expect(xirrTransactions.any { it.amount > 0 && it.date == LocalDate.now() }).toEqual(false)
+    }
+
+    @Test
+    fun `should handle commission in transaction conversion`() {
+      val buyTransaction =
+        PortfolioTransaction(
+        instrument = testInstrument,
+        transactionType = TransactionType.BUY,
+        quantity = BigDecimal("10"),
+        price = BigDecimal("100"),
+        transactionDate = LocalDate.now().minusDays(30),
+        platform = Platform.LIGHTYEAR,
+        commission = BigDecimal("10"),
+      )
+      val xirrTransaction = xirrCalculationService.convertToXirrTransaction(buyTransaction)
+      expect(xirrTransaction.amount).toEqual(-1010.0)
+    }
+
+    @Test
+    fun `should subtract commission from sell transaction`() {
+      val sellTransaction =
+        PortfolioTransaction(
+        instrument = testInstrument,
+        transactionType = TransactionType.SELL,
+        quantity = BigDecimal("10"),
+        price = BigDecimal("100"),
+        transactionDate = LocalDate.now().minusDays(30),
+        platform = Platform.LIGHTYEAR,
+        commission = BigDecimal("10"),
+      )
+      val xirrTransaction = xirrCalculationService.convertToXirrTransaction(sellTransaction)
+      expect(xirrTransaction.amount).toEqual(990.0)
+    }
+  }
+
+  private fun createTestInstrument(): Instrument =
+    Instrument(
+      symbol = "TEST",
+      name = "Test Instrument",
+      category = "Stock",
+      baseCurrency = "EUR",
+      currentPrice = BigDecimal("100.00"),
+      providerName = ProviderName.FT,
+    ).apply { id = 1L }
+
+  private fun createTransaction(
+    type: TransactionType,
+    quantity: BigDecimal,
+    price: BigDecimal,
+    date: LocalDate = LocalDate.now().minusDays(30),
+  ): PortfolioTransaction =
+    PortfolioTransaction(
+      instrument = testInstrument,
+      transactionType = type,
+      quantity = quantity,
+      price = price,
+      transactionDate = date,
+      platform = Platform.LIGHTYEAR,
+      commission = BigDecimal("0.50"),
+    )
+}

--- a/src/test/kotlin/ee/tenman/portfolio/service/HoldingsCalculationPropertyTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/service/HoldingsCalculationPropertyTest.kt
@@ -1,0 +1,175 @@
+package ee.tenman.portfolio.service
+
+import ch.tutteli.atrium.api.fluent.en_GB.toBeGreaterThanOrEqualTo
+import ch.tutteli.atrium.api.fluent.en_GB.toEqual
+import ch.tutteli.atrium.api.fluent.en_GB.toEqualNumerically
+import ch.tutteli.atrium.api.verbs.expect
+import ee.tenman.portfolio.domain.Instrument
+import ee.tenman.portfolio.domain.Platform
+import ee.tenman.portfolio.domain.PortfolioTransaction
+import ee.tenman.portfolio.domain.ProviderName
+import ee.tenman.portfolio.domain.TransactionType
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.bigDecimal
+import io.kotest.property.arbitrary.enum
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.list
+import io.kotest.property.arbitrary.localDate
+import io.kotest.property.checkAll
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.math.RoundingMode
+import java.time.LocalDate
+
+class HoldingsCalculationPropertyTest {
+  private lateinit var holdingsCalculationService: HoldingsCalculationService
+  private lateinit var testInstrument: Instrument
+
+  @BeforeEach
+  fun setUp() {
+    holdingsCalculationService = HoldingsCalculationService()
+    testInstrument =
+      Instrument(
+      symbol = "TEST",
+      name = "Test Instrument",
+      category = "Stock",
+      baseCurrency = "EUR",
+      currentPrice = BigDecimal("100.00"),
+      providerName = ProviderName.FT,
+    ).apply { id = 1L }
+  }
+
+  @Test
+  fun `net position equals buy quantity minus sell quantity`() =
+    runBlocking {
+    val transactionArb =
+      Arb.list(
+      createTransactionArb(),
+      1..20,
+    )
+    checkAll(100, transactionArb) { transactions ->
+      val buyQuantity =
+        transactions
+        .filter { it.transactionType == TransactionType.BUY }
+        .sumOf { it.quantity }
+      val sellQuantity =
+        transactions
+        .filter { it.transactionType == TransactionType.SELL }
+        .sumOf { it.quantity }
+      val expectedNetPosition = buyQuantity.subtract(sellQuantity)
+      val actualNetPosition = holdingsCalculationService.calculateNetQuantity(transactions)
+      expect(actualNetPosition).toEqualNumerically(expectedNetPosition)
+    }
+  }
+
+  @Test
+  fun `holdings quantity is never negative when sells do not exceed buys`() =
+    runBlocking {
+    val transactionArb =
+      Arb.list(
+      createBuyOnlyTransactionArb(),
+      1..10,
+    )
+    checkAll(100, transactionArb) { transactions ->
+      val (quantity, _) = holdingsCalculationService.calculateCurrentHoldings(transactions)
+      expect(quantity).toBeGreaterThanOrEqualTo(BigDecimal.ZERO)
+    }
+  }
+
+  @Test
+  fun `average cost is positive when holdings are positive`() =
+    runBlocking {
+    val transactionArb =
+      Arb.list(
+      createBuyOnlyTransactionArb(),
+      1..10,
+    )
+    checkAll(100, transactionArb) { transactions ->
+      val (quantity, averageCost) = holdingsCalculationService.calculateCurrentHoldings(transactions)
+      if (quantity > BigDecimal.ZERO) {
+        expect(averageCost > BigDecimal.ZERO).toEqual(true)
+      }
+    }
+  }
+
+  @Test
+  fun `current value equals holdings multiplied by price`() =
+    runBlocking {
+    val holdingsArb = Arb.bigDecimal(BigDecimal("0.01"), BigDecimal("10000"))
+    val priceArb = Arb.bigDecimal(BigDecimal("0.01"), BigDecimal("10000"))
+    checkAll(100, holdingsArb, priceArb) { holdings, price ->
+      val expectedValue = holdings.multiply(price)
+      val actualValue = holdingsCalculationService.calculateCurrentValue(holdings, price)
+      expect(actualValue.setScale(10, RoundingMode.HALF_UP))
+        .toEqualNumerically(expectedValue.setScale(10, RoundingMode.HALF_UP))
+    }
+  }
+
+  @Test
+  fun `profit calculation is consistent`() =
+    runBlocking {
+    val holdingsArb = Arb.bigDecimal(BigDecimal("1"), BigDecimal("1000"))
+    val avgCostArb = Arb.bigDecimal(BigDecimal("10"), BigDecimal("500"))
+    val currentPriceArb = Arb.bigDecimal(BigDecimal("10"), BigDecimal("500"))
+    checkAll(100, holdingsArb, avgCostArb, currentPriceArb) { holdings, avgCost, currentPrice ->
+      val profit = holdingsCalculationService.calculateProfit(holdings, avgCost, currentPrice)
+      val expectedProfit = holdings.multiply(currentPrice).subtract(holdings.multiply(avgCost))
+      expect(profit.setScale(10, RoundingMode.HALF_UP))
+        .toEqualNumerically(expectedProfit.setScale(10, RoundingMode.HALF_UP))
+    }
+  }
+
+  private fun createTransactionArb(): Arb<PortfolioTransaction> =
+    Arb.bigDecimal(BigDecimal("1"), BigDecimal("100")).let { quantityArb ->
+      Arb.bigDecimal(BigDecimal("10"), BigDecimal("500")).let { priceArb ->
+        Arb.enum<TransactionType>().let { typeArb ->
+          Arb
+            .localDate(
+            LocalDate.of(2020, 1, 1),
+            LocalDate.of(2024, 12, 31),
+          ).let { dateArb ->
+            Arb.int(1..100).let { idArb ->
+              io.kotest.property.arbitrary.arbitrary {
+                PortfolioTransaction(
+                  instrument = testInstrument,
+                  transactionType = typeArb.bind(),
+                  quantity = quantityArb.bind().setScale(2, RoundingMode.HALF_UP),
+                  price = priceArb.bind().setScale(2, RoundingMode.HALF_UP),
+                  transactionDate = dateArb.bind(),
+                  platform = Platform.LIGHTYEAR,
+                  commission = BigDecimal("0.50"),
+                ).apply { id = idArb.bind().toLong() }
+              }
+            }
+          }
+        }
+      }
+    }
+
+  private fun createBuyOnlyTransactionArb(): Arb<PortfolioTransaction> =
+    Arb.bigDecimal(BigDecimal("1"), BigDecimal("100")).let { quantityArb ->
+      Arb.bigDecimal(BigDecimal("10"), BigDecimal("500")).let { priceArb ->
+        Arb
+          .localDate(
+          LocalDate.of(2020, 1, 1),
+          LocalDate.of(2024, 12, 31),
+        ).let { dateArb ->
+          Arb.int(1..100).let { idArb ->
+            io.kotest.property.arbitrary.arbitrary {
+              PortfolioTransaction(
+                instrument = testInstrument,
+                transactionType = TransactionType.BUY,
+                quantity = quantityArb.bind().setScale(2, RoundingMode.HALF_UP),
+                price = priceArb.bind().setScale(2, RoundingMode.HALF_UP),
+                transactionDate = dateArb.bind(),
+                platform = Platform.LIGHTYEAR,
+                commission = BigDecimal("0.50"),
+              ).apply { id = idArb.bind().toLong() }
+            }
+          }
+        }
+      }
+    }
+}

--- a/src/test/kotlin/ee/tenman/portfolio/service/InstrumentServiceTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/service/InstrumentServiceTest.kt
@@ -14,6 +14,8 @@ import ee.tenman.portfolio.domain.Platform
 import ee.tenman.portfolio.domain.PortfolioTransaction
 import ee.tenman.portfolio.domain.ProviderName
 import ee.tenman.portfolio.domain.TransactionType
+import ee.tenman.portfolio.model.PriceChange
+import ee.tenman.portfolio.model.metrics.InstrumentMetrics
 import ee.tenman.portfolio.repository.InstrumentRepository
 import ee.tenman.portfolio.repository.PortfolioTransactionRepository
 import io.mockk.every

--- a/src/test/kotlin/ee/tenman/portfolio/service/PriceUpdateProcessorTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/service/PriceUpdateProcessorTest.kt
@@ -4,6 +4,7 @@ import ch.tutteli.atrium.api.fluent.en_GB.toContainExactly
 import ch.tutteli.atrium.api.fluent.en_GB.toEqual
 import ch.tutteli.atrium.api.verbs.expect
 import ee.tenman.portfolio.domain.Platform
+import ee.tenman.portfolio.model.ProcessResult
 import ee.tenman.portfolio.scheduler.MarketPhaseDetectionService
 import io.mockk.every
 import io.mockk.mockk

--- a/src/test/kotlin/ee/tenman/portfolio/service/SummaryServiceTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/service/SummaryServiceTest.kt
@@ -9,6 +9,7 @@ import ee.tenman.portfolio.domain.Platform
 import ee.tenman.portfolio.domain.PortfolioDailySummary
 import ee.tenman.portfolio.domain.PortfolioTransaction
 import ee.tenman.portfolio.domain.TransactionType
+import ee.tenman.portfolio.model.metrics.PortfolioMetrics
 import ee.tenman.portfolio.repository.PortfolioDailySummaryRepository
 import ee.tenman.portfolio.service.xirr.Transaction
 import io.mockk.every
@@ -34,6 +35,7 @@ class SummaryServiceTest {
   private val portfolioDailySummaryRepository = mockk<PortfolioDailySummaryRepository>(relaxUnitFun = true)
   private val cacheManager = mockk<CacheManager>(relaxed = true)
   private val investmentMetricsService = mockk<InvestmentMetricsService>()
+  private val xirrCalculationService = mockk<XirrCalculationService>()
   private val clock = mockk<Clock>()
   private val summaryBatchProcessor = mockk<SummaryBatchProcessorService>(relaxed = true)
   private val summaryDeletionService = mockk<SummaryDeletionService>(relaxed = true)
@@ -56,6 +58,7 @@ class SummaryServiceTest {
         transactionService,
         cacheManager,
         investmentMetricsService,
+        xirrCalculationService,
         clock,
         summaryBatchProcessor,
         summaryDeletionService,
@@ -77,9 +80,9 @@ class SummaryServiceTest {
         xirrTransactions = mutableListOf(),
       )
 
-    every { investmentMetricsService.buildXirrTransactions(any(), any(), any()) } returns emptyList()
+    every { xirrCalculationService.buildXirrTransactions(any(), any(), any()) } returns emptyList()
 
-    every { investmentMetricsService.calculateAdjustedXirr(any(), any()) } returns 0.0
+    every { xirrCalculationService.calculateAdjustedXirr(any(), any()) } returns 0.0
 
     instrument =
       Instrument(
@@ -129,7 +132,7 @@ class SummaryServiceTest {
         xirrTransactions = mutableListOf(),
       )
     every { investmentMetricsService.calculatePortfolioMetrics(any(), testDate) } returns portfolioMetrics
-    every { investmentMetricsService.calculateAdjustedXirr(any(), testDate) } returns 0.0
+    every { xirrCalculationService.calculateAdjustedXirr(any(), testDate) } returns 0.0
 
     val summary = summaryService.getCurrentDaySummary()
 
@@ -168,7 +171,7 @@ class SummaryServiceTest {
       )
 
     every { transactionService.getAllTransactions() } returns listOf(testTransaction)
-    every { investmentMetricsService.calculateAdjustedXirr(any(), date) } returns 0.05
+    every { xirrCalculationService.calculateAdjustedXirr(any(), date) } returns 0.05
 
     val expectedTotal = price.multiply(quantity)
     val expectedProfit = expectedTotal.subtract(originalPrice.multiply(quantity))
@@ -236,7 +239,7 @@ class SummaryServiceTest {
       )
 
     every { transactionService.getAllTransactions() } returns listOf(transaction)
-    every { investmentMetricsService.calculateAdjustedXirr(any(), any()) } returns 0.05
+    every { xirrCalculationService.calculateAdjustedXirr(any(), any()) } returns 0.05
 
     val totalValue = BigDecimal("110").multiply(transaction.quantity)
     val totalProfit = totalValue.subtract(transaction.price.multiply(transaction.quantity))
@@ -368,7 +371,7 @@ class SummaryServiceTest {
       )
 
     every { transactionService.getAllTransactions() } returns listOf(testTransaction)
-    every { investmentMetricsService.calculateAdjustedXirr(any(), date) } returns 0.05
+    every { xirrCalculationService.calculateAdjustedXirr(any(), date) } returns 0.05
 
     val expectedTotalValue = price.multiply(quantity)
     val xirrTransactions =
@@ -419,7 +422,7 @@ class SummaryServiceTest {
         xirrTransactions = mutableListOf(),
       )
     every { investmentMetricsService.calculatePortfolioMetrics(any(), testDate) } returns portfolioMetrics
-    every { investmentMetricsService.calculateAdjustedXirr(any(), testDate) } returns 0.075
+    every { xirrCalculationService.calculateAdjustedXirr(any(), testDate) } returns 0.075
 
     val summary = summaryService.getCurrentDaySummary()
 
@@ -471,7 +474,7 @@ class SummaryServiceTest {
 
     every { transactionService.getAllTransactions() } returns listOf(transaction)
     every { portfolioDailySummaryRepository.findAll() } returns listOf(todaySummary, oldSummary)
-    every { investmentMetricsService.calculateAdjustedXirr(any(), any()) } returns 0.05
+    every { xirrCalculationService.calculateAdjustedXirr(any(), any()) } returns 0.05
 
     val totalValue = BigDecimal("110").multiply(BigDecimal("10"))
     val totalProfit = totalValue.subtract(BigDecimal("100").multiply(BigDecimal("10")))
@@ -534,7 +537,7 @@ class SummaryServiceTest {
 
     every { transactionService.getAllTransactions() } returns listOf(transaction1, transaction2)
 
-    every { investmentMetricsService.calculateAdjustedXirr(any(), date) } returns xirrValue
+    every { xirrCalculationService.calculateAdjustedXirr(any(), date) } returns xirrValue
 
     val xirrTransactions =
       listOf(
@@ -582,7 +585,7 @@ class SummaryServiceTest {
 
     every { transactionService.getAllTransactions() } returns listOf(buyTransaction, sellTransaction)
 
-    every { investmentMetricsService.calculateAdjustedXirr(any(), date) } returns 0.12
+    every { xirrCalculationService.calculateAdjustedXirr(any(), date) } returns 0.12
 
     val remainingQuantity = BigDecimal("12")
     val currentPrice = BigDecimal("130")
@@ -647,7 +650,7 @@ class SummaryServiceTest {
 
     every { transactionService.getAllTransactions() } returns listOf(transaction1, transaction2)
 
-    every { investmentMetricsService.calculateAdjustedXirr(any(), date) } returns 0.08
+    every { xirrCalculationService.calculateAdjustedXirr(any(), date) } returns 0.08
 
     val xirrTransactions =
       listOf(
@@ -713,7 +716,7 @@ class SummaryServiceTest {
         xirrTransactions = mutableListOf(),
       )
     every { investmentMetricsService.calculatePortfolioMetrics(any(), today) } returns portfolioMetrics
-    every { investmentMetricsService.calculateAdjustedXirr(any(), today) } returns 0.08
+    every { xirrCalculationService.calculateAdjustedXirr(any(), today) } returns 0.08
 
     val result = summaryService.calculateSummaryForDate(today)
 
@@ -820,7 +823,7 @@ class SummaryServiceTest {
         xirrTransactions = mutableListOf(),
       )
     every { investmentMetricsService.calculatePortfolioMetrics(any(), today) } returns portfolioMetrics
-    every { investmentMetricsService.calculateAdjustedXirr(any(), today) } returns 0.08
+    every { xirrCalculationService.calculateAdjustedXirr(any(), today) } returns 0.08
 
     val result = summaryService.calculateSummaryForDate(today)
 
@@ -865,7 +868,7 @@ class SummaryServiceTest {
         xirrTransactions = mutableListOf(),
       )
     every { investmentMetricsService.calculatePortfolioMetrics(any(), date) } returns portfolioMetrics
-    every { investmentMetricsService.calculateAdjustedXirr(any(), date) } returns 0.06
+    every { xirrCalculationService.calculateAdjustedXirr(any(), date) } returns 0.06
 
     val result = summaryService.calculateSummaryForDate(date)
 
@@ -900,7 +903,7 @@ class SummaryServiceTest {
         xirrTransactions = mutableListOf(),
       )
     every { investmentMetricsService.calculatePortfolioMetrics(any(), date) } returns portfolioMetrics
-    every { investmentMetricsService.calculateAdjustedXirr(any(), date) } returns 0.06
+    every { xirrCalculationService.calculateAdjustedXirr(any(), date) } returns 0.06
 
     val result = summaryService.calculateSummaryForDate(date)
 
@@ -945,7 +948,7 @@ class SummaryServiceTest {
         xirrTransactions = mutableListOf(),
       )
     every { investmentMetricsService.calculatePortfolioMetrics(any(), date) } returns portfolioMetrics
-    every { investmentMetricsService.calculateAdjustedXirr(any(), date) } returns 0.07
+    every { xirrCalculationService.calculateAdjustedXirr(any(), date) } returns 0.07
 
     val result = summaryService.calculateSummaryForDate(date)
 

--- a/src/test/kotlin/ee/tenman/portfolio/service/XirrCalculationPropertyTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/service/XirrCalculationPropertyTest.kt
@@ -1,0 +1,191 @@
+package ee.tenman.portfolio.service
+
+import ch.tutteli.atrium.api.fluent.en_GB.toBeGreaterThanOrEqualTo
+import ch.tutteli.atrium.api.fluent.en_GB.toBeLessThanOrEqualTo
+import ch.tutteli.atrium.api.fluent.en_GB.toEqual
+import ch.tutteli.atrium.api.verbs.expect
+import ee.tenman.portfolio.domain.Instrument
+import ee.tenman.portfolio.domain.Platform
+import ee.tenman.portfolio.domain.PortfolioTransaction
+import ee.tenman.portfolio.domain.ProviderName
+import ee.tenman.portfolio.domain.TransactionType
+import ee.tenman.portfolio.service.xirr.Transaction
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.bigDecimal
+import io.kotest.property.arbitrary.double
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.list
+import io.kotest.property.arbitrary.localDate
+import io.kotest.property.checkAll
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.math.RoundingMode
+import java.time.LocalDate
+
+class XirrCalculationPropertyTest {
+  private lateinit var xirrCalculationService: XirrCalculationService
+  private lateinit var testInstrument: Instrument
+
+  @BeforeEach
+  fun setUp() {
+    xirrCalculationService = XirrCalculationService()
+    testInstrument =
+      Instrument(
+      symbol = "TEST",
+      name = "Test Instrument",
+      category = "Stock",
+      baseCurrency = "EUR",
+      currentPrice = BigDecimal("100.00"),
+      providerName = ProviderName.FT,
+    ).apply { id = 1L }
+  }
+
+  @Test
+  fun `XIRR result is always bounded between -10 and 10`() =
+    runBlocking {
+    val transactionArb = createXirrTransactionArb()
+    checkAll(100, Arb.list(transactionArb, 2..10)) { transactions ->
+      val calculationDate = LocalDate.now()
+      val xirr = xirrCalculationService.calculateAdjustedXirr(transactions, calculationDate)
+      expect(xirr).toBeGreaterThanOrEqualTo(-10.0)
+      expect(xirr).toBeLessThanOrEqualTo(10.0)
+    }
+  }
+
+  @Test
+  fun `XIRR returns zero for less than 2 transactions`() =
+    runBlocking {
+    val transactionArb = createXirrTransactionArb()
+    checkAll(50, transactionArb) { transaction ->
+      val xirr = xirrCalculationService.calculateAdjustedXirr(listOf(transaction), LocalDate.now())
+      expect(xirr).toEqual(0.0)
+    }
+  }
+
+  @Test
+  fun `XIRR returns zero for empty transaction list`() {
+    val xirr = xirrCalculationService.calculateAdjustedXirr(emptyList(), LocalDate.now())
+    expect(xirr).toEqual(0.0)
+  }
+
+  @Test
+  fun `XIRR transactions list contains final value when current value is positive`() =
+    runBlocking {
+    val portfolioTransactionArb = createPortfolioTransactionArb()
+    val currentValueArb = Arb.bigDecimal(BigDecimal("100"), BigDecimal("100000"))
+    checkAll(50, Arb.list(portfolioTransactionArb, 1..5), currentValueArb) { transactions, currentValue ->
+      val calculationDate = LocalDate.now()
+      val xirrTransactions =
+        xirrCalculationService.buildXirrTransactions(
+        transactions,
+        currentValue,
+        calculationDate,
+      )
+      val lastTransaction = xirrTransactions.lastOrNull()
+      expect(lastTransaction != null).toEqual(true)
+      expect(lastTransaction!!.amount > 0).toEqual(true)
+      expect(lastTransaction.date).toEqual(calculationDate)
+    }
+  }
+
+  @Test
+  fun `buy transactions convert to negative XIRR amounts`() =
+    runBlocking {
+    val quantityArb = Arb.bigDecimal(BigDecimal("1"), BigDecimal("100"))
+    val priceArb = Arb.bigDecimal(BigDecimal("10"), BigDecimal("500"))
+    checkAll(100, quantityArb, priceArb) { quantity, price ->
+      val buyTransaction =
+        PortfolioTransaction(
+        instrument = testInstrument,
+        transactionType = TransactionType.BUY,
+        quantity = quantity.setScale(2, RoundingMode.HALF_UP),
+        price = price.setScale(2, RoundingMode.HALF_UP),
+        transactionDate = LocalDate.now().minusDays(30),
+        platform = Platform.LIGHTYEAR,
+        commission = BigDecimal("0.50"),
+      )
+      val xirrTransaction = xirrCalculationService.convertToXirrTransaction(buyTransaction)
+      expect(xirrTransaction.amount < 0).toEqual(true)
+    }
+  }
+
+  @Test
+  fun `sell transactions convert to positive XIRR amounts`() =
+    runBlocking {
+    val quantityArb = Arb.bigDecimal(BigDecimal("1"), BigDecimal("100"))
+    val priceArb = Arb.bigDecimal(BigDecimal("10"), BigDecimal("500"))
+    checkAll(100, quantityArb, priceArb) { quantity, price ->
+      val sellTransaction =
+        PortfolioTransaction(
+        instrument = testInstrument,
+        transactionType = TransactionType.SELL,
+        quantity = quantity.setScale(2, RoundingMode.HALF_UP),
+        price = price.setScale(2, RoundingMode.HALF_UP),
+        transactionDate = LocalDate.now().minusDays(30),
+        platform = Platform.LIGHTYEAR,
+        commission = BigDecimal("0.50"),
+      )
+      val xirrTransaction = xirrCalculationService.convertToXirrTransaction(sellTransaction)
+      expect(xirrTransaction.amount > 0).toEqual(true)
+    }
+  }
+
+  @Test
+  fun `XIRR calculation is stable across multiple runs`() =
+    runBlocking {
+    val transactions =
+      listOf(
+      Transaction(-1000.0, LocalDate.now().minusDays(365)),
+      Transaction(-500.0, LocalDate.now().minusDays(180)),
+      Transaction(1800.0, LocalDate.now()),
+    )
+    val results =
+      (1..10).map {
+      xirrCalculationService.calculateAdjustedXirr(transactions, LocalDate.now())
+    }
+    val first = results.first()
+    results.forEach { result ->
+      expect(result).toEqual(first)
+    }
+  }
+
+  private fun createXirrTransactionArb(): Arb<Transaction> =
+    Arb.double(-10000.0, 10000.0).let { amountArb ->
+      Arb
+        .localDate(
+        LocalDate.now().minusYears(3),
+        LocalDate.now(),
+      ).let { dateArb ->
+        io.kotest.property.arbitrary.arbitrary {
+          Transaction(amountArb.bind(), dateArb.bind())
+        }
+      }
+    }
+
+  private fun createPortfolioTransactionArb(): Arb<PortfolioTransaction> =
+    Arb.bigDecimal(BigDecimal("1"), BigDecimal("100")).let { quantityArb ->
+      Arb.bigDecimal(BigDecimal("10"), BigDecimal("500")).let { priceArb ->
+        Arb
+          .localDate(
+          LocalDate.of(2020, 1, 1),
+          LocalDate.of(2024, 12, 31),
+        ).let { dateArb ->
+          Arb.int(1..100).let { idArb ->
+            io.kotest.property.arbitrary.arbitrary {
+              PortfolioTransaction(
+                instrument = testInstrument,
+                transactionType = TransactionType.BUY,
+                quantity = quantityArb.bind().setScale(2, RoundingMode.HALF_UP),
+                price = priceArb.bind().setScale(2, RoundingMode.HALF_UP),
+                transactionDate = dateArb.bind(),
+                platform = Platform.LIGHTYEAR,
+                commission = BigDecimal("0.50"),
+              ).apply { id = idArb.bind().toLong() }
+            }
+          }
+        }
+      }
+    }
+}


### PR DESCRIPTION
## Summary

### Phase 1: Package Reorganization
- Move 11 data classes from `service/` package to proper locations following clean architecture principles
- Create new `model/` package hierarchy for value objects and internal models
- Update `ArchitectureTest` to validate the new `Model` layer in layered architecture

| Class | From | To |
|-------|------|-----|
| InstrumentMetrics | service/ | model/metrics/ |
| PortfolioMetrics | service/ | model/metrics/ |
| HoldingKey | service/ | model/holding/ |
| HoldingValue | service/ | model/holding/ |
| HoldingsAccumulator | service/ | model/holding/ |
| InternalHoldingData | service/ | model/holding/ |
| PriceChange | service/ | model/ |
| TransactionState | service/ | model/ |
| XirrCalculationResult | service/ | model/ |
| CalculationResult | service/ | dto/ |
| InstrumentEnrichmentContext | service/ | dto/ |

### Phase 3: Service Decomposition
- Extract `XirrCalculationService` from `InvestmentMetricsService` (XIRR calculations, transaction conversion)
- Extract `HoldingsCalculationService` from `InvestmentMetricsService` (holdings quantity and cost calculations)
- `InvestmentMetricsService` now orchestrates these services for portfolio metrics

## Test plan

- [x] All backend tests pass (420+ tests)
- [x] All frontend tests pass (501 tests)
- [x] Architecture tests validate new Model layer
- [x] No compilation errors

Closes #975