### PR TITLE
Fix self-invocation AOP bypass in TransactionService

### DIFF
--- a/src/main/kotlin/ee/tenman/portfolio/service/TransactionService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/service/TransactionService.kt
@@ -8,6 +8,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.cache.annotation.CacheEvict
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.cache.annotation.Caching
+import org.springframework.context.annotation.Lazy
 import org.springframework.orm.ObjectOptimisticLockingFailureException
 import org.springframework.retry.annotation.Backoff
 import org.springframework.retry.annotation.Retryable
@@ -20,6 +21,7 @@ import java.math.RoundingMode
 @Service
 class TransactionService(
   private val portfolioTransactionRepository: PortfolioTransactionRepository,
+  @Lazy private val self: TransactionService,
 ) {
   private val log = LoggerFactory.getLogger(javaClass)
 
@@ -94,7 +96,7 @@ class TransactionService(
   )
   fun getAllTransactions(platforms: List<String>?): List<PortfolioTransaction> {
     if (platforms.isNullOrEmpty()) {
-      return getAllTransactions()
+      return self.getAllTransactions()
     }
 
     val platformEnums =
@@ -132,7 +134,7 @@ class TransactionService(
     val hasDates = fromDate != null || untilDate != null
 
     if (!hasPlatforms && !hasDates) {
-      return getAllTransactions()
+      return self.getAllTransactions()
     }
 
     val platformEnums =
@@ -165,7 +167,7 @@ class TransactionService(
       hasDates ->
         portfolioTransactionRepository.findAllByDateRangeWithInstruments(effectiveFromDate, effectiveUntilDate)
       else ->
-        getAllTransactions()
+        self.getAllTransactions()
     }
   }
 

--- a/src/test/kotlin/ee/tenman/portfolio/service/TransactionServiceTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/service/TransactionServiceTest.kt
@@ -36,7 +36,7 @@ class TransactionServiceTest {
   @BeforeEach
   fun setUp() {
     portfolioTransactionRepository = mockk()
-    transactionService = TransactionService(portfolioTransactionRepository)
+    transactionService = TransactionService(portfolioTransactionRepository, mockk(relaxed = true))
 
     testInstrument =
       Instrument(


### PR DESCRIPTION
## Summary
- Add `@Lazy` self-injection to `TransactionService` to fix cache bypass issue
- Update internal calls to `getAllTransactions()` to use `self.getAllTransactions()` 
- This ensures `@Cacheable` annotation works correctly when called from within the same class

## Problem
When `getAllTransactions(platforms)` or `getAllTransactions(platforms, fromDate, untilDate)` called `getAllTransactions()` internally, the Spring AOP proxy was bypassed, causing cache misses.

## Solution
Used `@Lazy` self-injection pattern as recommended in CLAUDE.md guidelines.

Closes #983

## Test plan
- [x] All existing tests pass
- [x] Updated test to handle new constructor parameter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal transaction service architecture to enhance method handling and stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->