### PR TITLE
Remove transient calculated fields from Instrument entity

### DIFF
--- a/src/main/kotlin/ee/tenman/portfolio/controller/InstrumentController.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/controller/InstrumentController.kt
@@ -63,9 +63,9 @@ class InstrumentController(
     @RequestParam(defaultValue = "24h") period: String,
   ): List<InstrumentDto> =
     instrumentService
-      .getAllInstruments(platforms, period)
-      .sortedBy { it.id }
-      .map { InstrumentDto.fromEntity(it) }
+      .getAllInstrumentSnapshots(platforms, period)
+      .sortedBy { it.instrument.id }
+      .map { InstrumentDto.fromSnapshot(it) }
 
   @PutMapping("/{id}")
   @Loggable

--- a/src/main/kotlin/ee/tenman/portfolio/domain/Instrument.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/domain/Instrument.kt
@@ -4,7 +4,6 @@ import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
-import jakarta.persistence.PostLoad
 import jakarta.persistence.Table
 import java.math.BigDecimal
 
@@ -24,31 +23,4 @@ class Instrument(
   @Enumerated(EnumType.STRING)
   @Column(name = "provider_name", nullable = true)
   var providerName: ProviderName = ProviderName.FT,
-  @Transient
-  var totalInvestment: BigDecimal = BigDecimal.ZERO,
-  @Transient
-  var currentValue: BigDecimal = BigDecimal.ZERO,
-  @Transient
-  var profit: BigDecimal = BigDecimal.ZERO,
-  @Transient
-  var realizedProfit: BigDecimal = BigDecimal.ZERO,
-  @Transient
-  var unrealizedProfit: BigDecimal? = BigDecimal.ZERO,
-  @Transient
-  var xirr: Double = 0.0,
-  @Transient
-  var quantity: BigDecimal = BigDecimal.ZERO,
-  @Transient
-  var platforms: Set<Platform> = emptySet(),
-  @Transient
-  var priceChangeAmount: BigDecimal? = null,
-  @Transient
-  var priceChangePercent: Double? = null,
-) : BaseEntity() {
-  @PostLoad
-  fun initializeTransientFields() {
-    if (unrealizedProfit == null) {
-      unrealizedProfit = BigDecimal.ZERO
-    }
-  }
-}
+) : BaseEntity()

--- a/src/main/kotlin/ee/tenman/portfolio/dto/InstrumentDto.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/dto/InstrumentDto.kt
@@ -2,6 +2,7 @@ package ee.tenman.portfolio.dto
 
 import ee.tenman.portfolio.domain.Instrument
 import ee.tenman.portfolio.domain.ProviderName
+import ee.tenman.portfolio.model.InstrumentSnapshot
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
 import java.math.BigDecimal
@@ -41,12 +42,6 @@ data class InstrumentDto(
       providerName = ProviderName.valueOf(providerName),
     ).apply {
       id.let { this.id = it }
-      totalInvestment = this@InstrumentDto.totalInvestment ?: BigDecimal.ZERO
-      currentValue = this@InstrumentDto.currentValue ?: BigDecimal.ZERO
-      profit = this@InstrumentDto.profit ?: BigDecimal.ZERO
-      realizedProfit = this@InstrumentDto.realizedProfit ?: BigDecimal.ZERO
-      unrealizedProfit = this@InstrumentDto.unrealizedProfit ?: BigDecimal.ZERO
-      xirr = this@InstrumentDto.xirr ?: 0.0
     }
 
   companion object {
@@ -58,17 +53,38 @@ data class InstrumentDto(
         category = instrument.category,
         baseCurrency = instrument.baseCurrency,
         currentPrice = instrument.currentPrice,
-        quantity = instrument.quantity,
+        quantity = BigDecimal.ZERO,
         providerName = instrument.providerName.name,
-        totalInvestment = instrument.totalInvestment,
-        currentValue = instrument.currentValue,
-        profit = instrument.profit,
-        realizedProfit = instrument.realizedProfit,
-        unrealizedProfit = instrument.unrealizedProfit,
-        xirr = instrument.xirr,
-        platforms = instrument.platforms?.map { it.name }?.toSet() ?: emptySet(),
-        priceChangeAmount = instrument.priceChangeAmount,
-        priceChangePercent = instrument.priceChangePercent,
+        totalInvestment = BigDecimal.ZERO,
+        currentValue = BigDecimal.ZERO,
+        profit = BigDecimal.ZERO,
+        realizedProfit = BigDecimal.ZERO,
+        unrealizedProfit = BigDecimal.ZERO,
+        xirr = 0.0,
+        platforms = emptySet(),
+        priceChangeAmount = null,
+        priceChangePercent = null,
+      )
+
+    fun fromSnapshot(snapshot: InstrumentSnapshot) =
+      InstrumentDto(
+        id = snapshot.instrument.id,
+        symbol = snapshot.instrument.symbol,
+        name = snapshot.instrument.name,
+        category = snapshot.instrument.category,
+        baseCurrency = snapshot.instrument.baseCurrency,
+        currentPrice = snapshot.instrument.currentPrice,
+        quantity = snapshot.quantity,
+        providerName = snapshot.instrument.providerName.name,
+        totalInvestment = snapshot.totalInvestment,
+        currentValue = snapshot.currentValue,
+        profit = snapshot.profit,
+        realizedProfit = snapshot.realizedProfit,
+        unrealizedProfit = snapshot.unrealizedProfit,
+        xirr = snapshot.xirr,
+        platforms = snapshot.platforms.map { it.name }.toSet(),
+        priceChangeAmount = snapshot.priceChangeAmount,
+        priceChangePercent = snapshot.priceChangePercent,
       )
   }
 }

