### PR TITLE
Decompose InstrumentService into focused services

### DIFF
--- a/src/main/kotlin/ee/tenman/portfolio/service/InstrumentService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/service/InstrumentService.kt
@@ -2,159 +2,39 @@ package ee.tenman.portfolio.service
 
 import ee.tenman.portfolio.configuration.RedisConfiguration.Companion.INSTRUMENT_CACHE
 import ee.tenman.portfolio.domain.Instrument
-import ee.tenman.portfolio.domain.Platform
-import ee.tenman.portfolio.domain.PortfolioTransaction
-import ee.tenman.portfolio.domain.PriceChangePeriod
-import ee.tenman.portfolio.dto.InstrumentEnrichmentContext
 import ee.tenman.portfolio.exception.EntityNotFoundException
 import ee.tenman.portfolio.model.InstrumentSnapshot
-import ee.tenman.portfolio.model.PriceChange
-import ee.tenman.portfolio.model.TransactionState
 import ee.tenman.portfolio.repository.InstrumentRepository
-import ee.tenman.portfolio.repository.PortfolioTransactionRepository
-import org.slf4j.LoggerFactory
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.math.BigDecimal
-import java.time.Clock
-import java.time.LocalDate
 
 @Service
 class InstrumentService(
   private val instrumentRepository: InstrumentRepository,
-  private val portfolioTransactionRepository: PortfolioTransactionRepository,
-  private val investmentMetricsService: InvestmentMetricsService,
-  private val dailyPriceService: DailyPriceService,
+  private val transactionProfitService: TransactionProfitService,
+  private val instrumentSnapshotService: InstrumentSnapshotService,
   private val cacheInvalidationService: CacheInvalidationService,
-  private val clock: Clock,
 ) {
-  private val log = LoggerFactory.getLogger(javaClass)
-
   @Transactional(readOnly = true)
   @Cacheable(value = [INSTRUMENT_CACHE], key = "#id")
   fun getInstrumentById(id: Long): Instrument =
-    instrumentRepository
-      .findById(
-        id,
-      ).orElseThrow {
-        ee.tenman.portfolio.exception
-          .EntityNotFoundException("Instrument not found with id: $id")
-      }
+    instrumentRepository.findById(id).orElseThrow {
+      EntityNotFoundException("Instrument not found with id: $id")
+    }
 
   @Transactional(readOnly = true)
-  fun findBySymbol(symbol: String): Instrument? =
+  fun findBySymbol(symbol: String): Instrument =
     instrumentRepository.findBySymbol(symbol).orElseThrow {
-    EntityNotFoundException("Instrument not found with symbol: $symbol")
-  }
+      EntityNotFoundException("Instrument not found with symbol: $symbol")
+    }
 
   @Transactional
   fun saveInstrument(instrument: Instrument): Instrument {
     val saved = instrumentRepository.save(instrument)
-    recalculateTransactionProfitsForInstrument(saved.id)
+    transactionProfitService.recalculateProfitsForInstrument(saved.id)
     cacheInvalidationService.evictAllRelatedCaches(saved.id, saved.symbol)
     return saved
-  }
-
-  private fun recalculateTransactionProfitsForInstrument(instrumentId: Long) {
-    val updatedInstrument = instrumentRepository.findById(instrumentId).orElse(null) ?: return
-    val transactions = portfolioTransactionRepository.findAllByInstrumentId(instrumentId)
-
-    if (transactions.isNotEmpty()) {
-      transactions.forEach { it.instrument = updatedInstrument }
-
-      transactions
-        .groupBy { it.platform }
-        .forEach { (_, platformTransactions) ->
-          calculateProfitsForPlatform(platformTransactions.sortedWith(compareBy({ it.transactionDate }, { it.id })))
-        }
-
-      portfolioTransactionRepository.saveAll(transactions)
-    }
-  }
-
-  private fun calculateProfitsForPlatform(transactions: List<PortfolioTransaction>) {
-    val sortedTransactions = transactions.sortedWith(compareBy({ it.transactionDate }, { it.id }))
-    val (totalCost, currentQuantity) = processTransactions(sortedTransactions)
-    val currentPrice = sortedTransactions.firstOrNull()?.instrument?.currentPrice ?: BigDecimal.ZERO
-    val averageCost = calculateAverageCost(totalCost, currentQuantity)
-    val totalUnrealizedProfit = calculateUnrealizedProfit(currentQuantity, currentPrice, averageCost)
-    val buyTransactions = sortedTransactions.filter { it.transactionType == ee.tenman.portfolio.domain.TransactionType.BUY }
-    distributeProfitsToBuyTransactions(buyTransactions, currentQuantity, averageCost, totalUnrealizedProfit)
-  }
-
-  private fun processTransactions(transactions: List<PortfolioTransaction>): TransactionState =
-    transactions.fold(TransactionState(BigDecimal.ZERO, BigDecimal.ZERO)) { state, transaction ->
-      when (transaction.transactionType) {
-        ee.tenman.portfolio.domain.TransactionType.BUY -> processBuyTransaction(transaction, state)
-        ee.tenman.portfolio.domain.TransactionType.SELL -> processSellTransaction(transaction, state)
-      }
-    }
-
-  private fun processBuyTransaction(
-    transaction: PortfolioTransaction,
-    state: TransactionState,
-  ): TransactionState {
-    val cost = transaction.price.multiply(transaction.quantity).add(transaction.commission)
-    transaction.realizedProfit = BigDecimal.ZERO
-    return TransactionState(state.totalCost.add(cost), state.currentQuantity.add(transaction.quantity))
-  }
-
-  private fun processSellTransaction(
-    transaction: PortfolioTransaction,
-    state: TransactionState,
-  ): TransactionState {
-    val averageCost = calculateAverageCost(state.totalCost, state.currentQuantity)
-    transaction.averageCost = averageCost
-    transaction.realizedProfit = transaction.quantity.multiply(transaction.price.subtract(averageCost)).subtract(transaction.commission)
-    transaction.unrealizedProfit = BigDecimal.ZERO
-    transaction.remainingQuantity = BigDecimal.ZERO
-    if (state.currentQuantity <= BigDecimal.ZERO) return state
-    val sellRatio = transaction.quantity.divide(state.currentQuantity, 10, java.math.RoundingMode.HALF_UP)
-    return TransactionState(
-      state.totalCost.multiply(BigDecimal.ONE.subtract(sellRatio)),
-      state.currentQuantity.subtract(transaction.quantity),
-    )
-  }
-
-  private fun calculateAverageCost(
-    totalCost: BigDecimal,
-    quantity: BigDecimal,
-  ): BigDecimal = if (quantity > BigDecimal.ZERO) totalCost.divide(quantity, 10, java.math.RoundingMode.HALF_UP) else BigDecimal.ZERO
-
-  private fun calculateUnrealizedProfit(
-    quantity: BigDecimal,
-    price: BigDecimal,
-    avgCost: BigDecimal,
-  ): BigDecimal = if (quantity > BigDecimal.ZERO && price > BigDecimal.ZERO) quantity.multiply(price.subtract(avgCost)) else BigDecimal.ZERO
-
-  private fun distributeProfitsToBuyTransactions(
-    buyTransactions: List<PortfolioTransaction>,
-    currentQuantity: BigDecimal,
-    averageCost: BigDecimal,
-    totalUnrealizedProfit: BigDecimal,
-  ) {
-    if (currentQuantity <= BigDecimal.ZERO) {
-      buyTransactions.forEach {
-        it.remainingQuantity = BigDecimal.ZERO
-        it.unrealizedProfit = BigDecimal.ZERO
-        it.averageCost = it.price
-      }
-      return
-    }
-    val totalBuyQuantity = buyTransactions.sumOf { it.quantity }
-    buyTransactions.forEach { buyTx ->
-      val proportionalQuantity =
-        buyTx.quantity
-        .multiply(currentQuantity)
-        .divide(totalBuyQuantity, 10, java.math.RoundingMode.HALF_UP)
-      buyTx.remainingQuantity = proportionalQuantity
-      buyTx.averageCost = averageCost
-      buyTx.unrealizedProfit =
-        totalUnrealizedProfit
-        .multiply(proportionalQuantity)
-        .divide(currentQuantity, 10, java.math.RoundingMode.HALF_UP)
-    }
   }
 
   @Transactional
