### PR TITLE
Extract business logic from PortfolioTransactionController

### DIFF
--- a/src/main/kotlin/ee/tenman/portfolio/controller/PortfolioTransactionController.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/controller/PortfolioTransactionController.kt
@@ -2,13 +2,11 @@ package ee.tenman.portfolio.controller
 
 import ee.tenman.portfolio.configuration.aspect.Loggable
 import ee.tenman.portfolio.domain.PortfolioTransaction
-import ee.tenman.portfolio.domain.TransactionType
 import ee.tenman.portfolio.dto.TransactionRequestDto
 import ee.tenman.portfolio.dto.TransactionResponseDto
-import ee.tenman.portfolio.dto.TransactionSummaryDto
 import ee.tenman.portfolio.dto.TransactionsWithSummaryDto
 import ee.tenman.portfolio.service.InstrumentService
-import ee.tenman.portfolio.service.InvestmentMetricsService
+import ee.tenman.portfolio.service.TransactionQueryService
 import ee.tenman.portfolio.service.TransactionService
 import jakarta.validation.Valid
 import org.springframework.format.annotation.DateTimeFormat
@@ -24,16 +22,15 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
-import java.math.BigDecimal
 import java.time.LocalDate
 
 @RestController
 @RequestMapping("/api/transactions")
 @Validated
 class PortfolioTransactionController(
-  private val portfolioTransactionService: TransactionService,
+  private val transactionService: TransactionService,
+  private val transactionQueryService: TransactionQueryService,
   private val instrumentService: InstrumentService,
-  private val investmentMetricsService: InvestmentMetricsService,
 ) {
   @PostMapping
   @ResponseStatus(HttpStatus.CREATED)
@@ -52,7 +49,7 @@ class PortfolioTransactionController(
         commission = request.commission,
         currency = request.currency,
       )
-    val savedTransaction = portfolioTransactionService.saveTransaction(transaction)
+    val savedTransaction = transactionService.saveTransaction(transaction)
     return TransactionResponseDto.fromEntity(savedTransaction)
   }
 
@@ -64,72 +61,14 @@ class PortfolioTransactionController(
     @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) untilDate: LocalDate?,
   ): TransactionsWithSummaryDto {
     val platformList = platforms?.split(",")?.map { it.trim() }?.filter { it.isNotEmpty() }
-    val transactions = portfolioTransactionService.getAllTransactions(platformList, fromDate, untilDate)
-
-    val isDateFiltered = fromDate != null || untilDate != null
-    if (isDateFiltered && transactions.isNotEmpty()) {
-      val fullHistory =
-        portfolioTransactionService.getFullTransactionHistoryForProfitCalculation(transactions, platformList)
-      portfolioTransactionService.calculateTransactionProfits(fullHistory)
-
-      val profitMap = fullHistory.associateBy { it.id }
-      transactions.forEach { tx ->
-        profitMap[tx.id]?.let { calculated ->
-          tx.realizedProfit = calculated.realizedProfit
-          tx.unrealizedProfit = calculated.unrealizedProfit
-          tx.remainingQuantity = calculated.remainingQuantity
-          tx.averageCost = calculated.averageCost
-        }
-      }
-    } else {
-      portfolioTransactionService.calculateTransactionProfits(transactions)
-    }
-
-    val groupedByInstrument = transactions.groupBy { it.instrument }
-    val totalUnrealizedProfit =
-      groupedByInstrument.entries.sumOf { (instrument, instrumentTransactions) ->
-        val metrics = investmentMetricsService.calculateInstrumentMetrics(instrument, instrumentTransactions)
-        metrics.unrealizedProfit
-      }
-
-    val totalRealizedProfit =
-      transactions
-        .filter { it.transactionType == TransactionType.SELL }
-        .sumOf { it.realizedProfit ?: BigDecimal.ZERO }
-
-    val totalInvested =
-      transactions.sumOf { transaction ->
-        val transactionCost = transaction.price.multiply(transaction.quantity).add(transaction.commission)
-        if (transaction.transactionType == TransactionType.BUY) {
-          transactionCost
-        } else {
-          transactionCost.negate()
-        }
-      }
-
-    val summary =
-      TransactionSummaryDto(
-        totalRealizedProfit = totalRealizedProfit,
-        totalUnrealizedProfit = totalUnrealizedProfit,
-        totalProfit = totalRealizedProfit + totalUnrealizedProfit,
-        totalInvested = totalInvested,
-      )
-
-    return TransactionsWithSummaryDto(
-      transactions = transactions.map { TransactionResponseDto.fromEntity(it) },
-      summary = summary,
-    )
+    return transactionQueryService.getTransactionsWithSummary(platformList, fromDate, untilDate)
   }
 
   @GetMapping("/{id}")
   @Loggable
   fun getTransaction(
     @PathVariable id: Long,
-  ): TransactionResponseDto {
-    val transaction = portfolioTransactionService.getTransactionById(id)
-    portfolioTransactionService.calculateTransactionProfits(listOf(transaction))
-    return TransactionResponseDto.fromEntity(transaction)
-  }
+  ): TransactionResponseDto = transactionQueryService.getTransactionWithProfits(id)
 
   @PutMapping("/{id}")
   @Loggable
