### PR TITLE
Implement fine-grained cache eviction with CacheInvalidationService

### DIFF
--- a/src/main/kotlin/ee/tenman/portfolio/configuration/RedisConfiguration.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/configuration/RedisConfiguration.kt
@@ -21,6 +21,7 @@ class RedisConfiguration {
       RedisCacheConfiguration.defaultCacheConfig().entryTtl(Duration.ofMinutes(1))
     cacheConfigurations[ETF_LOGOS_CACHE] = RedisCacheConfiguration.defaultCacheConfig().entryTtl(Duration.ofDays(7))
     cacheConfigurations[EASTER_HOLIDAYS_CACHE] = RedisCacheConfiguration.defaultCacheConfig().entryTtl(Duration.ofDays(365))
+    cacheConfigurations[ETF_BREAKDOWN_CACHE] = RedisCacheConfiguration.defaultCacheConfig().entryTtl(Duration.ofMinutes(5))
     val defaultConfig = RedisCacheConfiguration.defaultCacheConfig().entryTtl(DEFAULT_TTL)
     return RedisCacheManager
       .builder(connectionFactory)
@@ -35,6 +36,7 @@ class RedisConfiguration {
     const val TRANSACTION_CACHE = "transaction-cache-v2"
     const val ONE_DAY_CACHE: String = "one-day-cache-v2"
     const val ETF_LOGOS_CACHE: String = "etf-logos-v2"
+    const val ETF_BREAKDOWN_CACHE: String = "etf:breakdown"
     const val EASTER_HOLIDAYS_CACHE: String = "easter-holidays"
     private val DEFAULT_TTL: Duration = Duration.ofMinutes(5)
   }

--- a/src/main/kotlin/ee/tenman/portfolio/service/CacheInvalidationService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/service/CacheInvalidationService.kt
@@ -1,0 +1,73 @@
+package ee.tenman.portfolio.service
+
+import ee.tenman.portfolio.configuration.RedisConfiguration.Companion.ETF_BREAKDOWN_CACHE
+import ee.tenman.portfolio.configuration.RedisConfiguration.Companion.INSTRUMENT_CACHE
+import ee.tenman.portfolio.configuration.RedisConfiguration.Companion.ONE_DAY_CACHE
+import ee.tenman.portfolio.configuration.RedisConfiguration.Companion.SUMMARY_CACHE
+import ee.tenman.portfolio.configuration.RedisConfiguration.Companion.TRANSACTION_CACHE
+import org.slf4j.LoggerFactory
+import org.springframework.cache.CacheManager
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.stereotype.Service
+
+@Service
+class CacheInvalidationService(
+  private val cacheManager: CacheManager,
+  private val redisTemplate: StringRedisTemplate,
+) {
+  private val log = LoggerFactory.getLogger(javaClass)
+
+  fun evictInstrumentCaches(
+    instrumentId: Long?,
+    symbol: String?,
+  ) {
+    val cache = cacheManager.getCache(INSTRUMENT_CACHE) ?: return
+    instrumentId?.let { cache.evict(it) }
+    symbol?.let { cache.evict(it) }
+    cache.evict(ALL_INSTRUMENTS_KEY)
+    log.debug("Evicted instrument cache for id={}, symbol={}", instrumentId, symbol)
+  }
+
+  fun evictTransactionCaches() {
+    evictAllCacheKeys(TRANSACTION_CACHE)
+    log.debug("Evicted all transaction caches")
+  }
+
+  fun evictSummaryCaches() {
+    evictAllCacheKeys(SUMMARY_CACHE)
+    log.debug("Evicted all summary caches")
+  }
+
+  fun evictXirrCache() {
+    cacheManager.getCache(ONE_DAY_CACHE)?.evict(XIRR_KEY)
+    log.debug("Evicted XIRR cache")
+  }
+
+  fun evictAllRelatedCaches(
+    instrumentId: Long?,
+    symbol: String?,
+  ) {
+    evictInstrumentCaches(instrumentId, symbol)
+    evictTransactionCaches()
+    evictSummaryCaches()
+    evictXirrCache()
+  }
+
+  fun evictEtfBreakdownCache() {
+    evictAllCacheKeys(ETF_BREAKDOWN_CACHE)
+    log.debug("Evicted ETF breakdown cache")
+  }
+
+  private fun evictAllCacheKeys(cacheName: String) {
+    val keys = redisTemplate.keys("$cacheName::*")
+    if (keys.isNotEmpty()) {
+      redisTemplate.delete(keys)
+      log.debug("Evicted {} keys from cache {}", keys.size, cacheName)
+    }
+  }
+
+  companion object {
+    private const val ALL_INSTRUMENTS_KEY = "allInstruments"
+    private const val XIRR_KEY = "xirr-v3"
+  }
+}

--- a/src/main/kotlin/ee/tenman/portfolio/service/EtfBreakdownService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/service/EtfBreakdownService.kt
@@ -1,5 +1,6 @@
 package ee.tenman.portfolio.service
 
+import ee.tenman.portfolio.configuration.RedisConfiguration.Companion.ETF_BREAKDOWN_CACHE
 import ee.tenman.portfolio.domain.EtfPosition
 import ee.tenman.portfolio.domain.Instrument
 import ee.tenman.portfolio.domain.Platform
@@ -14,7 +15,6 @@ import ee.tenman.portfolio.repository.InstrumentRepository
 import ee.tenman.portfolio.repository.PortfolioTransactionRepository
 import ee.tenman.portfolio.util.LogSanitizerUtil
 import org.slf4j.LoggerFactory
-import org.springframework.cache.annotation.CacheEvict
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
 import java.math.BigDecimal
@@ -26,11 +26,12 @@ class EtfBreakdownService(
   private val etfPositionRepository: EtfPositionRepository,
   private val transactionRepository: PortfolioTransactionRepository,
   private val dailyPriceService: DailyPriceService,
+  private val cacheInvalidationService: CacheInvalidationService,
 ) {
   private val log = LoggerFactory.getLogger(javaClass)
 
   @Cacheable(
-    "etf:breakdown",
+    ETF_BREAKDOWN_CACHE,
     key =
       "T(java.util.Objects).hash(" +
       "#etfSymbols != null && !#etfSymbols.isEmpty() ? new java.util.TreeSet(#etfSymbols).toString() : 'all', " +
@@ -67,9 +68,9 @@ class EtfBreakdownService(
     return parsed.toSet().takeIf { it.isNotEmpty() }
   }
 
-  @CacheEvict("etf:breakdown", allEntries = true)
   fun evictBreakdownCache() {
-    log.info("Evicting ETF breakdown cache")
+    cacheInvalidationService.evictEtfBreakdownCache()
+    log.info("Evicted ETF breakdown cache")
   }
 
   private fun getLightyearEtfs(

--- a/src/main/kotlin/ee/tenman/portfolio/service/InstrumentService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/service/InstrumentService.kt
@@ -1,9 +1,6 @@
 package ee.tenman.portfolio.service
 
 import ee.tenman.portfolio.configuration.RedisConfiguration.Companion.INSTRUMENT_CACHE
-import ee.tenman.portfolio.configuration.RedisConfiguration.Companion.ONE_DAY_CACHE
-import ee.tenman.portfolio.configuration.RedisConfiguration.Companion.SUMMARY_CACHE
-import ee.tenman.portfolio.configuration.RedisConfiguration.Companion.TRANSACTION_CACHE
 import ee.tenman.portfolio.domain.Instrument
 import ee.tenman.portfolio.domain.Platform
 import ee.tenman.portfolio.domain.PortfolioTransaction
@@ -16,9 +13,7 @@ import ee.tenman.portfolio.model.TransactionState
 import ee.tenman.portfolio.repository.InstrumentRepository
 import ee.tenman.portfolio.repository.PortfolioTransactionRepository
 import org.slf4j.LoggerFactory
-import org.springframework.cache.annotation.CacheEvict
 import org.springframework.cache.annotation.Cacheable
-import org.springframework.cache.annotation.Caching
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
@@ -31,6 +26,7 @@ class InstrumentService(
   private val portfolioTransactionRepository: PortfolioTransactionRepository,
   private val investmentMetricsService: InvestmentMetricsService,
   private val dailyPriceService: DailyPriceService,
+  private val cacheInvalidationService: CacheInvalidationService,
   private val clock: Clock,
 ) {
   private val log = LoggerFactory.getLogger(javaClass)
@@ -53,29 +49,10 @@ class InstrumentService(
   }
 
   @Transactional
-  @Caching(
-    evict = [
-      CacheEvict(
-        value = [INSTRUMENT_CACHE],
-        key = "#instrument.id",
-        condition = "#instrument.id != null",
-      ),
-      CacheEvict(value = [INSTRUMENT_CACHE], key = "#instrument.symbol"),
-      CacheEvict(
-        value = [INSTRUMENT_CACHE],
-        key = "'allInstruments'",
-      ),
-      CacheEvict(value = [SUMMARY_CACHE], allEntries = true),
-      CacheEvict(
-        value = [TRANSACTION_CACHE],
-        allEntries = true,
-      ),
-      CacheEvict(value = [ONE_DAY_CACHE], allEntries = true),
-    ],
-  )
   fun saveInstrument(instrument: Instrument): Instrument {
     val saved = instrumentRepository.save(instrument)
     recalculateTransactionProfitsForInstrument(saved.id)
+    cacheInvalidationService.evictAllRelatedCaches(saved.id, saved.symbol)
     return saved
   }
 
@@ -181,16 +158,11 @@ class InstrumentService(
   }
 
   @Transactional
-  @Caching(
-    evict = [
-      CacheEvict(value = [INSTRUMENT_CACHE], key = "#id"),
-      CacheEvict(
-        value = [INSTRUMENT_CACHE],
-        key = "'allInstruments'",
-      ),
-    ],
-  )
-  fun deleteInstrument(id: Long) = instrumentRepository.deleteById(id)
+  fun deleteInstrument(id: Long) {
+    val instrument = instrumentRepository.findById(id).orElse(null)
+    instrumentRepository.deleteById(id)
+    cacheInvalidationService.evictInstrumentCaches(id, instrument?.symbol)
+  }
 
   @Transactional(readOnly = true)
   fun getAllInstrumentsWithoutFiltering(): List<Instrument> = instrumentRepository.findAll()

--- a/src/main/kotlin/ee/tenman/portfolio/service/SummaryCacheService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/service/SummaryCacheService.kt
@@ -3,9 +3,7 @@ package ee.tenman.portfolio.service
 import ee.tenman.portfolio.configuration.RedisConfiguration.Companion.SUMMARY_CACHE
 import ee.tenman.portfolio.domain.PortfolioDailySummary
 import ee.tenman.portfolio.repository.PortfolioDailySummaryRepository
-import org.springframework.cache.annotation.CacheEvict
 import org.springframework.cache.annotation.Cacheable
-import org.springframework.cache.annotation.Caching
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
@@ -17,6 +15,7 @@ import java.time.LocalDate
 @Service
 class SummaryCacheService(
   private val portfolioDailySummaryRepository: PortfolioDailySummaryRepository,
+  private val cacheInvalidationService: CacheInvalidationService,
 ) {
   @Transactional(readOnly = true)
   @Cacheable(value = [SUMMARY_CACHE], key = "'summaries'", unless = "#result.isEmpty()")
@@ -56,11 +55,5 @@ class SummaryCacheService(
   )
   fun findByEntryDate(date: LocalDate): PortfolioDailySummary? = portfolioDailySummaryRepository.findByEntryDate(date)
 
-  @Caching(
-    evict = [
-      CacheEvict(value = [SUMMARY_CACHE], key = "'summaries'"),
-      CacheEvict(value = [SUMMARY_CACHE], allEntries = true),
-    ],
-  )
-  fun evictAllCaches() {}
+  fun evictAllCaches() = cacheInvalidationService.evictSummaryCaches()
 }

--- a/src/test/kotlin/ee/tenman/portfolio/service/CacheInvalidationServiceTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/service/CacheInvalidationServiceTest.kt
@@ -1,0 +1,131 @@
+package ee.tenman.portfolio.service
+
+import ee.tenman.portfolio.configuration.RedisConfiguration.Companion.ETF_BREAKDOWN_CACHE
+import ee.tenman.portfolio.configuration.RedisConfiguration.Companion.INSTRUMENT_CACHE
+import ee.tenman.portfolio.configuration.RedisConfiguration.Companion.ONE_DAY_CACHE
+import ee.tenman.portfolio.configuration.RedisConfiguration.Companion.SUMMARY_CACHE
+import ee.tenman.portfolio.configuration.RedisConfiguration.Companion.TRANSACTION_CACHE
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.cache.Cache
+import org.springframework.cache.CacheManager
+import org.springframework.data.redis.core.StringRedisTemplate
+
+class CacheInvalidationServiceTest {
+  private val cacheManager = mockk<CacheManager>()
+  private val redisTemplate = mockk<StringRedisTemplate>()
+  private val mockCache = mockk<Cache>(relaxed = true)
+
+  private lateinit var cacheInvalidationService: CacheInvalidationService
+
+  @BeforeEach
+  fun setup() {
+    every { cacheManager.getCache(any()) } returns mockCache
+    every { redisTemplate.keys(any()) } returns emptySet()
+    every { redisTemplate.delete(any<Set<String>>()) } returns 0L
+
+    cacheInvalidationService = CacheInvalidationService(cacheManager, redisTemplate)
+  }
+
+  @Test
+  fun `evictInstrumentCaches should evict instrument cache entries`() {
+    cacheInvalidationService.evictInstrumentCaches(1L, "AAPL")
+
+    verify { cacheManager.getCache(INSTRUMENT_CACHE) }
+    verify { mockCache.evict(1L) }
+    verify { mockCache.evict("AAPL") }
+    verify { mockCache.evict("allInstruments") }
+  }
+
+  @Test
+  fun `evictInstrumentCaches should handle null id`() {
+    cacheInvalidationService.evictInstrumentCaches(null, "AAPL")
+
+    verify { mockCache.evict("AAPL") }
+    verify { mockCache.evict("allInstruments") }
+    verify(exactly = 2) { mockCache.evict(any()) }
+  }
+
+  @Test
+  fun `evictInstrumentCaches should handle null symbol`() {
+    cacheInvalidationService.evictInstrumentCaches(1L, null)
+
+    verify { mockCache.evict(1L) }
+    verify { mockCache.evict("allInstruments") }
+    verify(exactly = 2) { mockCache.evict(any()) }
+  }
+
+  @Test
+  fun `evictTransactionCaches should evict transaction cache by pattern`() {
+    every { redisTemplate.keys("$TRANSACTION_CACHE::*") } returns setOf("key1", "key2")
+    every { redisTemplate.delete(setOf("key1", "key2")) } returns 2L
+
+    cacheInvalidationService.evictTransactionCaches()
+
+    verify { redisTemplate.keys("$TRANSACTION_CACHE::*") }
+    verify { redisTemplate.delete(setOf("key1", "key2")) }
+  }
+
+  @Test
+  fun `evictSummaryCaches should evict summary cache by pattern`() {
+    every { redisTemplate.keys("$SUMMARY_CACHE::*") } returns setOf("summary1")
+    every { redisTemplate.delete(setOf("summary1")) } returns 1L
+
+    cacheInvalidationService.evictSummaryCaches()
+
+    verify { redisTemplate.keys("$SUMMARY_CACHE::*") }
+    verify { redisTemplate.delete(setOf("summary1")) }
+  }
+
+  @Test
+  fun `evictXirrCache should evict xirr key from one day cache`() {
+    cacheInvalidationService.evictXirrCache()
+
+    verify { cacheManager.getCache(ONE_DAY_CACHE) }
+    verify { mockCache.evict("xirr-v3") }
+  }
+
+  @Test
+  fun `evictAllRelatedCaches should evict all cache types`() {
+    cacheInvalidationService.evictAllRelatedCaches(1L, "AAPL")
+
+    verify { cacheManager.getCache(INSTRUMENT_CACHE) }
+    verify { redisTemplate.keys("$TRANSACTION_CACHE::*") }
+    verify { redisTemplate.keys("$SUMMARY_CACHE::*") }
+    verify { cacheManager.getCache(ONE_DAY_CACHE) }
+  }
+
+  @Test
+  fun `evictEtfBreakdownCache should evict etf breakdown cache by pattern`() {
+    every { redisTemplate.keys("$ETF_BREAKDOWN_CACHE::*") } returns setOf("etf1", "etf2")
+    every { redisTemplate.delete(setOf("etf1", "etf2")) } returns 2L
+
+    cacheInvalidationService.evictEtfBreakdownCache()
+
+    verify { redisTemplate.keys("$ETF_BREAKDOWN_CACHE::*") }
+    verify { redisTemplate.delete(setOf("etf1", "etf2")) }
+  }
+
+  @Test
+  fun `evictTransactionCaches should not delete when no keys found`() {
+    every { redisTemplate.keys("$TRANSACTION_CACHE::*") } returns emptySet()
+
+    cacheInvalidationService.evictTransactionCaches()
+
+    verify { redisTemplate.keys("$TRANSACTION_CACHE::*") }
+    verify(exactly = 0) { redisTemplate.delete(any<Set<String>>()) }
+  }
+
+  @Test
+  fun `evictInstrumentCaches should not fail when cache is null`() {
+    every { cacheManager.getCache(INSTRUMENT_CACHE) } returns null
+
+    cacheInvalidationService.evictInstrumentCaches(1L, "AAPL")
+
+    verify { cacheManager.getCache(INSTRUMENT_CACHE) }
+    verify(exactly = 0) { mockCache.evict(any()) }
+  }
+}

--- a/src/test/kotlin/ee/tenman/portfolio/service/EtfBreakdownServiceTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/service/EtfBreakdownServiceTest.kt
@@ -27,6 +27,7 @@ class EtfBreakdownServiceTest {
   private val etfPositionRepository = mockk<EtfPositionRepository>()
   private val transactionRepository = mockk<PortfolioTransactionRepository>()
   private val dailyPriceService = mockk<DailyPriceService>()
+  private val cacheInvalidationService = mockk<CacheInvalidationService>(relaxed = true)
   private lateinit var etfBreakdownService: EtfBreakdownService
 
   @BeforeEach
@@ -37,6 +38,7 @@ class EtfBreakdownServiceTest {
         etfPositionRepository,
         transactionRepository,
         dailyPriceService,
+        cacheInvalidationService,
       )
   }
 


### PR DESCRIPTION
## Summary
- Create centralized `CacheInvalidationService` for targeted cache eviction
- Replace `allEntries=true` pattern with specific key-based eviction
- Add `ETF_BREAKDOWN_CACHE` constant to `RedisConfiguration` with TTL configuration
- Evict caches after successful database operations, not before
- Update `InstrumentService`, `EtfBreakdownService`, and `PriceRefreshService`

Closes #981

## Test plan
- [x] Unit tests for CacheInvalidationService (10 test cases)
- [x] Existing tests updated and passing
- [x] Cache eviction occurs after successful saves