@@ -168,140 +48,14 @@ class InstrumentService(
   fun getAllInstrumentsWithoutFiltering(): List<Instrument> = instrumentRepository.findAll()
 
   @Transactional(readOnly = true)
-  fun getAllInstrumentSnapshots(): List<InstrumentSnapshot> = getAllInstrumentSnapshots(null, null)
+  fun getAllInstrumentSnapshots(): List<InstrumentSnapshot> = instrumentSnapshotService.getAllSnapshots()
 
   @Transactional(readOnly = true)
-  fun getAllInstrumentSnapshots(platforms: List<String>?): List<InstrumentSnapshot> = getAllInstrumentSnapshots(platforms, null)
+  fun getAllInstrumentSnapshots(platforms: List<String>?): List<InstrumentSnapshot> = instrumentSnapshotService.getAllSnapshots(platforms)
 
   @Transactional(readOnly = true)
   fun getAllInstrumentSnapshots(
     platforms: List<String>?,
     period: String?,
-  ): List<InstrumentSnapshot> {
-    val instruments = getAllInstrumentsWithoutFiltering().toList()
-    val transactionsByInstrument = portfolioTransactionRepository.findAllWithInstruments().groupBy { it.instrument.id }
-    val context =
-      InstrumentEnrichmentContext(
-        calculationDate = LocalDate.now(clock),
-        priceChangePeriod = period?.let { PriceChangePeriod.fromString(it) } ?: PriceChangePeriod.P24H,
-        targetPlatforms = parsePlatformFilters(platforms),
-      )
-
-    return instruments.mapNotNull { instrument ->
-      enrichInstrumentWithMetrics(instrument, transactionsByInstrument, context)
-    }
-  }
-
-  private fun parsePlatformFilters(platforms: List<String>?): Set<Platform>? =
-    platforms
-      ?.mapNotNull { platformStr ->
-      runCatching { Platform.valueOf(platformStr.uppercase()) }
-        .onFailure { log.debug("Invalid platform filter: {}", platformStr, it) }
-        .getOrNull()
-    }?.toSet()
-
-  private fun enrichInstrumentWithMetrics(
-    instrument: Instrument,
-    transactionsByInstrument: Map<Long, List<PortfolioTransaction>>,
-    context: InstrumentEnrichmentContext,
-  ): InstrumentSnapshot? {
-    val allTransactions = transactionsByInstrument[instrument.id] ?: emptyList()
-    val filteredTransactions = filterTransactionsByPlatforms(allTransactions, context.targetPlatforms)
-
-    if (!shouldIncludeInstrument(filteredTransactions)) {
-      return if (context.targetPlatforms == null) InstrumentSnapshot(instrument) else null
-    }
-
-    return createInstrumentSnapshot(instrument, filteredTransactions, context)
-  }
-
-  private fun filterTransactionsByPlatforms(
-    transactions: List<PortfolioTransaction>,
-    targetPlatforms: Set<Platform>?,
-  ): List<PortfolioTransaction> =
-    if (targetPlatforms != null) {
-      transactions.filter { targetPlatforms.contains(it.platform) }
-    } else {
-      transactions
-    }
-
-  private fun shouldIncludeInstrument(filteredTransactions: List<PortfolioTransaction>): Boolean = filteredTransactions.isNotEmpty()
-
-  private fun createInstrumentSnapshot(
-    instrument: Instrument,
-    transactions: List<PortfolioTransaction>,
-    context: InstrumentEnrichmentContext,
-  ): InstrumentSnapshot? {
-    val metrics =
-      investmentMetricsService.calculateInstrumentMetricsWithProfits(instrument, transactions, context.calculationDate)
-
-    val priceChange = calculatePriceChange(instrument, transactions, context)
-
-    return if (metrics.quantity == BigDecimal.ZERO && metrics.totalInvestment == BigDecimal.ZERO) {
-      null
-    } else {
-      InstrumentSnapshot(
-        instrument = instrument,
-        totalInvestment = metrics.totalInvestment,
-        currentValue = metrics.currentValue,
-        profit = metrics.profit,
-        realizedProfit = metrics.realizedProfit,
-        unrealizedProfit = metrics.unrealizedProfit ?: BigDecimal.ZERO,
-        xirr = metrics.xirr,
-        quantity = metrics.quantity,
-        platforms = transactions.map { it.platform }.toSet(),
-        priceChangeAmount = priceChange?.changeAmount?.multiply(metrics.quantity),
-        priceChangePercent = priceChange?.changePercent,
-      )
-    }
-  }
-
-  private fun calculatePriceChange(
-    instrument: Instrument,
-    transactions: List<PortfolioTransaction>,
-    context: InstrumentEnrichmentContext,
-  ): PriceChange? {
-    if (transactions.isEmpty()) return null
-
-    val earliestTransaction = transactions.minByOrNull { it.transactionDate } ?: return null
-    val holdingPeriodDays =
-      java.time.temporal.ChronoUnit.DAYS
-        .between(earliestTransaction.transactionDate, context.calculationDate)
-
-    return if (holdingPeriodDays >= context.priceChangePeriod.days) {
-      dailyPriceService.getPriceChange(instrument, context.priceChangePeriod)
-    } else {
-      calculatePriceChangeSincePurchase(instrument, transactions)
-    }
-  }
-
-  private fun calculatePriceChangeSincePurchase(
-    instrument: Instrument,
-    transactions: List<PortfolioTransaction>,
-  ): PriceChange? {
-    val currentPrice = instrument.currentPrice ?: return null
-
-    val buyTransactions = transactions.filter { it.transactionType == ee.tenman.portfolio.domain.TransactionType.BUY }
-    if (buyTransactions.isEmpty()) return null
-
-    val totalQuantity = buyTransactions.sumOf { it.quantity }
-    if (totalQuantity <= BigDecimal.ZERO) return null
-
-    val totalCost =
-      buyTransactions.sumOf { transaction ->
-        transaction.price.multiply(transaction.quantity).add(transaction.commission)
-      }
-
-    val weightedAveragePurchasePrice =
-      totalCost.divide(totalQuantity, 10, java.math.RoundingMode.HALF_UP)
-
-    val changeAmount = currentPrice.subtract(weightedAveragePurchasePrice)
-    val changePercent =
-      changeAmount
-        .divide(weightedAveragePurchasePrice, 10, java.math.RoundingMode.HALF_UP)
-        .multiply(BigDecimal(100))
-        .toDouble()
-
-    return PriceChange(changeAmount, changePercent)
-  }
+  ): List<InstrumentSnapshot> = instrumentSnapshotService.getAllSnapshots(platforms, period)
 }

--- a/src/main/kotlin/ee/tenman/portfolio/service/InstrumentSnapshotService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/service/InstrumentSnapshotService.kt
@@ -1,0 +1,148 @@
+package ee.tenman.portfolio.service
+
+import ee.tenman.portfolio.domain.Instrument
+import ee.tenman.portfolio.domain.Platform
+import ee.tenman.portfolio.domain.PortfolioTransaction
+import ee.tenman.portfolio.domain.PriceChangePeriod
+import ee.tenman.portfolio.domain.TransactionType
+import ee.tenman.portfolio.dto.InstrumentEnrichmentContext
+import ee.tenman.portfolio.model.InstrumentSnapshot
+import ee.tenman.portfolio.model.PriceChange
+import ee.tenman.portfolio.repository.InstrumentRepository
+import ee.tenman.portfolio.repository.PortfolioTransactionRepository
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+import java.math.RoundingMode
+import java.time.Clock
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit
+
+@Service
+class InstrumentSnapshotService(
+  private val instrumentRepository: InstrumentRepository,
+  private val portfolioTransactionRepository: PortfolioTransactionRepository,
+  private val investmentMetricsService: InvestmentMetricsService,
+  private val dailyPriceService: DailyPriceService,
+  private val clock: Clock,
+) {
+  private val log = LoggerFactory.getLogger(javaClass)
+
+  @Transactional(readOnly = true)
+  fun getAllSnapshots(): List<InstrumentSnapshot> = getAllSnapshots(null, null)
+
+  @Transactional(readOnly = true)
+  fun getAllSnapshots(platforms: List<String>?): List<InstrumentSnapshot> = getAllSnapshots(platforms, null)
+
+  @Transactional(readOnly = true)
+  fun getAllSnapshots(
+    platforms: List<String>?,
+    period: String?,
+  ): List<InstrumentSnapshot> {
+    val instruments = instrumentRepository.findAll()
+    val transactionsByInstrument = portfolioTransactionRepository.findAllWithInstruments().groupBy { it.instrument.id }
+    val context =
+      InstrumentEnrichmentContext(
+        calculationDate = LocalDate.now(clock),
+        priceChangePeriod = period?.let { PriceChangePeriod.fromString(it) } ?: PriceChangePeriod.P24H,
+        targetPlatforms = parsePlatformFilters(platforms),
+      )
+    return instruments.mapNotNull { instrument ->
+      enrichInstrumentWithMetrics(instrument, transactionsByInstrument, context)
+    }
+  }
+
+  private fun parsePlatformFilters(platforms: List<String>?): Set<Platform>? =
+    platforms
+      ?.mapNotNull { platformStr ->
+        runCatching { Platform.valueOf(platformStr.uppercase()) }
+          .onFailure { log.debug("Invalid platform filter: {}", platformStr, it) }
+          .getOrNull()
+      }?.toSet()
+
+  private fun enrichInstrumentWithMetrics(
+    instrument: Instrument,
+    transactionsByInstrument: Map<Long, List<PortfolioTransaction>>,
+    context: InstrumentEnrichmentContext,
+  ): InstrumentSnapshot? {
+    val allTransactions = transactionsByInstrument[instrument.id] ?: emptyList()
+    val filteredTransactions = filterTransactionsByPlatforms(allTransactions, context.targetPlatforms)
+    if (filteredTransactions.isEmpty()) {
+      return if (context.targetPlatforms == null) InstrumentSnapshot(instrument) else null
+    }
+    return createInstrumentSnapshot(instrument, filteredTransactions, context)
+  }
+
+  private fun filterTransactionsByPlatforms(
+    transactions: List<PortfolioTransaction>,
+    targetPlatforms: Set<Platform>?,
+  ): List<PortfolioTransaction> =
+    if (targetPlatforms != null) {
+      transactions.filter { targetPlatforms.contains(it.platform) }
+    } else {
+      transactions
+    }
+
+  private fun createInstrumentSnapshot(
+    instrument: Instrument,
+    transactions: List<PortfolioTransaction>,
+    context: InstrumentEnrichmentContext,
+  ): InstrumentSnapshot? {
+    val metrics =
+      investmentMetricsService.calculateInstrumentMetricsWithProfits(instrument, transactions, context.calculationDate)
+    val priceChange = calculatePriceChange(instrument, transactions, context)
+    if (metrics.quantity.compareTo(BigDecimal.ZERO) == 0 && metrics.totalInvestment.compareTo(BigDecimal.ZERO) == 0) return null
+    return InstrumentSnapshot(
+      instrument = instrument,
+      totalInvestment = metrics.totalInvestment,
+      currentValue = metrics.currentValue,
+      profit = metrics.profit,
+      realizedProfit = metrics.realizedProfit,
+      unrealizedProfit = metrics.unrealizedProfit ?: BigDecimal.ZERO,
+      xirr = metrics.xirr,
+      quantity = metrics.quantity,
+      platforms = transactions.map { it.platform }.toSet(),
+      priceChangeAmount = priceChange?.changeAmount?.multiply(metrics.quantity),
+      priceChangePercent = priceChange?.changePercent,
+    )
+  }
+
+  private fun calculatePriceChange(
+    instrument: Instrument,
+    transactions: List<PortfolioTransaction>,
+    context: InstrumentEnrichmentContext,
+  ): PriceChange? {
+    if (transactions.isEmpty()) return null
+    val earliestTransaction = transactions.minBy { it.transactionDate }
+    val holdingPeriodDays = ChronoUnit.DAYS.between(earliestTransaction.transactionDate, context.calculationDate)
+    return if (holdingPeriodDays >= context.priceChangePeriod.days) {
+      dailyPriceService.getPriceChange(instrument, context.priceChangePeriod)
+    } else {
+      calculatePriceChangeSincePurchase(instrument, transactions)
+    }
+  }
+
+  private fun calculatePriceChangeSincePurchase(
+    instrument: Instrument,
+    transactions: List<PortfolioTransaction>,
+  ): PriceChange? {
+    val currentPrice = instrument.currentPrice ?: return null
+    val buyTransactions = transactions.filter { it.transactionType == TransactionType.BUY }
+    if (buyTransactions.isEmpty()) return null
+    val totalQuantity = buyTransactions.sumOf { it.quantity }
+    if (totalQuantity.compareTo(BigDecimal.ZERO) <= 0) return null
+    val totalCost =
+      buyTransactions.sumOf { transaction ->
+        transaction.price.multiply(transaction.quantity).add(transaction.commission)
+      }
+    val weightedAveragePurchasePrice = totalCost.divide(totalQuantity, 10, RoundingMode.HALF_UP)
+    val changeAmount = currentPrice.subtract(weightedAveragePurchasePrice)
+    val changePercent =
+      changeAmount
+        .divide(weightedAveragePurchasePrice, 10, RoundingMode.HALF_UP)
+        .multiply(BigDecimal(100))
+        .toDouble()
+    return PriceChange(changeAmount, changePercent)
+  }
+}