@@ -137,10 +76,8 @@ class PortfolioTransactionController(
     @PathVariable id: Long,
     @Valid @RequestBody request: TransactionRequestDto,
   ): TransactionResponseDto {
-    val existingTransaction = portfolioTransactionService.getTransactionById(id)
-
+    val existingTransaction = transactionService.getTransactionById(id)
     val instrument = instrumentService.getInstrumentById(request.instrumentId)
-
     existingTransaction.apply {
       this.instrument = instrument
       this.transactionType = request.transactionType
@@ -151,8 +88,7 @@ class PortfolioTransactionController(
       this.commission = request.commission
       this.currency = request.currency
     }
-
-    val updatedTransaction = portfolioTransactionService.saveTransaction(existingTransaction)
+    val updatedTransaction = transactionService.saveTransaction(existingTransaction)
     return TransactionResponseDto.fromEntity(updatedTransaction)
   }
 
@@ -160,5 +96,5 @@ class PortfolioTransactionController(
   @ResponseStatus(HttpStatus.NO_CONTENT)
   fun deleteTransaction(
     @PathVariable id: Long,
-  ) = portfolioTransactionService.deleteTransaction(id)
+  ) = transactionService.deleteTransaction(id)
 }

--- a/src/main/kotlin/ee/tenman/portfolio/service/TransactionQueryService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/service/TransactionQueryService.kt
@@ -1,0 +1,101 @@
+package ee.tenman.portfolio.service
+
+import ee.tenman.portfolio.domain.PortfolioTransaction
+import ee.tenman.portfolio.domain.TransactionType
+import ee.tenman.portfolio.dto.TransactionResponseDto
+import ee.tenman.portfolio.dto.TransactionSummaryDto
+import ee.tenman.portfolio.dto.TransactionsWithSummaryDto
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+import java.time.LocalDate
+
+@Service
+class TransactionQueryService(
+  private val transactionService: TransactionService,
+  private val investmentMetricsService: InvestmentMetricsService,
+) {
+  @Transactional(readOnly = true)
+  fun getTransactionsWithSummary(
+    platforms: List<String>?,
+    fromDate: LocalDate?,
+    untilDate: LocalDate?,
+  ): TransactionsWithSummaryDto {
+    val transactions = transactionService.getAllTransactions(platforms, fromDate, untilDate)
+    val isDateFiltered = fromDate != null || untilDate != null
+    calculateProfitsForTransactions(transactions, platforms, isDateFiltered)
+    val summary = calculateTransactionSummary(transactions)
+    return TransactionsWithSummaryDto(
+      transactions = transactions.map { TransactionResponseDto.fromEntity(it) },
+      summary = summary,
+    )
+  }
+
+  @Transactional(readOnly = true)
+  fun getTransactionWithProfits(id: Long): TransactionResponseDto {
+    val transaction = transactionService.getTransactionById(id)
+    transactionService.calculateTransactionProfits(listOf(transaction))
+    return TransactionResponseDto.fromEntity(transaction)
+  }
+
+  private fun calculateProfitsForTransactions(
+    transactions: List<PortfolioTransaction>,
+    platforms: List<String>?,
+    isDateFiltered: Boolean,
+  ) {
+    if (transactions.isEmpty()) return
+    if (isDateFiltered) {
+      calculateProfitsWithFullHistory(transactions, platforms)
+    } else {
+      transactionService.calculateTransactionProfits(transactions)
+    }
+  }
+
+  private fun calculateProfitsWithFullHistory(
+    transactions: List<PortfolioTransaction>,
+    platforms: List<String>?,
+  ) {
+    val fullHistory = transactionService.getFullTransactionHistoryForProfitCalculation(transactions, platforms)
+    transactionService.calculateTransactionProfits(fullHistory)
+    val profitMap = fullHistory.associateBy { it.id }
+    transactions.forEach { tx ->
+      profitMap[tx.id]?.let { calculated ->
+        tx.realizedProfit = calculated.realizedProfit
+        tx.unrealizedProfit = calculated.unrealizedProfit
+        tx.remainingQuantity = calculated.remainingQuantity
+        tx.averageCost = calculated.averageCost
+      }
+    }
+  }
+
+  private fun calculateTransactionSummary(transactions: List<PortfolioTransaction>): TransactionSummaryDto {
+    val totalUnrealizedProfit = calculateTotalUnrealizedProfit(transactions)
+    val totalRealizedProfit = calculateTotalRealizedProfit(transactions)
+    val totalInvested = calculateTotalInvested(transactions)
+    return TransactionSummaryDto(
+      totalRealizedProfit = totalRealizedProfit,
+      totalUnrealizedProfit = totalUnrealizedProfit,
+      totalProfit = totalRealizedProfit + totalUnrealizedProfit,
+      totalInvested = totalInvested,
+    )
+  }
+
+  private fun calculateTotalUnrealizedProfit(transactions: List<PortfolioTransaction>): BigDecimal =
+    transactions
+      .groupBy { it.instrument }
+      .entries
+      .sumOf { (instrument, instrumentTransactions) ->
+        investmentMetricsService.calculateInstrumentMetrics(instrument, instrumentTransactions).unrealizedProfit
+      }
+
+  private fun calculateTotalRealizedProfit(transactions: List<PortfolioTransaction>): BigDecimal =
+    transactions
+      .filter { it.transactionType == TransactionType.SELL }
+      .sumOf { it.realizedProfit ?: BigDecimal.ZERO }
+
+  private fun calculateTotalInvested(transactions: List<PortfolioTransaction>): BigDecimal =
+    transactions.sumOf { transaction ->
+      val transactionCost = transaction.price.multiply(transaction.quantity).add(transaction.commission)
+      if (transaction.transactionType == TransactionType.BUY) transactionCost else transactionCost.negate()
+    }
+}