--- a/src/main/kotlin/ee/tenman/portfolio/job/FtDataRetrievalJob.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/job/FtDataRetrievalJob.kt
@@ -61,7 +61,7 @@ class FtDataRetrievalJob(
       log.info("Starting FT data retrieval execution")
       val instruments =
         instrumentService
-          .getAllInstruments()
+          .getAllInstrumentsWithoutFiltering()
           .filter { it.providerName == ProviderName.FT }
 
       if (instruments.isEmpty()) {

--- a/src/main/kotlin/ee/tenman/portfolio/model/InstrumentSnapshot.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/model/InstrumentSnapshot.kt
@@ -1,0 +1,19 @@
+package ee.tenman.portfolio.model
+
+import ee.tenman.portfolio.domain.Instrument
+import ee.tenman.portfolio.domain.Platform
+import java.math.BigDecimal
+
+data class InstrumentSnapshot(
+  val instrument: Instrument,
+  val totalInvestment: BigDecimal = BigDecimal.ZERO,
+  val currentValue: BigDecimal = BigDecimal.ZERO,
+  val profit: BigDecimal = BigDecimal.ZERO,
+  val realizedProfit: BigDecimal = BigDecimal.ZERO,
+  val unrealizedProfit: BigDecimal = BigDecimal.ZERO,
+  val xirr: Double = 0.0,
+  val quantity: BigDecimal = BigDecimal.ZERO,
+  val platforms: Set<Platform> = emptySet(),
+  val priceChangeAmount: BigDecimal? = null,
+  val priceChangePercent: Double? = null,
+)

--- a/src/test/kotlin/ee/tenman/portfolio/scheduler/FtDataRetrievalJobConcurrencyTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/scheduler/FtDataRetrievalJobConcurrencyTest.kt
@@ -47,7 +47,7 @@ class FtDataRetrievalJobConcurrencyTest {
   fun `should prevent concurrent execution`() {
     val instrument = createTestInstrument()
 
-    every { instrumentService.getAllInstruments() } returns listOf(instrument)
+    every { instrumentService.getAllInstrumentsWithoutFiltering() } returns listOf(instrument)
     every { historicalPricesService.fetchPrices(any()) } answers {
       Thread.sleep(100)
       emptyMap()
@@ -82,20 +82,20 @@ class FtDataRetrievalJobConcurrencyTest {
   fun `should allow execution after previous execution completes`() {
     val instrument = createTestInstrument()
 
-    every { instrumentService.getAllInstruments() } returns listOf(instrument)
+    every { instrumentService.getAllInstrumentsWithoutFiltering() } returns listOf(instrument)
     every { historicalPricesService.fetchPrices(any()) } returns emptyMap()
 
     job.execute()
     job.execute()
 
-    verify(exactly = 2) { instrumentService.getAllInstruments() }
+    verify(exactly = 2) { instrumentService.getAllInstrumentsWithoutFiltering() }
   }
 
   @Test
   fun `should release lock even when exception occurs`() {
     val instrument = createTestInstrument()
 
-    every { instrumentService.getAllInstruments() } returns listOf(instrument)
+    every { instrumentService.getAllInstrumentsWithoutFiltering() } returns listOf(instrument)
     every { historicalPricesService.fetchPrices(any()) } throws RuntimeException("Test error")
     every { dataProcessingUtil.processDailyData(any(), any(), any()) } returns Unit
 
@@ -103,16 +103,16 @@ class FtDataRetrievalJobConcurrencyTest {
 
     job.execute()
 
-    verify(exactly = 2) { instrumentService.getAllInstruments() }
+    verify(exactly = 2) { instrumentService.getAllInstrumentsWithoutFiltering() }
   }
 
   @Test
   fun `should handle empty instruments list`() {
-    every { instrumentService.getAllInstruments() } returns emptyList()
+    every { instrumentService.getAllInstrumentsWithoutFiltering() } returns emptyList()
 
     job.execute()
 
-    verify(exactly = 1) { instrumentService.getAllInstruments() }
+    verify(exactly = 1) { instrumentService.getAllInstrumentsWithoutFiltering() }
     verify(exactly = 0) { historicalPricesService.fetchPrices(any()) }
   }
 

--- a/src/test/kotlin/ee/tenman/portfolio/service/InstrumentServiceTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/service/InstrumentServiceTest.kt
@@ -147,17 +147,17 @@ class InstrumentServiceTest {
     every { dailyPriceService.getPriceChange(testInstrument, any()) } returns
       PriceChange(BigDecimal("5.00"), 3.5)
 
-    val result = instrumentService.getAllInstruments()
+    val result = instrumentService.getAllInstrumentSnapshots()
 
     expect(result).toHaveSize(1)
-    val instrument = result[0]
-    expect(instrument.totalInvestment).toEqualNumerically(BigDecimal("1000"))
-    expect(instrument.currentValue).toEqualNumerically(BigDecimal("1500"))
-    expect(instrument.profit).toEqualNumerically(BigDecimal("500"))
-    expect(instrument.xirr).toEqual(25.0)
-    expect(instrument.quantity).toEqualNumerically(BigDecimal("10"))
-    expect(instrument.priceChangeAmount).notToEqualNull().toEqualNumerically(BigDecimal("50.00"))
-    expect(instrument.priceChangePercent).toEqual(3.5)
+    val snapshot = result[0]
+    expect(snapshot.totalInvestment).toEqualNumerically(BigDecimal("1000"))
+    expect(snapshot.currentValue).toEqualNumerically(BigDecimal("1500"))
+    expect(snapshot.profit).toEqualNumerically(BigDecimal("500"))
+    expect(snapshot.xirr).toEqual(25.0)
+    expect(snapshot.quantity).toEqualNumerically(BigDecimal("10"))
+    expect(snapshot.priceChangeAmount).notToEqualNull().toEqualNumerically(BigDecimal("50.00"))
+    expect(snapshot.priceChangePercent).toEqual(3.5)
   }
 
   @Test
@@ -198,7 +198,7 @@ class InstrumentServiceTest {
     } returns metrics
     every { dailyPriceService.getPriceChange(testInstrument, any()) } returns null
 
-    val result = instrumentService.getAllInstruments(listOf("lhv"))
+    val result = instrumentService.getAllInstrumentSnapshots(listOf("lhv"))
 
     expect(result).toHaveSize(1)
     expect(result[0].platforms).toContainExactly(Platform.LHV)
@@ -231,7 +231,7 @@ class InstrumentServiceTest {
     } returns metrics
     every { dailyPriceService.getPriceChange(testInstrument, any()) } returns null
 
-    val result = instrumentService.getAllInstruments(listOf("invalid_platform", "lhv"))
+    val result = instrumentService.getAllInstrumentSnapshots(listOf("invalid_platform", "lhv"))
 
     expect(result).toHaveSize(1)
   }
@@ -263,7 +263,7 @@ class InstrumentServiceTest {
     } returns metrics
     every { dailyPriceService.getPriceChange(testInstrument, any()) } returns null
 
-    val result = instrumentService.getAllInstruments(listOf("lhv"))
+    val result = instrumentService.getAllInstrumentSnapshots(listOf("lhv"))
 
     expect(result).toBeEmpty()
   }
@@ -295,7 +295,7 @@ class InstrumentServiceTest {
     } returns metrics
     every { dailyPriceService.getPriceChange(testInstrument, any()) } returns null
 
-    val result = instrumentService.getAllInstruments(listOf("lhv"))
+    val result = instrumentService.getAllInstrumentSnapshots(listOf("lhv"))
 
     expect(result).toHaveSize(1)
     expect(result[0].totalInvestment).toEqualNumerically(BigDecimal("1000"))
@@ -315,20 +315,20 @@ class InstrumentServiceTest {
     every { instrumentRepository.findAll() } returns listOf(testInstrument, anotherInstrument)
     every { portfolioTransactionRepository.findAllWithInstruments() } returns emptyList()
 
-    val result = instrumentService.getAllInstruments(listOf("lhv"))
+    val result = instrumentService.getAllInstrumentSnapshots(listOf("lhv"))
 
     expect(result).toBeEmpty()
   }
 
   @Test
-  fun `should return instrument when no transactions and no platform filter`() {
+  fun `should return instrument snapshot when no transactions and no platform filter`() {
     every { instrumentRepository.findAll() } returns listOf(testInstrument)
     every { portfolioTransactionRepository.findAllWithInstruments() } returns emptyList()
 
-    val result = instrumentService.getAllInstruments()
+    val result = instrumentService.getAllInstrumentSnapshots()
 
     expect(result).toHaveSize(1)
-    expect(result[0]).toEqual(testInstrument)
+    expect(result[0].instrument).toEqual(testInstrument)
   }
 
   @Test
@@ -364,7 +364,7 @@ class InstrumentServiceTest {
     } returns metrics
     every { dailyPriceService.getPriceChange(testInstrument, any()) } returns priceChange
 
-    val result = instrumentService.getAllInstruments()
+    val result = instrumentService.getAllInstrumentSnapshots()
 
     expect(result).toHaveSize(1)
     expect(result[0].priceChangeAmount).notToEqualNull().toEqualNumerically(BigDecimal("50.00"))
@@ -402,7 +402,7 @@ class InstrumentServiceTest {
     } returns metrics
     every { dailyPriceService.getPriceChange(testInstrument, any()) } returns null
 
-    val result = instrumentService.getAllInstruments()
+    val result = instrumentService.getAllInstrumentSnapshots()
 
     expect(result).toHaveSize(1)
     expect(result[0].priceChangeAmount).toEqual(null)
@@ -443,7 +443,7 @@ class InstrumentServiceTest {
       )
     } returns metrics
 
-    val result = instrumentService.getAllInstruments()
+    val result = instrumentService.getAllInstrumentSnapshots()
 
     expect(result).toHaveSize(1)
     expect(result[0].priceChangeAmount).notToEqualNull().toEqualNumerically(BigDecimal("500.00"))
@@ -491,7 +491,7 @@ class InstrumentServiceTest {
       )
     } returns metrics
 
-    val result = instrumentService.getAllInstruments()
+    val result = instrumentService.getAllInstrumentSnapshots()
 
     expect(result).toHaveSize(1)
     val priceChange = result[0].priceChangeAmount
@@ -532,7 +532,7 @@ class InstrumentServiceTest {
       )
     } returns metrics
 
-    val result = instrumentService.getAllInstruments()
+    val result = instrumentService.getAllInstrumentSnapshots()
 
     expect(result).toHaveSize(1)
     val priceChange = result[0].priceChangeAmount
@@ -579,7 +579,7 @@ class InstrumentServiceTest {
     } returns metrics
     every { dailyPriceService.getPriceChange(testInstrument, any()) } returns null
 
-    val result = instrumentService.getAllInstruments()
+    val result = instrumentService.getAllInstrumentSnapshots()
 
     expect(result).toHaveSize(1)
     expect(result[0].platforms.toSet()).toEqual(setOf(Platform.LHV, Platform.LIGHTYEAR))
@@ -623,7 +623,7 @@ class InstrumentServiceTest {
     } returns metrics
     every { dailyPriceService.getPriceChange(testInstrument, any()) } returns null
 
-    val result = instrumentService.getAllInstruments(listOf("lhv", "lightyear"))
+    val result = instrumentService.getAllInstrumentSnapshots(listOf("lhv", "lightyear"))
 
     expect(result).toHaveSize(1)
     expect(result[0].platforms.toSet()).toEqual(setOf(Platform.LHV, Platform.LIGHTYEAR))
@@ -660,7 +660,7 @@ class InstrumentServiceTest {
     } returns metrics
     every { dailyPriceService.getPriceChange(testInstrument, any()) } returns null
 
-    val result = instrumentService.getAllInstruments(listOf("Lhv", "LIGHTYEAR"))
+    val result = instrumentService.getAllInstrumentSnapshots(listOf("Lhv", "LIGHTYEAR"))
 
     expect(result).toHaveSize(1)
   }
@@ -673,7 +673,7 @@ class InstrumentServiceTest {
     every { instrumentRepository.findAll() } returns listOf(testInstrument)
     every { portfolioTransactionRepository.findAllWithInstruments() } returns listOf(transaction)
 
-    val result = instrumentService.getAllInstruments(emptyList())
+    val result = instrumentService.getAllInstrumentSnapshots(emptyList())
 
     expect(result).toBeEmpty()
   }
@@ -690,7 +690,7 @@ class InstrumentServiceTest {
     every { instrumentRepository.findAll() } returns listOf(testInstrument)
     every { portfolioTransactionRepository.findAllWithInstruments() } returns listOf(lhvTransaction)
 
-    val result = instrumentService.getAllInstruments(listOf("LIGHTYEAR"))
+    val result = instrumentService.getAllInstrumentSnapshots(listOf("LIGHTYEAR"))
 
     expect(result).toBeEmpty()
   }
@@ -742,10 +742,10 @@ class InstrumentServiceTest {
     } returns metrics1
     every { dailyPriceService.getPriceChange(testInstrument, any()) } returns null
 
-    val result = instrumentService.getAllInstruments(listOf("lhv"))
+    val result = instrumentService.getAllInstrumentSnapshots(listOf("lhv"))
 
     expect(result).toHaveSize(1)
-    expect(result[0].symbol).toEqual("AAPL")
+    expect(result[0].instrument.symbol).toEqual("AAPL")
   }
 
   @Test
@@ -775,7 +775,7 @@ class InstrumentServiceTest {
     } returns metrics
     every { dailyPriceService.getPriceChange(testInstrument, any()) } returns null
 
-    instrumentService.getAllInstruments()
+    instrumentService.getAllInstrumentSnapshots()
 
     verify {
       investmentMetricsService.calculateInstrumentMetricsWithProfits(

--- a/src/test/kotlin/ee/tenman/portfolio/service/SummaryServiceTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/service/SummaryServiceTest.kt
@@ -93,9 +93,6 @@ class SummaryServiceTest {
         currentPrice = BigDecimal("27.58"),
       ).apply {
         id = 1L
-        currentValue = BigDecimal("21870.94")
-        totalInvestment = BigDecimal("23633.33")
-        profit = BigDecimal("-1762.39")
       }
 
     transaction =


### PR DESCRIPTION
## Summary
- Introduce `InstrumentSnapshot` value object to hold calculated fields (totalInvestment, currentValue, profit, realizedProfit, unrealizedProfit, xirr, quantity, platforms, priceChangeAmount, priceChangePercent) that were previously stored as `@Transient` fields on the `Instrument` JPA entity
- Make `Instrument` a pure JPA entity with only persisted fields, following the persistence ignorance principle
- Update `InstrumentService` to return `List<InstrumentSnapshot>` from `getAllInstrumentSnapshots()` instead of mutating entity fields
- Add `InstrumentDto.fromSnapshot()` factory method for mapping snapshots to DTOs

## Test plan
- [x] All existing tests pass with updated assertions
- [x] InstrumentServiceTest updated to verify snapshot behavior
- [x] FtDataRetrievalJobConcurrencyTest updated to use getAllInstrumentsWithoutFiltering()
- [x] SummaryServiceTest updated to not set removed transient fields
- [x] Full test suite passes (261 tests)

Closes #979