--- a/src/main/kotlin/ee/tenman/portfolio/service/Trading212PriceUpdateService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/service/Trading212PriceUpdateService.kt
@@ -26,32 +26,26 @@ class Trading212PriceUpdateService(
   ): ProcessResult =
     try {
       val instrument = instrumentService.findBySymbol(symbol)
-      if (instrument != null) {
-        instrument.currentPrice = price
-        instrumentService.saveInstrument(instrument)
-        log.debug("Updated current price for {}: {}", symbol, price)
-
-        if (!isWeekend) {
-          val dailyPrice =
-            DailyPrice(
-              instrument = instrument,
-              entryDate = today,
-              providerName = ProviderName.TRADING212,
-              openPrice = price,
-              highPrice = price,
-              lowPrice = price,
-              closePrice = price,
-              volume = null,
-            )
-          dailyPriceService.saveDailyPrice(dailyPrice)
-          log.debug("Saved Trading212 daily price for {}: {}", symbol, price)
-          ProcessResult.SUCCESS_WITH_DAILY_PRICE
-        } else {
-          ProcessResult.SUCCESS_WITHOUT_DAILY_PRICE
-        }
+      instrument.currentPrice = price
+      instrumentService.saveInstrument(instrument)
+      log.debug("Updated current price for {}: {}", symbol, price)
+      if (isWeekend) {
+        ProcessResult.SUCCESS_WITHOUT_DAILY_PRICE
       } else {
-        log.warn("Instrument not found for symbol: $symbol")
-        ProcessResult.FAILED
+        val dailyPrice =
+          DailyPrice(
+            instrument = instrument,
+            entryDate = today,
+            providerName = ProviderName.TRADING212,
+            openPrice = price,
+            highPrice = price,
+            lowPrice = price,
+            closePrice = price,
+            volume = null,
+          )
+        dailyPriceService.saveDailyPrice(dailyPrice)
+        log.debug("Saved Trading212 daily price for {}: {}", symbol, price)
+        ProcessResult.SUCCESS_WITH_DAILY_PRICE
       }
     } catch (e: Exception) {
       log.warn("Failed to update price for symbol $symbol: ${e.message}")

--- a/src/main/kotlin/ee/tenman/portfolio/service/TransactionProfitService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/service/TransactionProfitService.kt
@@ -1,0 +1,129 @@
+package ee.tenman.portfolio.service
+
+import ee.tenman.portfolio.domain.PortfolioTransaction
+import ee.tenman.portfolio.domain.TransactionType
+import ee.tenman.portfolio.model.TransactionState
+import ee.tenman.portfolio.repository.InstrumentRepository
+import ee.tenman.portfolio.repository.PortfolioTransactionRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+import java.math.RoundingMode
+
+@Service
+class TransactionProfitService(
+  private val instrumentRepository: InstrumentRepository,
+  private val portfolioTransactionRepository: PortfolioTransactionRepository,
+) {
+  @Transactional
+  fun recalculateProfitsForInstrument(instrumentId: Long) {
+    val instrument = instrumentRepository.findById(instrumentId).orElse(null) ?: return
+    val transactions = portfolioTransactionRepository.findAllByInstrumentId(instrumentId)
+    if (transactions.isEmpty()) return
+    transactions.forEach { it.instrument = instrument }
+    transactions
+      .groupBy { it.platform }
+      .forEach { (_, platformTransactions) ->
+        calculateProfitsForPlatform(platformTransactions.sortedWith(compareBy({ it.transactionDate }, { it.id })))
+      }
+    portfolioTransactionRepository.saveAll(transactions)
+  }
+
+  private fun calculateProfitsForPlatform(transactions: List<PortfolioTransaction>) {
+    val (totalCost, currentQuantity) = processTransactions(transactions)
+    val currentPrice = transactions.firstOrNull()?.instrument?.currentPrice ?: BigDecimal.ZERO
+    val averageCost = calculateAverageCost(totalCost, currentQuantity)
+    val totalUnrealizedProfit = calculateUnrealizedProfit(currentQuantity, currentPrice, averageCost)
+    val buyTransactions = transactions.filter { it.transactionType == TransactionType.BUY }
+    distributeProfitsToBuyTransactions(buyTransactions, currentQuantity, averageCost, totalUnrealizedProfit)
+  }
+
+  private fun processTransactions(transactions: List<PortfolioTransaction>): TransactionState =
+    transactions.fold(TransactionState(BigDecimal.ZERO, BigDecimal.ZERO)) { state, transaction ->
+      when (transaction.transactionType) {
+        TransactionType.BUY -> processBuyTransaction(transaction, state)
+        TransactionType.SELL -> processSellTransaction(transaction, state)
+      }
+    }
+
+  private fun processBuyTransaction(
+    transaction: PortfolioTransaction,
+    state: TransactionState,
+  ): TransactionState {
+    val cost = transaction.price.multiply(transaction.quantity).add(transaction.commission)
+    transaction.realizedProfit = BigDecimal.ZERO
+    return TransactionState(state.totalCost.add(cost), state.currentQuantity.add(transaction.quantity))
+  }
+
+  private fun processSellTransaction(
+    transaction: PortfolioTransaction,
+    state: TransactionState,
+  ): TransactionState {
+    if (state.currentQuantity.compareTo(BigDecimal.ZERO) <= 0) {
+      transaction.averageCost = BigDecimal.ZERO
+      transaction.realizedProfit = BigDecimal.ZERO
+      transaction.unrealizedProfit = BigDecimal.ZERO
+      transaction.remainingQuantity = BigDecimal.ZERO
+      return state
+    }
+    val actualSellQuantity = transaction.quantity.min(state.currentQuantity)
+    val averageCost = calculateAverageCost(state.totalCost, state.currentQuantity)
+    transaction.averageCost = averageCost
+    transaction.realizedProfit = actualSellQuantity.multiply(transaction.price.subtract(averageCost)).subtract(transaction.commission)
+    transaction.unrealizedProfit = BigDecimal.ZERO
+    transaction.remainingQuantity = BigDecimal.ZERO
+    val sellRatio = actualSellQuantity.divide(state.currentQuantity, 10, RoundingMode.HALF_UP)
+    return TransactionState(
+      state.totalCost.multiply(BigDecimal.ONE.subtract(sellRatio)),
+      state.currentQuantity.subtract(actualSellQuantity),
+    )
+  }
+
+  private fun calculateAverageCost(
+    totalCost: BigDecimal,
+    quantity: BigDecimal,
+  ): BigDecimal = if (quantity.compareTo(BigDecimal.ZERO) > 0) totalCost.divide(quantity, 10, RoundingMode.HALF_UP) else BigDecimal.ZERO
+
+  private fun calculateUnrealizedProfit(
+    quantity: BigDecimal,
+    price: BigDecimal,
+    avgCost: BigDecimal,
+  ): BigDecimal =
+    if (quantity.compareTo(BigDecimal.ZERO) > 0 &&
+    price.compareTo(BigDecimal.ZERO) > 0
+    ) {
+      quantity.multiply(price.subtract(avgCost))
+    } else {
+      BigDecimal.ZERO
+    }
+
+  private fun distributeProfitsToBuyTransactions(
+    buyTransactions: List<PortfolioTransaction>,
+    currentQuantity: BigDecimal,
+    averageCost: BigDecimal,
+    totalUnrealizedProfit: BigDecimal,
+  ) {
+    if (currentQuantity.compareTo(BigDecimal.ZERO) <= 0) {
+      buyTransactions.forEach {
+        it.remainingQuantity = BigDecimal.ZERO
+        it.unrealizedProfit = BigDecimal.ZERO
+        it.averageCost = it.price
+      }
+      return
+    }
+    val totalBuyQuantity = buyTransactions.sumOf { it.quantity }
+    if (totalBuyQuantity.compareTo(BigDecimal.ZERO) <= 0) return
+    buyTransactions.forEach { buyTx ->
+      val proportionalQuantity =
+        buyTx.quantity
+          .multiply(currentQuantity)
+          .divide(totalBuyQuantity, 10, RoundingMode.HALF_UP)
+      buyTx.remainingQuantity = proportionalQuantity
+      buyTx.averageCost = averageCost
+      buyTx.unrealizedProfit =
+        totalUnrealizedProfit
+          .multiply(proportionalQuantity)
+          .divide(currentQuantity, 10, RoundingMode.HALF_UP)
+    }
+  }
+}

--- a/src/test/kotlin/ee/tenman/portfolio/service/InstrumentServiceTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/service/InstrumentServiceTest.kt
@@ -1,74 +1,48 @@
 package ee.tenman.portfolio.service
 
 import ch.tutteli.atrium.api.fluent.en_GB.messageToContain
-import ch.tutteli.atrium.api.fluent.en_GB.notToEqualNull
-import ch.tutteli.atrium.api.fluent.en_GB.toBeEmpty
-import ch.tutteli.atrium.api.fluent.en_GB.toContainExactly
 import ch.tutteli.atrium.api.fluent.en_GB.toEqual
-import ch.tutteli.atrium.api.fluent.en_GB.toEqualNumerically
-import ch.tutteli.atrium.api.fluent.en_GB.toHaveSize
 import ch.tutteli.atrium.api.fluent.en_GB.toThrow
 import ch.tutteli.atrium.api.verbs.expect
 import ee.tenman.portfolio.domain.Instrument
-import ee.tenman.portfolio.domain.Platform
-import ee.tenman.portfolio.domain.PortfolioTransaction
 import ee.tenman.portfolio.domain.ProviderName
-import ee.tenman.portfolio.domain.TransactionType
-import ee.tenman.portfolio.model.PriceChange
-import ee.tenman.portfolio.model.metrics.InstrumentMetrics
+import ee.tenman.portfolio.model.InstrumentSnapshot
 import ee.tenman.portfolio.repository.InstrumentRepository
-import ee.tenman.portfolio.repository.PortfolioTransactionRepository
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.math.BigDecimal
-import java.time.Clock
-import java.time.Instant
-import java.time.LocalDate
-import java.time.ZoneId
 import java.util.*
 
 class InstrumentServiceTest {
   private val instrumentRepository = mockk<InstrumentRepository>()
-  private val portfolioTransactionRepository = mockk<PortfolioTransactionRepository>()
-  private val investmentMetricsService = mockk<InvestmentMetricsService>()
-  private val dailyPriceService = mockk<DailyPriceService>()
+  private val transactionProfitService = mockk<TransactionProfitService>(relaxed = true)
+  private val instrumentSnapshotService = mockk<InstrumentSnapshotService>()
   private val cacheInvalidationService = mockk<CacheInvalidationService>(relaxed = true)
-  private val clock = mockk<Clock>()
 
   private lateinit var instrumentService: InstrumentService
   private lateinit var testInstrument: Instrument
-  private val testDate = LocalDate.of(2024, 1, 15)
-  private val fixedInstant = Instant.parse("2024-01-15T10:00:00Z")
 
   @BeforeEach
   fun setUp() {
     testInstrument =
       Instrument(
-      symbol = "AAPL",
-      name = "Apple Inc.",
-      category = "Stock",
-      baseCurrency = "USD",
-      currentPrice = BigDecimal("150.00"),
-      providerName = ProviderName.FT,
-    ).apply {
-      id = 1L
-    }
-
-    every { clock.instant() } returns fixedInstant
-    every { clock.zone } returns ZoneId.systemDefault()
-    every { dailyPriceService.getPriceChangeSinceDate(any(), any()) } returns null
+        symbol = "AAPL",
+        name = "Apple Inc.",
+        category = "Stock",
+        baseCurrency = "USD",
+        currentPrice = BigDecimal("150.00"),
+        providerName = ProviderName.FT,
+      ).apply { id = 1L }
 
     instrumentService =
       InstrumentService(
         instrumentRepository,
-        portfolioTransactionRepository,
-        investmentMetricsService,
-        dailyPriceService,
+        transactionProfitService,
+        instrumentSnapshotService,
         cacheInvalidationService,
-        clock,
       )
   }
 
@@ -95,716 +69,100 @@ class InstrumentServiceTest {
   }
 
   @Test
-  fun `should save and return instrument when saving`() {
+  fun `should return instrument when found by symbol`() {
+    every { instrumentRepository.findBySymbol("AAPL") } returns Optional.of(testInstrument)
+
+    val result = instrumentService.findBySymbol("AAPL")
+
+    expect(result).toEqual(testInstrument)
+    verify { instrumentRepository.findBySymbol("AAPL") }
+  }
+
+  @Test
+  fun `should throw exception when instrument not found by symbol`() {
+    every { instrumentRepository.findBySymbol("UNKNOWN") } returns Optional.empty()
+
+    expect {
+      instrumentService.findBySymbol("UNKNOWN")
+    }.toThrow<RuntimeException> {
+      messageToContain("Instrument not found with symbol: UNKNOWN")
+    }
+  }
+
+  @Test
+  fun `should save instrument and recalculate profits`() {
     every { instrumentRepository.save(testInstrument) } returns testInstrument
-    every { instrumentRepository.findById(1L) } returns Optional.of(testInstrument)
-    every { portfolioTransactionRepository.findAllByInstrumentId(1L) } returns emptyList()
 
     val result = instrumentService.saveInstrument(testInstrument)
 
     expect(result).toEqual(testInstrument)
     verify { instrumentRepository.save(testInstrument) }
+    verify { transactionProfitService.recalculateProfitsForInstrument(1L) }
+    verify { cacheInvalidationService.evictAllRelatedCaches(1L, "AAPL") }
   }
 
   @Test
-  fun `should call repository delete when deleting instrument`() {
+  fun `should delete instrument and evict cache`() {
     every { instrumentRepository.findById(1L) } returns Optional.of(testInstrument)
     every { instrumentRepository.deleteById(1L) } returns Unit
 
     instrumentService.deleteInstrument(1L)
 
-    verify { cacheInvalidationService.evictInstrumentCaches(1L, "AAPL") }
     verify { instrumentRepository.deleteById(1L) }
+    verify { cacheInvalidationService.evictInstrumentCaches(1L, "AAPL") }
   }
 
   @Test
-  fun `should return all instruments with metrics when no platform filter specified`() {
-    val transactions =
-      listOf(
-        createBuyTransaction(
-          quantity = BigDecimal("10"),
-          price = BigDecimal("100"),
-          date = testDate.minusDays(2),
-        ),
-      )
+  fun `should delete instrument when not found and evict cache with null symbol`() {
+    every { instrumentRepository.findById(999L) } returns Optional.empty()
+    every { instrumentRepository.deleteById(999L) } returns Unit
 
-    val metrics =
-      InstrumentMetrics(
-        totalInvestment = BigDecimal("1000"),
-        currentValue = BigDecimal("1500"),
-        profit = BigDecimal("500"),
-        realizedProfit = BigDecimal.ZERO,
-        unrealizedProfit = BigDecimal("500"),
-        xirr = 25.0,
-        quantity = BigDecimal("10"),
-      )
+    instrumentService.deleteInstrument(999L)
 
+    verify { instrumentRepository.deleteById(999L) }
+    verify { cacheInvalidationService.evictInstrumentCaches(999L, null) }
+  }
+
+  @Test
+  fun `should return all instruments without filtering`() {
     every { instrumentRepository.findAll() } returns listOf(testInstrument)
-    every { portfolioTransactionRepository.findAllWithInstruments() } returns transactions
-    every {
-      investmentMetricsService.calculateInstrumentMetricsWithProfits(
-        testInstrument,
-        any(),
-        any(),
-      )
-    } returns metrics
-    every { dailyPriceService.getPriceChange(testInstrument, any()) } returns
-      PriceChange(BigDecimal("5.00"), 3.5)
+
+    val result = instrumentService.getAllInstrumentsWithoutFiltering()
+
+    expect(result).toEqual(listOf(testInstrument))
+    verify { instrumentRepository.findAll() }
+  }
+
+  @Test
+  fun `should delegate to snapshot service for getAllInstrumentSnapshots`() {
+    val snapshot = InstrumentSnapshot(testInstrument)
+    every { instrumentSnapshotService.getAllSnapshots() } returns listOf(snapshot)
 
     val result = instrumentService.getAllInstrumentSnapshots()
 
-    expect(result).toHaveSize(1)
-    val snapshot = result[0]
-    expect(snapshot.totalInvestment).toEqualNumerically(BigDecimal("1000"))
-    expect(snapshot.currentValue).toEqualNumerically(BigDecimal("1500"))
-    expect(snapshot.profit).toEqualNumerically(BigDecimal("500"))
-    expect(snapshot.xirr).toEqual(25.0)
-    expect(snapshot.quantity).toEqualNumerically(BigDecimal("10"))
-    expect(snapshot.priceChangeAmount).notToEqualNull().toEqualNumerically(BigDecimal("50.00"))
-    expect(snapshot.priceChangePercent).toEqual(3.5)
+    expect(result).toEqual(listOf(snapshot))
+    verify { instrumentSnapshotService.getAllSnapshots() }
   }
 
   @Test
-  fun `should return only matching instruments when platform filter specified`() {
-    val lhvTransaction =
-      createBuyTransaction(
-        quantity = BigDecimal("10"),
-        price = BigDecimal("100"),
-        platform = Platform.LHV,
-      )
-    val lightyearTransaction =
-      createBuyTransaction(
-        quantity = BigDecimal("5"),
-        price = BigDecimal("100"),
-        platform = Platform.LIGHTYEAR,
-      )
+  fun `should delegate to snapshot service for getAllInstrumentSnapshots with platforms`() {
+    val snapshot = InstrumentSnapshot(testInstrument)
+    every { instrumentSnapshotService.getAllSnapshots(listOf("LHV")) } returns listOf(snapshot)
 
-    val metrics =
-      InstrumentMetrics(
-        totalInvestment = BigDecimal("1000"),
-        currentValue = BigDecimal("1500"),
-        profit = BigDecimal("500"),
-        realizedProfit = BigDecimal.ZERO,
-        unrealizedProfit = BigDecimal("500"),
-        xirr = 25.0,
-        quantity = BigDecimal("10"),
-      )
+    val result = instrumentService.getAllInstrumentSnapshots(listOf("LHV"))
 
-    every { instrumentRepository.findAll() } returns listOf(testInstrument)
-    every { portfolioTransactionRepository.findAllWithInstruments() } returns
-      listOf(lhvTransaction, lightyearTransaction)
-    every {
-      investmentMetricsService.calculateInstrumentMetricsWithProfits(
-        testInstrument,
-        listOf(lhvTransaction),
-        any(),
-      )
-    } returns metrics
-    every { dailyPriceService.getPriceChange(testInstrument, any()) } returns null
-
-    val result = instrumentService.getAllInstrumentSnapshots(listOf("lhv"))
-
-    expect(result).toHaveSize(1)
-    expect(result[0].platforms).toContainExactly(Platform.LHV)
+    expect(result).toEqual(listOf(snapshot))
+    verify { instrumentSnapshotService.getAllSnapshots(listOf("LHV")) }
   }
 
   @Test
-  fun `should ignore invalid platforms when platform filter contains invalid values`() {
-    val transaction =
-      createBuyTransaction(quantity = BigDecimal("10"), price = BigDecimal("100"))
+  fun `should delegate to snapshot service for getAllInstrumentSnapshots with platforms and period`() {
+    val snapshot = InstrumentSnapshot(testInstrument)
+    every { instrumentSnapshotService.getAllSnapshots(listOf("LHV"), "P7D") } returns listOf(snapshot)
 
-    val metrics =
-      InstrumentMetrics(
-        totalInvestment = BigDecimal("1000"),
-        currentValue = BigDecimal("1500"),
-        profit = BigDecimal("500"),
-        realizedProfit = BigDecimal.ZERO,
-        unrealizedProfit = BigDecimal("500"),
-        xirr = 25.0,
-        quantity = BigDecimal("10"),
-      )
+    val result = instrumentService.getAllInstrumentSnapshots(listOf("LHV"), "P7D")
 
-    every { instrumentRepository.findAll() } returns listOf(testInstrument)
-    every { portfolioTransactionRepository.findAllWithInstruments() } returns listOf(transaction)
-    every {
-      investmentMetricsService.calculateInstrumentMetricsWithProfits(
-        testInstrument,
-        any(),
-        any(),
-      )
-    } returns metrics
-    every { dailyPriceService.getPriceChange(testInstrument, any()) } returns null
-
-    val result = instrumentService.getAllInstrumentSnapshots(listOf("invalid_platform", "lhv"))
-
-    expect(result).toHaveSize(1)
+    expect(result).toEqual(listOf(snapshot))
+    verify { instrumentSnapshotService.getAllSnapshots(listOf("LHV"), "P7D") }
   }
-
-  @Test
-  fun `should exclude instruments with zero quantity and zero investment when platform filter applied`() {
-    val transaction =
-      createBuyTransaction(quantity = BigDecimal("10"), price = BigDecimal("100"))
-
-    val metrics =
-      InstrumentMetrics(
-        totalInvestment = BigDecimal.ZERO,
-        currentValue = BigDecimal.ZERO,
-        profit = BigDecimal.ZERO,
-        realizedProfit = BigDecimal.ZERO,
-        unrealizedProfit = BigDecimal.ZERO,
-        xirr = 0.0,
-        quantity = BigDecimal.ZERO,
-      )
-
-    every { instrumentRepository.findAll() } returns listOf(testInstrument)
-    every { portfolioTransactionRepository.findAllWithInstruments() } returns listOf(transaction)
-    every {
-      investmentMetricsService.calculateInstrumentMetricsWithProfits(
-        testInstrument,
-        any(),
-        any(),
-      )
-    } returns metrics
-    every { dailyPriceService.getPriceChange(testInstrument, any()) } returns null
-
-    val result = instrumentService.getAllInstrumentSnapshots(listOf("lhv"))
-
-    expect(result).toBeEmpty()
-  }
-
-  @Test
-  fun `should include instruments with zero quantity but positive investment when platform filter applied`() {
-    val transaction =
-      createBuyTransaction(quantity = BigDecimal("10"), price = BigDecimal("100"))
-
-    val metrics =
-      InstrumentMetrics(
-        totalInvestment = BigDecimal("1000"),
-        currentValue = BigDecimal.ZERO,
-        profit = BigDecimal("-1000"),
-        realizedProfit = BigDecimal("-1000"),
-        unrealizedProfit = BigDecimal.ZERO,
-        xirr = -100.0,
-        quantity = BigDecimal.ZERO,
-      )
-
-    every { instrumentRepository.findAll() } returns listOf(testInstrument)
-    every { portfolioTransactionRepository.findAllWithInstruments() } returns listOf(transaction)
-    every {
-      investmentMetricsService.calculateInstrumentMetricsWithProfits(
-        testInstrument,
-        listOf(transaction),
-        any(),
-      )
-    } returns metrics
-    every { dailyPriceService.getPriceChange(testInstrument, any()) } returns null
-
-    val result = instrumentService.getAllInstrumentSnapshots(listOf("lhv"))
-
-    expect(result).toHaveSize(1)
-    expect(result[0].totalInvestment).toEqualNumerically(BigDecimal("1000"))
-  }
-
-  @Test
-  fun `should return empty when no transactions for instrument and platform filter applied`() {
-    val anotherInstrument =
-      Instrument(
-        symbol = "GOOGL",
-        name = "Alphabet Inc.",
-        category = "Stock",
-        baseCurrency = "USD",
-        currentPrice = BigDecimal("2800"),
-      ).apply { id = 2L }
-
-    every { instrumentRepository.findAll() } returns listOf(testInstrument, anotherInstrument)
-    every { portfolioTransactionRepository.findAllWithInstruments() } returns emptyList()
-
-    val result = instrumentService.getAllInstrumentSnapshots(listOf("lhv"))
-
-    expect(result).toBeEmpty()
-  }
-
-  @Test
-  fun `should return instrument snapshot when no transactions and no platform filter`() {
-    every { instrumentRepository.findAll() } returns listOf(testInstrument)
-    every { portfolioTransactionRepository.findAllWithInstruments() } returns emptyList()
-
-    val result = instrumentService.getAllInstrumentSnapshots()
-
-    expect(result).toHaveSize(1)
-    expect(result[0].instrument).toEqual(testInstrument)
-  }
-
-  @Test
-  fun `should calculate price change correctly when price change available`() {
-    val transaction =
-      createBuyTransaction(
-        quantity = BigDecimal("10"),
-        price = BigDecimal("100"),
-        date = testDate.minusDays(2),
-      )
-
-    val metrics =
-      InstrumentMetrics(
-        totalInvestment = BigDecimal("1000"),
-        currentValue = BigDecimal("1500"),
-        profit = BigDecimal("500"),
-        realizedProfit = BigDecimal.ZERO,
-        unrealizedProfit = BigDecimal("500"),
-        xirr = 25.0,
-        quantity = BigDecimal("10"),
-      )
-
-    val priceChange = PriceChange(BigDecimal("5.00"), 3.5)
-
-    every { instrumentRepository.findAll() } returns listOf(testInstrument)
-    every { portfolioTransactionRepository.findAllWithInstruments() } returns listOf(transaction)
-    every {
-      investmentMetricsService.calculateInstrumentMetricsWithProfits(
-        testInstrument,
-        any(),
-        any(),
-      )
-    } returns metrics
-    every { dailyPriceService.getPriceChange(testInstrument, any()) } returns priceChange
-
-    val result = instrumentService.getAllInstrumentSnapshots()
-
-    expect(result).toHaveSize(1)
-    expect(result[0].priceChangeAmount).notToEqualNull().toEqualNumerically(BigDecimal("50.00"))
-    expect(result[0].priceChangePercent).toEqual(3.5)
-  }
-
-  @Test
-  fun `should handle null price change when price change not available`() {
-    val transaction =
-      createBuyTransaction(
-        quantity = BigDecimal("10"),
-        price = BigDecimal("100"),
-        date = testDate.minusDays(2),
-      )
-
-    val metrics =
-      InstrumentMetrics(
-        totalInvestment = BigDecimal("1000"),
-        currentValue = BigDecimal("1500"),
-        profit = BigDecimal("500"),
-        realizedProfit = BigDecimal.ZERO,
-        unrealizedProfit = BigDecimal("500"),
-        xirr = 25.0,
-        quantity = BigDecimal("10"),
-      )
-
-    every { instrumentRepository.findAll() } returns listOf(testInstrument)
-    every { portfolioTransactionRepository.findAllWithInstruments() } returns listOf(transaction)
-    every {
-      investmentMetricsService.calculateInstrumentMetricsWithProfits(
-        testInstrument,
-        any(),
-        any(),
-      )
-    } returns metrics
-    every { dailyPriceService.getPriceChange(testInstrument, any()) } returns null
-
-    val result = instrumentService.getAllInstrumentSnapshots()
-
-    expect(result).toHaveSize(1)
-    expect(result[0].priceChangeAmount).toEqual(null)
-    expect(result[0].priceChangePercent).toEqual(null)
-  }
-
-  @Test
-  fun `should show all-time earnings when holding period is insufficient for selected period`() {
-    val transactionDate = testDate
-    val transaction =
-      createBuyTransaction(
-        quantity = BigDecimal("10"),
-        price = BigDecimal("100"),
-        date = transactionDate,
-        commission = BigDecimal("0"),
-      )
-
-    testInstrument.currentPrice = BigDecimal("150")
-
-    val metrics =
-      InstrumentMetrics(
-        totalInvestment = BigDecimal("1000"),
-        currentValue = BigDecimal("1500"),
-        profit = BigDecimal("500"),
-        realizedProfit = BigDecimal.ZERO,
-        unrealizedProfit = BigDecimal("500"),
-        xirr = 25.0,
-        quantity = BigDecimal("10"),
-      )
-
-    every { instrumentRepository.findAll() } returns listOf(testInstrument)
-    every { portfolioTransactionRepository.findAllWithInstruments() } returns listOf(transaction)
-    every {
-      investmentMetricsService.calculateInstrumentMetricsWithProfits(
-        testInstrument,
-        any(),
-        any(),
-      )
-    } returns metrics
-
-    val result = instrumentService.getAllInstrumentSnapshots()
-
-    expect(result).toHaveSize(1)
-    expect(result[0].priceChangeAmount).notToEqualNull().toEqualNumerically(BigDecimal("500.00"))
-    expect(result[0].priceChangePercent).toEqual(50.0)
-  }
-
-  @Test
-  fun `should calculate P24H using weighted average purchase price for same-day purchases`() {
-    val transaction1 =
-      createBuyTransaction(
-        quantity = BigDecimal("100"),
-        price = BigDecimal("14.50"),
-        date = testDate,
-        commission = BigDecimal("1.00"),
-      )
-    val transaction2 =
-      createBuyTransaction(
-        quantity = BigDecimal("50"),
-        price = BigDecimal("14.60"),
-        date = testDate,
-        commission = BigDecimal("0.50"),
-      )
-
-    testInstrument.currentPrice = BigDecimal("14.80")
-
-    val metrics =
-      InstrumentMetrics(
-        totalInvestment = BigDecimal("2181.50"),
-        currentValue = BigDecimal("2220.00"),
-        profit = BigDecimal("38.50"),
-        realizedProfit = BigDecimal.ZERO,
-        unrealizedProfit = BigDecimal("38.50"),
-        xirr = 0.0,
-        quantity = BigDecimal("150"),
-      )
-
-    every { instrumentRepository.findAll() } returns listOf(testInstrument)
-    every { portfolioTransactionRepository.findAllWithInstruments() } returns
-      listOf(transaction1, transaction2)
-    every {
-      investmentMetricsService.calculateInstrumentMetricsWithProfits(
-        testInstrument,
-        any(),
-        any(),
-      )
-    } returns metrics
-
-    val result = instrumentService.getAllInstrumentSnapshots()
-
-    expect(result).toHaveSize(1)
-    val priceChange = result[0].priceChangeAmount
-    expect(priceChange).notToEqualNull()
-    expect(priceChange!!.compareTo(BigDecimal.ZERO)).toEqual(1)
-  }
-
-  @Test
-  fun `should handle multiple same-day purchases with commissions correctly`() {
-    val transaction1 =
-      createBuyTransaction(
-        quantity = BigDecimal("320.85"),
-        price = BigDecimal("14.50"),
-        date = testDate,
-        commission = BigDecimal("0.00"),
-      )
-
-    testInstrument.currentPrice = BigDecimal("14.54")
-
-    val metrics =
-      InstrumentMetrics(
-        totalInvestment = BigDecimal("4652.325"),
-        currentValue = BigDecimal("4665.159"),
-        profit = BigDecimal("12.834"),
-        realizedProfit = BigDecimal.ZERO,
-        unrealizedProfit = BigDecimal("12.834"),
-        xirr = 0.0,
-        quantity = BigDecimal("320.85"),
-      )
-
-    every { instrumentRepository.findAll() } returns listOf(testInstrument)
-    every { portfolioTransactionRepository.findAllWithInstruments() } returns listOf(transaction1)
-    every {
-      investmentMetricsService.calculateInstrumentMetricsWithProfits(
-        testInstrument,
-        any(),
-        any(),
-      )
-    } returns metrics
-
-    val result = instrumentService.getAllInstrumentSnapshots()
-
-    expect(result).toHaveSize(1)
-    val priceChange = result[0].priceChangeAmount
-    expect(priceChange).notToEqualNull()
-    expect(priceChange!!.compareTo(BigDecimal.ZERO)).toEqual(1)
-    expect(result[0].priceChangePercent).notToEqualNull()
-  }
-
-  @Test
-  fun `should aggregate correctly when multiple platforms exist`() {
-    val lhvTx =
-      createBuyTransaction(
-        quantity = BigDecimal("10"),
-        price = BigDecimal("100"),
-        platform = Platform.LHV,
-      )
-    val lightyearTx =
-      createBuyTransaction(
-        quantity = BigDecimal("5"),
-        price = BigDecimal("110"),
-        platform = Platform.LIGHTYEAR,
-      )
-
-    val metrics =
-      InstrumentMetrics(
-        totalInvestment = BigDecimal("1550"),
-        currentValue = BigDecimal("2250"),
-        profit = BigDecimal("700"),
-        realizedProfit = BigDecimal.ZERO,
-        unrealizedProfit = BigDecimal("700"),
-        xirr = 30.0,
-        quantity = BigDecimal("15"),
-      )
-
-    every { instrumentRepository.findAll() } returns listOf(testInstrument)
-    every { portfolioTransactionRepository.findAllWithInstruments() } returns
-      listOf(lhvTx, lightyearTx)
-    every {
-      investmentMetricsService.calculateInstrumentMetricsWithProfits(
-        testInstrument,
-        any(),
-        any(),
-      )
-    } returns metrics
-    every { dailyPriceService.getPriceChange(testInstrument, any()) } returns null
-
-    val result = instrumentService.getAllInstrumentSnapshots()
-
-    expect(result).toHaveSize(1)
-    expect(result[0].platforms.toSet()).toEqual(setOf(Platform.LHV, Platform.LIGHTYEAR))
-  }
-
-  @Test
-  fun `should return instruments matching multiple platforms when filter includes multiple platforms`() {
-    val lhvTx =
-      createBuyTransaction(
-        quantity = BigDecimal("10"),
-        price = BigDecimal("100"),
-        platform = Platform.LHV,
-      )
-    val lightyearTx =
-      createBuyTransaction(
-        quantity = BigDecimal("5"),
-        price = BigDecimal("110"),
-        platform = Platform.LIGHTYEAR,
-      )
-
-    val metrics =
-      InstrumentMetrics(
-        totalInvestment = BigDecimal("1550"),
-        currentValue = BigDecimal("2250"),
-        profit = BigDecimal("700"),
-        realizedProfit = BigDecimal.ZERO,
-        unrealizedProfit = BigDecimal("700"),
-        xirr = 30.0,
-        quantity = BigDecimal("15"),
-      )
-
-    every { instrumentRepository.findAll() } returns listOf(testInstrument)
-    every { portfolioTransactionRepository.findAllWithInstruments() } returns
-      listOf(lhvTx, lightyearTx)
-    every {
-      investmentMetricsService.calculateInstrumentMetricsWithProfits(
-        testInstrument,
-        listOf(lhvTx, lightyearTx),
-        any(),
-      )
-    } returns metrics
-    every { dailyPriceService.getPriceChange(testInstrument, any()) } returns null
-
-    val result = instrumentService.getAllInstrumentSnapshots(listOf("lhv", "lightyear"))
-
-    expect(result).toHaveSize(1)
-    expect(result[0].platforms.toSet()).toEqual(setOf(Platform.LHV, Platform.LIGHTYEAR))
-  }
-
-  @Test
-  fun `should handle mixed case platform names when filtering`() {
-    val transaction =
-      createBuyTransaction(
-        quantity = BigDecimal("10"),
-        price = BigDecimal("100"),
-        platform = Platform.LHV,
-      )
-
-    val metrics =
-      InstrumentMetrics(
-        totalInvestment = BigDecimal("1000"),
-        currentValue = BigDecimal("1500"),
-        profit = BigDecimal("500"),
-        realizedProfit = BigDecimal.ZERO,
-        unrealizedProfit = BigDecimal("500"),
-        xirr = 25.0,
-        quantity = BigDecimal("10"),
-      )
-
-    every { instrumentRepository.findAll() } returns listOf(testInstrument)
-    every { portfolioTransactionRepository.findAllWithInstruments() } returns listOf(transaction)
-    every {
-      investmentMetricsService.calculateInstrumentMetricsWithProfits(
-        testInstrument,
-        listOf(transaction),
-        any(),
-      )
-    } returns metrics
-    every { dailyPriceService.getPriceChange(testInstrument, any()) } returns null
-
-    val result = instrumentService.getAllInstrumentSnapshots(listOf("Lhv", "LIGHTYEAR"))
-
-    expect(result).toHaveSize(1)
-  }
-
-  @Test
-  fun `should filter out instruments with no transactions when empty platform list provided`() {
-    val transaction =
-      createBuyTransaction(quantity = BigDecimal("10"), price = BigDecimal("100"))
-
-    every { instrumentRepository.findAll() } returns listOf(testInstrument)
-    every { portfolioTransactionRepository.findAllWithInstruments() } returns listOf(transaction)
-
-    val result = instrumentService.getAllInstrumentSnapshots(emptyList())
-
-    expect(result).toBeEmpty()
-  }
-
-  @Test
-  fun `should filter out instruments when no matching platform transactions exist`() {
-    val lhvTransaction =
-      createBuyTransaction(
-        quantity = BigDecimal("10"),
-        price = BigDecimal("100"),
-        platform = Platform.LHV,
-      )
-
-    every { instrumentRepository.findAll() } returns listOf(testInstrument)
-    every { portfolioTransactionRepository.findAllWithInstruments() } returns listOf(lhvTransaction)
-
-    val result = instrumentService.getAllInstrumentSnapshots(listOf("LIGHTYEAR"))
-
-    expect(result).toBeEmpty()
-  }
-
-  @Test
-  fun `should return only instruments with matching platforms when multiple instruments exist`() {
-    val instrument2 =
-      Instrument(
-        symbol = "GOOGL",
-        name = "Alphabet Inc.",
-        category = "Stock",
-        baseCurrency = "USD",
-        currentPrice = BigDecimal("2800"),
-      ).apply { id = 2L }
-
-    val tx1 =
-      createBuyTransaction(
-        quantity = BigDecimal("10"),
-        price = BigDecimal("100"),
-        platform = Platform.LHV,
-      )
-    val tx2 =
-      createBuyTransaction(
-        quantity = BigDecimal("5"),
-        price = BigDecimal("2500"),
-        platform = Platform.LIGHTYEAR,
-        instrument = instrument2,
-      )
-
-    val metrics1 =
-      InstrumentMetrics(
-        totalInvestment = BigDecimal("1000"),
-        currentValue = BigDecimal("1500"),
-        profit = BigDecimal("500"),
-        realizedProfit = BigDecimal("200"),
-        unrealizedProfit = BigDecimal("300"),
-        xirr = 25.0,
-        quantity = BigDecimal("10"),
-      )
-
-    every { instrumentRepository.findAll() } returns listOf(testInstrument, instrument2)
-    every { portfolioTransactionRepository.findAllWithInstruments() } returns listOf(tx1, tx2)
-    every {
-      investmentMetricsService.calculateInstrumentMetricsWithProfits(
-        testInstrument,
-        listOf(tx1),
-        any(),
-      )
-    } returns metrics1
-    every { dailyPriceService.getPriceChange(testInstrument, any()) } returns null
-
-    val result = instrumentService.getAllInstrumentSnapshots(listOf("lhv"))
-
-    expect(result).toHaveSize(1)
-    expect(result[0].instrument.symbol).toEqual("AAPL")
-  }
-
-  @Test
-  fun `should use current date from clock when calculating metrics`() {
-    val transaction =
-      createBuyTransaction(quantity = BigDecimal("10"), price = BigDecimal("100"))
-
-    val metrics =
-      InstrumentMetrics(
-        totalInvestment = BigDecimal("1000"),
-        currentValue = BigDecimal("1500"),
-        profit = BigDecimal("500"),
-        realizedProfit = BigDecimal.ZERO,
-        unrealizedProfit = BigDecimal("500"),
-        xirr = 25.0,
-        quantity = BigDecimal("10"),
-      )
-
-    every { instrumentRepository.findAll() } returns listOf(testInstrument)
-    every { portfolioTransactionRepository.findAllWithInstruments() } returns listOf(transaction)
-    every {
-      investmentMetricsService.calculateInstrumentMetricsWithProfits(
-        testInstrument,
-        any(),
-        testDate,
-      )
-    } returns metrics
-    every { dailyPriceService.getPriceChange(testInstrument, any()) } returns null
-
-    instrumentService.getAllInstrumentSnapshots()
-
-    verify {
-      investmentMetricsService.calculateInstrumentMetricsWithProfits(
-        testInstrument,
-        any(),
-        testDate,
-      )
-    }
-  }
-
-  private fun createBuyTransaction(
-    quantity: BigDecimal,
-    price: BigDecimal,
-    date: LocalDate = testDate,
-    commission: BigDecimal = BigDecimal("5"),
-    platform: Platform = Platform.LHV,
-    instrument: Instrument = testInstrument,
-  ): PortfolioTransaction =
-    PortfolioTransaction(
-      instrument = instrument,
-      transactionType = TransactionType.BUY,
-      quantity = quantity,
-      price = price,
-      transactionDate = date,
-      platform = platform,
-      commission = commission,
-    )
 }

--- a/src/test/kotlin/ee/tenman/portfolio/service/InstrumentSnapshotServiceTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/service/InstrumentSnapshotServiceTest.kt
@@ -1,0 +1,238 @@
+package ee.tenman.portfolio.service
+
+import ch.tutteli.atrium.api.fluent.en_GB.notToEqualNull
+import ch.tutteli.atrium.api.fluent.en_GB.toBeEmpty
+import ch.tutteli.atrium.api.fluent.en_GB.toContainExactly
+import ch.tutteli.atrium.api.fluent.en_GB.toEqual
+import ch.tutteli.atrium.api.fluent.en_GB.toEqualNumerically
+import ch.tutteli.atrium.api.fluent.en_GB.toHaveSize
+import ch.tutteli.atrium.api.verbs.expect
+import ee.tenman.portfolio.domain.Instrument
+import ee.tenman.portfolio.domain.Platform
+import ee.tenman.portfolio.domain.PortfolioTransaction
+import ee.tenman.portfolio.domain.ProviderName
+import ee.tenman.portfolio.domain.TransactionType
+import ee.tenman.portfolio.model.PriceChange
+import ee.tenman.portfolio.model.metrics.InstrumentMetrics
+import ee.tenman.portfolio.repository.InstrumentRepository
+import ee.tenman.portfolio.repository.PortfolioTransactionRepository
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+
+class InstrumentSnapshotServiceTest {
+  private val instrumentRepository = mockk<InstrumentRepository>()
+  private val portfolioTransactionRepository = mockk<PortfolioTransactionRepository>()
+  private val investmentMetricsService = mockk<InvestmentMetricsService>()
+  private val dailyPriceService = mockk<DailyPriceService>()
+  private val clock = mockk<Clock>()
+
+  private lateinit var instrumentSnapshotService: InstrumentSnapshotService
+  private lateinit var testInstrument: Instrument
+  private val testDate = LocalDate.of(2024, 1, 15)
+  private val fixedInstant = Instant.parse("2024-01-15T10:00:00Z")
+
+  @BeforeEach
+  fun setUp() {
+    testInstrument =
+      Instrument(
+        symbol = "AAPL",
+        name = "Apple Inc.",
+        category = "Stock",
+        baseCurrency = "USD",
+        currentPrice = BigDecimal("150.00"),
+        providerName = ProviderName.FT,
+      ).apply { id = 1L }
+
+    every { clock.instant() } returns fixedInstant
+    every { clock.zone } returns ZoneId.of("UTC")
+
+    instrumentSnapshotService =
+      InstrumentSnapshotService(
+        instrumentRepository,
+        portfolioTransactionRepository,
+        investmentMetricsService,
+        dailyPriceService,
+        clock,
+      )
+  }
+
+  @Test
+  fun `should return snapshots with metrics when transactions exist`() {
+    val transaction = createBuyTransaction(BigDecimal("10"), BigDecimal("100"), testDate.minusDays(2))
+    val metrics = createMetrics()
+
+    every { instrumentRepository.findAll() } returns listOf(testInstrument)
+    every { portfolioTransactionRepository.findAllWithInstruments() } returns listOf(transaction)
+    every { investmentMetricsService.calculateInstrumentMetricsWithProfits(testInstrument, any(), any()) } returns metrics
+    every { dailyPriceService.getPriceChange(testInstrument, any()) } returns PriceChange(BigDecimal("5.00"), 3.5)
+
+    val result = instrumentSnapshotService.getAllSnapshots()
+
+    expect(result).toHaveSize(1)
+    expect(result[0].totalInvestment).toEqualNumerically(BigDecimal("1000"))
+    expect(result[0].currentValue).toEqualNumerically(BigDecimal("1500"))
+    expect(result[0].profit).toEqualNumerically(BigDecimal("500"))
+  }
+
+  @Test
+  fun `should filter by platform when platform filter specified`() {
+    val lhvTransaction = createBuyTransaction(BigDecimal("10"), BigDecimal("100"), testDate, Platform.LHV)
+    val lightyearTransaction = createBuyTransaction(BigDecimal("5"), BigDecimal("100"), testDate, Platform.LIGHTYEAR)
+    val metrics = createMetrics()
+
+    every { instrumentRepository.findAll() } returns listOf(testInstrument)
+    every { portfolioTransactionRepository.findAllWithInstruments() } returns listOf(lhvTransaction, lightyearTransaction)
+    every { investmentMetricsService.calculateInstrumentMetricsWithProfits(testInstrument, listOf(lhvTransaction), any()) } returns metrics
+    every { dailyPriceService.getPriceChange(testInstrument, any()) } returns null
+
+    val result = instrumentSnapshotService.getAllSnapshots(listOf("lhv"))
+
+    expect(result).toHaveSize(1)
+    expect(result[0].platforms).toContainExactly(Platform.LHV)
+  }
+
+  @Test
+  fun `should return empty when no matching platform transactions`() {
+    val lhvTransaction = createBuyTransaction(BigDecimal("10"), BigDecimal("100"), testDate, Platform.LHV)
+
+    every { instrumentRepository.findAll() } returns listOf(testInstrument)
+    every { portfolioTransactionRepository.findAllWithInstruments() } returns listOf(lhvTransaction)
+
+    val result = instrumentSnapshotService.getAllSnapshots(listOf("LIGHTYEAR"))
+
+    expect(result).toBeEmpty()
+  }
+
+  @Test
+  fun `should return instrument snapshot when no transactions and no platform filter`() {
+    every { instrumentRepository.findAll() } returns listOf(testInstrument)
+    every { portfolioTransactionRepository.findAllWithInstruments() } returns emptyList()
+
+    val result = instrumentSnapshotService.getAllSnapshots()
+
+    expect(result).toHaveSize(1)
+    expect(result[0].instrument).toEqual(testInstrument)
+  }
+
+  @Test
+  fun `should exclude instruments with zero quantity and zero investment`() {
+    val transaction = createBuyTransaction(BigDecimal("10"), BigDecimal("100"), testDate)
+    val zeroMetrics =
+      InstrumentMetrics(
+      totalInvestment = BigDecimal.ZERO,
+      currentValue = BigDecimal.ZERO,
+      profit = BigDecimal.ZERO,
+      realizedProfit = BigDecimal.ZERO,
+      unrealizedProfit = BigDecimal.ZERO,
+      xirr = 0.0,
+      quantity = BigDecimal.ZERO,
+    )
+
+    every { instrumentRepository.findAll() } returns listOf(testInstrument)
+    every { portfolioTransactionRepository.findAllWithInstruments() } returns listOf(transaction)
+    every { investmentMetricsService.calculateInstrumentMetricsWithProfits(testInstrument, any(), any()) } returns zeroMetrics
+    every { dailyPriceService.getPriceChange(testInstrument, any()) } returns null
+
+    val result = instrumentSnapshotService.getAllSnapshots(listOf("lhv"))
+
+    expect(result).toBeEmpty()
+  }
+
+  @Test
+  fun `should calculate price change from daily price service when holding period sufficient`() {
+    val transaction = createBuyTransaction(BigDecimal("10"), BigDecimal("100"), testDate.minusDays(30))
+    val metrics = createMetrics()
+    val priceChange = PriceChange(BigDecimal("5.00"), 3.5)
+
+    every { instrumentRepository.findAll() } returns listOf(testInstrument)
+    every { portfolioTransactionRepository.findAllWithInstruments() } returns listOf(transaction)
+    every { investmentMetricsService.calculateInstrumentMetricsWithProfits(testInstrument, any(), any()) } returns metrics
+    every { dailyPriceService.getPriceChange(testInstrument, any()) } returns priceChange
+
+    val result = instrumentSnapshotService.getAllSnapshots()
+
+    expect(result[0].priceChangeAmount).notToEqualNull().toEqualNumerically(BigDecimal("50.00"))
+    expect(result[0].priceChangePercent).toEqual(3.5)
+  }
+
+  @Test
+  fun `should calculate price change since purchase when holding period insufficient`() {
+    val transaction = createBuyTransaction(BigDecimal("10"), BigDecimal("100"), testDate, commission = BigDecimal.ZERO)
+    val metrics = createMetrics()
+
+    every { instrumentRepository.findAll() } returns listOf(testInstrument)
+    every { portfolioTransactionRepository.findAllWithInstruments() } returns listOf(transaction)
+    every { investmentMetricsService.calculateInstrumentMetricsWithProfits(testInstrument, any(), any()) } returns metrics
+
+    val result = instrumentSnapshotService.getAllSnapshots()
+
+    expect(result[0].priceChangeAmount).notToEqualNull().toEqualNumerically(BigDecimal("500.00"))
+    expect(result[0].priceChangePercent).toEqual(50.0)
+  }
+
+  @Test
+  fun `should handle mixed case platform names`() {
+    val transaction = createBuyTransaction(BigDecimal("10"), BigDecimal("100"), testDate, Platform.LHV)
+    val metrics = createMetrics()
+
+    every { instrumentRepository.findAll() } returns listOf(testInstrument)
+    every { portfolioTransactionRepository.findAllWithInstruments() } returns listOf(transaction)
+    every { investmentMetricsService.calculateInstrumentMetricsWithProfits(testInstrument, listOf(transaction), any()) } returns metrics
+    every { dailyPriceService.getPriceChange(testInstrument, any()) } returns null
+
+    val result = instrumentSnapshotService.getAllSnapshots(listOf("Lhv"))
+
+    expect(result).toHaveSize(1)
+  }
+
+  @Test
+  fun `should use current date from clock`() {
+    val transaction = createBuyTransaction(BigDecimal("10"), BigDecimal("100"), testDate)
+    val metrics = createMetrics()
+
+    every { instrumentRepository.findAll() } returns listOf(testInstrument)
+    every { portfolioTransactionRepository.findAllWithInstruments() } returns listOf(transaction)
+    every { investmentMetricsService.calculateInstrumentMetricsWithProfits(testInstrument, any(), testDate) } returns metrics
+    every { dailyPriceService.getPriceChange(testInstrument, any()) } returns null
+
+    instrumentSnapshotService.getAllSnapshots()
+
+    verify { investmentMetricsService.calculateInstrumentMetricsWithProfits(testInstrument, any(), testDate) }
+  }
+
+  private fun createBuyTransaction(
+    quantity: BigDecimal,
+    price: BigDecimal,
+    date: LocalDate,
+    platform: Platform = Platform.LHV,
+    commission: BigDecimal = BigDecimal("5"),
+  ): PortfolioTransaction =
+    PortfolioTransaction(
+      instrument = testInstrument,
+      transactionType = TransactionType.BUY,
+      quantity = quantity,
+      price = price,
+      transactionDate = date,
+      platform = platform,
+      commission = commission,
+    )
+
+  private fun createMetrics(): InstrumentMetrics =
+    InstrumentMetrics(
+      totalInvestment = BigDecimal("1000"),
+      currentValue = BigDecimal("1500"),
+      profit = BigDecimal("500"),
+      realizedProfit = BigDecimal.ZERO,
+      unrealizedProfit = BigDecimal("500"),
+      xirr = 25.0,
+      quantity = BigDecimal("10"),
+    )
+}

--- a/src/test/kotlin/ee/tenman/portfolio/service/TransactionProfitServiceTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/service/TransactionProfitServiceTest.kt
@@ -1,0 +1,172 @@
+package ee.tenman.portfolio.service
+
+import ch.tutteli.atrium.api.fluent.en_GB.notToEqualNull
+import ch.tutteli.atrium.api.fluent.en_GB.toEqualNumerically
+import ch.tutteli.atrium.api.verbs.expect
+import ee.tenman.portfolio.domain.Instrument
+import ee.tenman.portfolio.domain.Platform
+import ee.tenman.portfolio.domain.PortfolioTransaction
+import ee.tenman.portfolio.domain.ProviderName
+import ee.tenman.portfolio.domain.TransactionType
+import ee.tenman.portfolio.repository.InstrumentRepository
+import ee.tenman.portfolio.repository.PortfolioTransactionRepository
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.*
+
+class TransactionProfitServiceTest {
+  private val instrumentRepository = mockk<InstrumentRepository>()
+  private val portfolioTransactionRepository = mockk<PortfolioTransactionRepository>()
+
+  private lateinit var transactionProfitService: TransactionProfitService
+  private lateinit var testInstrument: Instrument
+
+  @BeforeEach
+  fun setUp() {
+    testInstrument =
+      Instrument(
+        symbol = "AAPL",
+        name = "Apple Inc.",
+        category = "Stock",
+        baseCurrency = "USD",
+        currentPrice = BigDecimal("150.00"),
+        providerName = ProviderName.FT,
+      ).apply { id = 1L }
+
+    transactionProfitService = TransactionProfitService(instrumentRepository, portfolioTransactionRepository)
+  }
+
+  @Test
+  fun `should not recalculate when instrument not found`() {
+    every { instrumentRepository.findById(999L) } returns Optional.empty()
+
+    transactionProfitService.recalculateProfitsForInstrument(999L)
+
+    verify(exactly = 0) { portfolioTransactionRepository.findAllByInstrumentId(any()) }
+  }
+
+  @Test
+  fun `should not recalculate when no transactions exist`() {
+    every { instrumentRepository.findById(1L) } returns Optional.of(testInstrument)
+    every { portfolioTransactionRepository.findAllByInstrumentId(1L) } returns emptyList()
+
+    transactionProfitService.recalculateProfitsForInstrument(1L)
+
+    verify(exactly = 0) { portfolioTransactionRepository.saveAll(any<List<PortfolioTransaction>>()) }
+  }
+
+  @Test
+  fun `should calculate realized profit for sell transaction`() {
+    val buyTx = createTransaction(TransactionType.BUY, BigDecimal("10"), BigDecimal("100"), LocalDate.of(2024, 1, 1))
+    val sellTx = createTransaction(TransactionType.SELL, BigDecimal("5"), BigDecimal("120"), LocalDate.of(2024, 1, 10))
+
+    val transactionsSlot = slot<List<PortfolioTransaction>>()
+
+    every { instrumentRepository.findById(1L) } returns Optional.of(testInstrument)
+    every { portfolioTransactionRepository.findAllByInstrumentId(1L) } returns listOf(buyTx, sellTx)
+    every { portfolioTransactionRepository.saveAll(capture(transactionsSlot)) } answers { transactionsSlot.captured }
+
+    transactionProfitService.recalculateProfitsForInstrument(1L)
+
+    val savedSellTx = transactionsSlot.captured.find { it.transactionType == TransactionType.SELL }!!
+    expect(savedSellTx.realizedProfit).notToEqualNull().toEqualNumerically(BigDecimal("92.50"))
+  }
+
+  @Test
+  fun `should calculate unrealized profit for buy transaction`() {
+    val buyTx = createTransaction(TransactionType.BUY, BigDecimal("10"), BigDecimal("100"), LocalDate.of(2024, 1, 1))
+
+    val transactionsSlot = slot<List<PortfolioTransaction>>()
+
+    every { instrumentRepository.findById(1L) } returns Optional.of(testInstrument)
+    every { portfolioTransactionRepository.findAllByInstrumentId(1L) } returns listOf(buyTx)
+    every { portfolioTransactionRepository.saveAll(capture(transactionsSlot)) } answers { transactionsSlot.captured }
+
+    transactionProfitService.recalculateProfitsForInstrument(1L)
+
+    val savedBuyTx = transactionsSlot.captured.find { it.transactionType == TransactionType.BUY }!!
+    expect(savedBuyTx.unrealizedProfit).toEqualNumerically(BigDecimal("495.00"))
+    expect(savedBuyTx.remainingQuantity).toEqualNumerically(BigDecimal("10"))
+  }
+
+  @Test
+  fun `should handle multiple platforms separately`() {
+    val lhvBuy = createTransaction(TransactionType.BUY, BigDecimal("10"), BigDecimal("100"), LocalDate.of(2024, 1, 1), Platform.LHV)
+    val lightyearBuy =
+      createTransaction(TransactionType.BUY, BigDecimal("5"), BigDecimal("110"), LocalDate.of(2024, 1, 1), Platform.LIGHTYEAR)
+
+    val transactionsSlot = slot<List<PortfolioTransaction>>()
+
+    every { instrumentRepository.findById(1L) } returns Optional.of(testInstrument)
+    every { portfolioTransactionRepository.findAllByInstrumentId(1L) } returns listOf(lhvBuy, lightyearBuy)
+    every { portfolioTransactionRepository.saveAll(capture(transactionsSlot)) } answers { transactionsSlot.captured }
+
+    transactionProfitService.recalculateProfitsForInstrument(1L)
+
+    val savedLhv = transactionsSlot.captured.find { it.platform == Platform.LHV }!!
+    val savedLightyear = transactionsSlot.captured.find { it.platform == Platform.LIGHTYEAR }!!
+    expect(savedLhv.remainingQuantity).toEqualNumerically(BigDecimal("10"))
+    expect(savedLightyear.remainingQuantity).toEqualNumerically(BigDecimal("5"))
+  }
+
+  @Test
+  fun `should set zero remaining quantity when all sold`() {
+    val buyTx = createTransaction(TransactionType.BUY, BigDecimal("10"), BigDecimal("100"), LocalDate.of(2024, 1, 1))
+    val sellTx = createTransaction(TransactionType.SELL, BigDecimal("10"), BigDecimal("120"), LocalDate.of(2024, 1, 10))
+
+    val transactionsSlot = slot<List<PortfolioTransaction>>()
+
+    every { instrumentRepository.findById(1L) } returns Optional.of(testInstrument)
+    every { portfolioTransactionRepository.findAllByInstrumentId(1L) } returns listOf(buyTx, sellTx)
+    every { portfolioTransactionRepository.saveAll(capture(transactionsSlot)) } answers { transactionsSlot.captured }
+
+    transactionProfitService.recalculateProfitsForInstrument(1L)
+
+    val savedBuyTx = transactionsSlot.captured.find { it.transactionType == TransactionType.BUY }!!
+    expect(savedBuyTx.remainingQuantity).toEqualNumerically(BigDecimal.ZERO)
+    expect(savedBuyTx.unrealizedProfit).toEqualNumerically(BigDecimal.ZERO)
+  }
+
+  @Test
+  fun `should clamp sell quantity when attempting to oversell`() {
+    val buyTx = createTransaction(TransactionType.BUY, BigDecimal("10"), BigDecimal("100"), LocalDate.of(2024, 1, 1))
+    val oversellTx = createTransaction(TransactionType.SELL, BigDecimal("15"), BigDecimal("120"), LocalDate.of(2024, 1, 10))
+
+    val transactionsSlot = slot<List<PortfolioTransaction>>()
+
+    every { instrumentRepository.findById(1L) } returns Optional.of(testInstrument)
+    every { portfolioTransactionRepository.findAllByInstrumentId(1L) } returns listOf(buyTx, oversellTx)
+    every { portfolioTransactionRepository.saveAll(capture(transactionsSlot)) } answers { transactionsSlot.captured }
+
+    transactionProfitService.recalculateProfitsForInstrument(1L)
+
+    val savedSellTx = transactionsSlot.captured.find { it.transactionType == TransactionType.SELL }!!
+    val savedBuyTx = transactionsSlot.captured.find { it.transactionType == TransactionType.BUY }!!
+    expect(savedSellTx.realizedProfit).notToEqualNull().toEqualNumerically(BigDecimal("190.00"))
+    expect(savedBuyTx.remainingQuantity).toEqualNumerically(BigDecimal.ZERO)
+    expect(savedBuyTx.unrealizedProfit).toEqualNumerically(BigDecimal.ZERO)
+  }
+
+  private fun createTransaction(
+    type: TransactionType,
+    quantity: BigDecimal,
+    price: BigDecimal,
+    date: LocalDate,
+    platform: Platform = Platform.LHV,
+  ): PortfolioTransaction =
+    PortfolioTransaction(
+      instrument = testInstrument,
+      transactionType = type,
+      quantity = quantity,
+      price = price,
+      transactionDate = date,
+      platform = platform,
+      commission = BigDecimal("5"),
+    )
+}


### PR DESCRIPTION
## Summary
- Extract `TransactionProfitService` (128 lines) for profit/loss calculations with oversell protection
- Extract `InstrumentSnapshotService` (148 lines) for metrics aggregation
- Reduce `InstrumentService` from 307 to 62 lines (80% reduction)
- Fix `findBySymbol` return type from `Instrument?` to `Instrument` (throws on not found)
- Add oversell validation to prevent negative portfolio state corruption
- Use proper BigDecimal comparisons with `compareTo()`

## Test plan
- [x] All existing tests pass
- [x] Added 7 tests for TransactionProfitService (including oversell scenario)
- [x] Added 10 tests for InstrumentSnapshotService
- [x] Updated tests for InstrumentService delegation
- [x] Tests use fixed ZoneId for deterministic behavior

Closes #982

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Restructured instrument service to delegate snapshot generation and profit recalculation to dedicated services; simplified error handling for missing instruments.

* **New Features**
  * Added a snapshot-generation service for enriched instrument views and a profit-recalculation service to keep transaction profits up to date.

* **Tests**
  * Added and updated tests covering snapshot generation, platform filtering, and detailed profit recalculation scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->