--- a/src/test/kotlin/ee/tenman/portfolio/service/TransactionQueryServiceTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/service/TransactionQueryServiceTest.kt
@@ -1,0 +1,155 @@
+package ee.tenman.portfolio.service
+
+import ch.tutteli.atrium.api.fluent.en_GB.toEqual
+import ch.tutteli.atrium.api.fluent.en_GB.toEqualNumerically
+import ch.tutteli.atrium.api.fluent.en_GB.toHaveSize
+import ch.tutteli.atrium.api.verbs.expect
+import ee.tenman.portfolio.domain.Instrument
+import ee.tenman.portfolio.domain.Platform
+import ee.tenman.portfolio.domain.PortfolioTransaction
+import ee.tenman.portfolio.domain.ProviderName
+import ee.tenman.portfolio.domain.TransactionType
+import ee.tenman.portfolio.model.metrics.InstrumentMetrics
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+
+class TransactionQueryServiceTest {
+  private val transactionService = mockk<TransactionService>()
+  private val investmentMetricsService = mockk<InvestmentMetricsService>()
+  private lateinit var transactionQueryService: TransactionQueryService
+  private lateinit var testInstrument: Instrument
+
+  @BeforeEach
+  fun setUp() {
+    testInstrument =
+      Instrument(
+        symbol = "AAPL",
+        name = "Apple Inc.",
+        category = "Stock",
+        baseCurrency = "USD",
+        currentPrice = BigDecimal("150.00"),
+        providerName = ProviderName.FT,
+      ).apply { id = 1L }
+    transactionQueryService = TransactionQueryService(transactionService, investmentMetricsService)
+  }
+
+  @Test
+  fun `should return transactions with summary without date filter`() {
+    val transaction = createTransaction(TransactionType.BUY, BigDecimal("10"), BigDecimal("100"))
+    val metrics = createMetrics(unrealizedProfit = BigDecimal("500"))
+    every { transactionService.getAllTransactions(null, null, null) } returns listOf(transaction)
+    every { transactionService.calculateTransactionProfits(any()) } returns Unit
+    every { investmentMetricsService.calculateInstrumentMetrics(testInstrument, any()) } returns metrics
+    val result = transactionQueryService.getTransactionsWithSummary(null, null, null)
+    expect(result.transactions).toHaveSize(1)
+    expect(result.summary.totalUnrealizedProfit).toEqualNumerically(BigDecimal("500"))
+    verify { transactionService.calculateTransactionProfits(any()) }
+  }
+
+  @Test
+  fun `should calculate profits with full history when date filtered`() {
+    val transaction = createTransaction(TransactionType.BUY, BigDecimal("10"), BigDecimal("100"))
+    transaction.id = 1L
+    val fullHistoryTx = createTransaction(TransactionType.BUY, BigDecimal("10"), BigDecimal("100"))
+    fullHistoryTx.id = 1L
+    fullHistoryTx.realizedProfit = BigDecimal("50")
+    fullHistoryTx.unrealizedProfit = BigDecimal("100")
+    val metrics = createMetrics(unrealizedProfit = BigDecimal("100"))
+    every { transactionService.getAllTransactions(null, LocalDate.of(2024, 1, 1), null) } returns listOf(transaction)
+    every { transactionService.getFullTransactionHistoryForProfitCalculation(any(), any()) } returns listOf(fullHistoryTx)
+    every { transactionService.calculateTransactionProfits(any()) } returns Unit
+    every { investmentMetricsService.calculateInstrumentMetrics(testInstrument, any()) } returns metrics
+    val result = transactionQueryService.getTransactionsWithSummary(null, LocalDate.of(2024, 1, 1), null)
+    expect(result.transactions).toHaveSize(1)
+    verify { transactionService.getFullTransactionHistoryForProfitCalculation(any(), any()) }
+  }
+
+  @Test
+  fun `should calculate total realized profit from sell transactions`() {
+    val buyTx = createTransaction(TransactionType.BUY, BigDecimal("10"), BigDecimal("100"))
+    val sellTx = createTransaction(TransactionType.SELL, BigDecimal("5"), BigDecimal("120"))
+    sellTx.realizedProfit = BigDecimal("100")
+    val metrics = createMetrics(unrealizedProfit = BigDecimal.ZERO)
+    every { transactionService.getAllTransactions(null, null, null) } returns listOf(buyTx, sellTx)
+    every { transactionService.calculateTransactionProfits(any()) } returns Unit
+    every { investmentMetricsService.calculateInstrumentMetrics(testInstrument, any()) } returns metrics
+    val result = transactionQueryService.getTransactionsWithSummary(null, null, null)
+    expect(result.summary.totalRealizedProfit).toEqualNumerically(BigDecimal("100"))
+  }
+
+  @Test
+  fun `should calculate total invested correctly`() {
+    val buyTx = createTransaction(TransactionType.BUY, BigDecimal("10"), BigDecimal("100"))
+    buyTx.commission = BigDecimal("5")
+    val sellTx = createTransaction(TransactionType.SELL, BigDecimal("5"), BigDecimal("120"))
+    sellTx.commission = BigDecimal("5")
+    val metrics = createMetrics(unrealizedProfit = BigDecimal.ZERO)
+    every { transactionService.getAllTransactions(null, null, null) } returns listOf(buyTx, sellTx)
+    every { transactionService.calculateTransactionProfits(any()) } returns Unit
+    every { investmentMetricsService.calculateInstrumentMetrics(testInstrument, any()) } returns metrics
+    val result = transactionQueryService.getTransactionsWithSummary(null, null, null)
+    expect(result.summary.totalInvested).toEqualNumerically(BigDecimal("400"))
+  }
+
+  @Test
+  fun `should return empty transactions when none exist`() {
+    every { transactionService.getAllTransactions(null, null, null) } returns emptyList()
+    val result = transactionQueryService.getTransactionsWithSummary(null, null, null)
+    expect(result.transactions).toHaveSize(0)
+    expect(result.summary.totalProfit).toEqualNumerically(BigDecimal.ZERO)
+  }
+
+  @Test
+  fun `should get single transaction with profits`() {
+    val transaction = createTransaction(TransactionType.BUY, BigDecimal("10"), BigDecimal("100"))
+    transaction.id = 1L
+    every { transactionService.getTransactionById(1L) } returns transaction
+    every { transactionService.calculateTransactionProfits(any()) } returns Unit
+    val result = transactionQueryService.getTransactionWithProfits(1L)
+    expect(result.instrumentId).toEqual(1L)
+    verify { transactionService.calculateTransactionProfits(listOf(transaction)) }
+  }
+
+  @Test
+  fun `should filter by platforms`() {
+    val transaction = createTransaction(TransactionType.BUY, BigDecimal("10"), BigDecimal("100"))
+    val metrics = createMetrics(unrealizedProfit = BigDecimal("500"))
+    every { transactionService.getAllTransactions(listOf("LHV"), null, null) } returns listOf(transaction)
+    every { transactionService.calculateTransactionProfits(any()) } returns Unit
+    every { investmentMetricsService.calculateInstrumentMetrics(testInstrument, any()) } returns metrics
+    val result = transactionQueryService.getTransactionsWithSummary(listOf("LHV"), null, null)
+    expect(result.transactions).toHaveSize(1)
+    verify { transactionService.getAllTransactions(listOf("LHV"), null, null) }
+  }
+
+  private fun createTransaction(
+    type: TransactionType,
+    quantity: BigDecimal,
+    price: BigDecimal,
+  ): PortfolioTransaction =
+    PortfolioTransaction(
+      instrument = testInstrument,
+      transactionType = type,
+      quantity = quantity,
+      price = price,
+      transactionDate = LocalDate.of(2024, 1, 1),
+      platform = Platform.LHV,
+      commission = BigDecimal.ZERO,
+    )
+
+  private fun createMetrics(unrealizedProfit: BigDecimal): InstrumentMetrics =
+    InstrumentMetrics(
+      totalInvestment = BigDecimal("1000"),
+      currentValue = BigDecimal("1500"),
+      profit = BigDecimal("500"),
+      realizedProfit = BigDecimal.ZERO,
+      unrealizedProfit = unrealizedProfit,
+      xirr = 25.0,
+      quantity = BigDecimal("10"),
+    )
+}


