### PR TITLE
Add centralized frontend constants for API endpoints and storage keys

### DIFF
--- a/ui/components/instruments/instruments-view.vue
+++ b/ui/components/instruments/instruments-view.vue
@@ -68,9 +68,10 @@ import InstrumentModal from './instrument-modal.vue'
 import { instrumentsService } from '../../services/instruments-service'
 import { InstrumentDto } from '../../models/generated/domain-models'
 import { formatPlatformName } from '../../utils/platform-utils'
+import { STORAGE_KEYS, REFETCH_INTERVALS } from '../../constants'
 
 const selectedItem = ref<InstrumentDto | null>(null)
-const selectedPlatforms = useLocalStorage<string[]>('portfolio_selected_platforms', [])
+const selectedPlatforms = useLocalStorage<string[]>(STORAGE_KEYS.SELECTED_PLATFORMS, [])
 const { show: showModal, hide: hideModal } = useBootstrapModal('instrumentModal')
 const { selectedPeriod, periods } = usePriceChangePeriod()
 const queryClient = useQueryClient()
@@ -134,7 +135,7 @@ const {
     }
     return instrumentsService.getAll(selectedPlatforms.value, selectedPeriod.value)
   },
-  refetchInterval: 2000,
+  refetchInterval: REFETCH_INTERVALS.INSTRUMENTS,
 })
 
 const items = computed(() => {

--- a/ui/components/transactions/transactions-view.vue
+++ b/ui/components/transactions/transactions-view.vue
@@ -121,11 +121,12 @@ import TransactionTable from './transaction-table.vue'
 import { transactionsService } from '../../services/transactions-service'
 import { formatCurrency } from '../../utils/formatters'
 import { formatPlatformName } from '../../utils/platform-utils'
+import { STORAGE_KEYS } from '../../constants'
 
-const selectedPlatforms = useLocalStorage<string[]>('portfolio_selected_transaction_platforms', [])
-const fromDate = useLocalStorage<string>('portfolio_transactions_from_date', '')
-const untilDate = useLocalStorage<string>('portfolio_transactions_until_date', '')
-const selectedQuickDate = useLocalStorage<string>('portfolio_selected_quick_date', '')
+const selectedPlatforms = useLocalStorage<string[]>(STORAGE_KEYS.SELECTED_TRANSACTION_PLATFORMS, [])
+const fromDate = useLocalStorage<string>(STORAGE_KEYS.TRANSACTIONS_FROM_DATE, '')
+const untilDate = useLocalStorage<string>(STORAGE_KEYS.TRANSACTIONS_UNTIL_DATE, '')
+const selectedQuickDate = useLocalStorage<string>(STORAGE_KEYS.SELECTED_QUICK_DATE, '')
 const quickDateDropdown = ref<HTMLElement | null>(null)
 
 let manualDateChange = false

--- a/ui/constants/api.ts
+++ b/ui/constants/api.ts
@@ -1,0 +1,17 @@
+export const API_ENDPOINTS = {
+  INSTRUMENTS: '/instruments',
+  INSTRUMENTS_REFRESH_PRICES: '/instruments/refresh-prices',
+  TRANSACTIONS: '/transactions',
+  PORTFOLIO_SUMMARY_HISTORICAL: '/portfolio-summary/historical',
+  PORTFOLIO_SUMMARY_CURRENT: '/portfolio-summary/current',
+  PORTFOLIO_SUMMARY_RECALCULATE: '/portfolio-summary/recalculate',
+  ETF_BREAKDOWN: '/etf-breakdown',
+  ENUMS: '/enums',
+  LOGOS: '/logos',
+  CALCULATOR: '/calculator',
+  BUILD_INFO: '/build-info',
+} as const
+
+export const REFETCH_INTERVALS = {
+  INSTRUMENTS: 2000,
+} as const

--- a/ui/constants/index.ts
+++ b/ui/constants/index.ts
@@ -1,0 +1,2 @@
+export { STORAGE_KEYS } from './storage-keys'
+export { API_ENDPOINTS, REFETCH_INTERVALS } from './api'

--- a/ui/constants/storage-keys.ts
+++ b/ui/constants/storage-keys.ts
@@ -1,0 +1,7 @@
+export const STORAGE_KEYS = {
+  SELECTED_PLATFORMS: 'portfolio_selected_platforms',
+  SELECTED_TRANSACTION_PLATFORMS: 'portfolio_selected_transaction_platforms',
+  SELECTED_QUICK_DATE: 'portfolio_selected_quick_date',
+  TRANSACTIONS_FROM_DATE: 'portfolio_transactions_from_date',
+  TRANSACTIONS_UNTIL_DATE: 'portfolio_transactions_until_date',
+} as const

--- a/ui/services/enum-service.ts
+++ b/ui/services/enum-service.ts
@@ -1,4 +1,5 @@
 import { httpClient } from '../utils/http-client'
+import { API_ENDPOINTS } from '../constants'
 
 interface EnumValues {
   platforms: string[]
@@ -9,5 +10,5 @@ interface EnumValues {
 }
 
 export const enumService = {
-  getAll: () => httpClient.get<EnumValues>('/enums').then(res => res.data),
+  getAll: () => httpClient.get<EnumValues>(API_ENDPOINTS.ENUMS).then(res => res.data),
 }

--- a/ui/services/etf-breakdown-service.ts
+++ b/ui/services/etf-breakdown-service.ts
@@ -1,5 +1,6 @@
 import { httpClient } from '../utils/http-client'
 import type { EtfHoldingBreakdownDto } from '../models/generated/domain-models'
+import { API_ENDPOINTS } from '../constants'
 
 export const etfBreakdownService = {
   getBreakdown: (etfSymbols?: string[], platforms?: string[]) => {
@@ -7,7 +8,7 @@ export const etfBreakdownService = {
     if (etfSymbols?.length) params.etfSymbols = etfSymbols
     if (platforms?.length) params.platforms = platforms
     return httpClient
-      .get<EtfHoldingBreakdownDto[]>('/etf-breakdown', { params })
+      .get<EtfHoldingBreakdownDto[]>(API_ENDPOINTS.ETF_BREAKDOWN, { params })
       .then(res => res.data)
   },
 }

--- a/ui/services/instruments-service.ts
+++ b/ui/services/instruments-service.ts
@@ -1,5 +1,6 @@
 import { httpClient } from '../utils/http-client'
 import { type InstrumentDto, PriceChangePeriod } from '../models/generated/domain-models'
+import { API_ENDPOINTS } from '../constants'
 
 export const instrumentsService = {
   getAll: (platforms?: string[], period: PriceChangePeriod = PriceChangePeriod.P24H) => {
@@ -7,15 +8,19 @@ export const instrumentsService = {
     if (platforms && platforms.length > 0) {
       params.platforms = platforms
     }
-    return httpClient.get<InstrumentDto[]>('/instruments', { params }).then(res => res.data)
+    return httpClient
+      .get<InstrumentDto[]>(API_ENDPOINTS.INSTRUMENTS, { params })
+      .then(res => res.data)
   },
 
   create: (data: Partial<InstrumentDto>) =>
-    httpClient.post<InstrumentDto>('/instruments', data).then(res => res.data),
+    httpClient.post<InstrumentDto>(API_ENDPOINTS.INSTRUMENTS, data).then(res => res.data),
 
   update: (id: number | string, data: Partial<InstrumentDto>) =>
-    httpClient.put<InstrumentDto>(`/instruments/${id}`, data).then(res => res.data),
+    httpClient.put<InstrumentDto>(`${API_ENDPOINTS.INSTRUMENTS}/${id}`, data).then(res => res.data),
 
   refreshPrices: () =>
-    httpClient.post<{ status: string }>('/instruments/refresh-prices').then(res => res.data),
+    httpClient
+      .post<{ status: string }>(API_ENDPOINTS.INSTRUMENTS_REFRESH_PRICES)
+      .then(res => res.data),
 }

--- a/ui/services/portfolio-summary-service.ts
+++ b/ui/services/portfolio-summary-service.ts
@@ -1,21 +1,24 @@
 import { httpClient } from '../utils/http-client'
 import type { PortfolioSummaryDto } from '../models/generated/domain-models'
 import type { Page } from '../models/page'
+import { API_ENDPOINTS } from '../constants'
 
 export const portfolioSummaryService = {
   getHistorical: (page: number, size: number) =>
     httpClient
-      .get<Page<PortfolioSummaryDto>>('/portfolio-summary/historical', {
+      .get<Page<PortfolioSummaryDto>>(API_ENDPOINTS.PORTFOLIO_SUMMARY_HISTORICAL, {
         params: { page, size },
       })
       .then(res => res.data),
 
   getCurrent: () =>
-    httpClient.get<PortfolioSummaryDto>('/portfolio-summary/current').then(res => res.data),
+    httpClient
+      .get<PortfolioSummaryDto>(API_ENDPOINTS.PORTFOLIO_SUMMARY_CURRENT)
+      .then(res => res.data),
 
   recalculate: () =>
     httpClient
-      .post<{ message: string }>('/portfolio-summary/recalculate', undefined, {
+      .post<{ message: string }>(API_ENDPOINTS.PORTFOLIO_SUMMARY_RECALCULATE, undefined, {
         timeout: 60000,
       })
       .then(res => res.data),

--- a/ui/services/transactions-service.ts
+++ b/ui/services/transactions-service.ts
@@ -4,6 +4,7 @@ import type {
   TransactionRequestDto,
   TransactionsWithSummaryDto,
 } from '../models/generated/domain-models'
+import { API_ENDPOINTS } from '../constants'
 
 export const transactionsService = {
   getAll: (platforms?: string[], fromDate?: string, untilDate?: string) => {
@@ -18,16 +19,18 @@ export const transactionsService = {
       params.untilDate = untilDate
     }
     return httpClient
-      .get<TransactionsWithSummaryDto>('/transactions', { params })
+      .get<TransactionsWithSummaryDto>(API_ENDPOINTS.TRANSACTIONS, { params })
       .then(res => res.data)
   },
 
   create: (data: Partial<TransactionRequestDto>) =>
-    httpClient.post<TransactionResponseDto>('/transactions', data).then(res => res.data),
+    httpClient.post<TransactionResponseDto>(API_ENDPOINTS.TRANSACTIONS, data).then(res => res.data),
 
   update: (id: number | string, data: Partial<TransactionRequestDto>) =>
-    httpClient.put<TransactionResponseDto>(`/transactions/${id}`, data).then(res => res.data),
+    httpClient
+      .put<TransactionResponseDto>(`${API_ENDPOINTS.TRANSACTIONS}/${id}`, data)
+      .then(res => res.data),
 
   delete: (id: number | string) =>
-    httpClient.delete<void>(`/transactions/${id}`).then(() => undefined),
+    httpClient.delete<void>(`${API_ENDPOINTS.TRANSACTIONS}/${id}`).then(() => undefined),
 }

--- a/ui/services/utility-service.ts
+++ b/ui/services/utility-service.ts
@@ -1,5 +1,6 @@
 import { httpClient } from '../utils/http-client'
 import { CalculationResult } from '../models/calculation-result'
+import { API_ENDPOINTS } from '../constants'
 
 interface BuildInfo {
   hash: string
@@ -8,9 +9,9 @@ interface BuildInfo {
 
 export const utilityService = {
   getCalculationResult: () =>
-    httpClient.get<CalculationResult>('/calculator').then(res => res.data),
+    httpClient.get<CalculationResult>(API_ENDPOINTS.CALCULATOR).then(res => res.data),
 
-  getBuildInfo: () => httpClient.get<BuildInfo>('/build-info').then(res => res.data),
+  getBuildInfo: () => httpClient.get<BuildInfo>(API_ENDPOINTS.BUILD_INFO).then(res => res.data),
 
-  getLogoUrl: (ticker: string): string => `/api/logos/${ticker}`,
+  getLogoUrl: (ticker: string): string => `/api${API_ENDPOINTS.LOGOS}/${ticker}`,
 }


### PR DESCRIPTION
## Summary
- Create `ui/constants/` directory with centralized constants
- Extract `API_ENDPOINTS` constant for all API paths (instruments, transactions, portfolio-summary, etc.)
- Extract `REFETCH_INTERVALS` constant for query refetch intervals
- Extract `STORAGE_KEYS` constant for localStorage key management (platforms, dates, quick dates)
- Update all service files to use `API_ENDPOINTS` instead of hardcoded strings
- Update `instruments-view.vue` and `transactions-view.vue` to use `STORAGE_KEYS` and `REFETCH_INTERVALS`

## Test plan
- [x] Run `npm run lint-format` - passes
- [x] Run `npm test` - all 501 tests pass
- [ ] Verify frontend functionality works correctly with new constants

Closes #984

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized API endpoint and storage key configuration across the application for improved maintainability and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->