### PR DESCRIPTION
## Summary
- Create `TransactionQueryService` to handle transaction queries with profit calculations
- Move profit calculation and summary aggregation logic from controller to service layer
- Reduce `PortfolioTransactionController` from 164 to 100 lines (39% reduction)
- Controller now only handles HTTP concerns (request parsing, response building)

## Changes
- **New:** `TransactionQueryService.kt` (97 lines) - Handles:
  - `getTransactionsWithSummary()` - Retrieves transactions with calculated profits and summary
  - `getTransactionWithProfits()` - Retrieves single transaction with profits
  - `calculateProfitsForTransactions()` - Handles date-filtered vs non-filtered profit calculation
  - `calculateTransactionSummary()` - Calculates realized/unrealized profits and total invested

- **Updated:** `PortfolioTransactionController.kt` - Now delegates to services:
  - Removed business logic for profit calculation conditionals
  - Removed entity mutation code
  - Removed summary aggregation logic
  - Removed `InvestmentMetricsService` dependency (moved to query service)

## Test plan
- [x] Added 7 tests for TransactionQueryService
- [x] All existing tests pass
- [x] ktlint formatting passes

Closes #1004

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored internal transaction service architecture to improve code maintainability and separation of concerns.
  * Optimized transaction retrieval and profit calculation operations for better performance and organization.
  * Expanded test coverage for transaction query functionality to ensure reliability and stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->