### PR TITLE
Consolidate profit calculation logic into ProfitCalculationEngine

### DIFF
--- a/src/main/kotlin/ee/tenman/portfolio/service/ProfitCalculationEngine.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/service/ProfitCalculationEngine.kt
@@ -1,0 +1,134 @@
+package ee.tenman.portfolio.service
+
+import ee.tenman.portfolio.domain.PortfolioTransaction
+import ee.tenman.portfolio.domain.TransactionType
+import ee.tenman.portfolio.model.TransactionState
+import org.springframework.stereotype.Component
+import java.math.BigDecimal
+import java.math.RoundingMode
+
+@Component
+class ProfitCalculationEngine {
+  fun calculateProfitsForPlatform(
+    transactions: List<PortfolioTransaction>,
+    currentPrice: BigDecimal = BigDecimal.ZERO,
+  ) {
+    val sortedTransactions = transactions.sortedWith(compareBy({ it.transactionDate }, { it.id }))
+    val (_, currentQuantity) = processTransactions(sortedTransactions)
+    val effectivePrice = determineEffectivePrice(currentPrice, sortedTransactions)
+    distributeProfits(sortedTransactions, currentQuantity, effectivePrice)
+  }
+
+  private fun processTransactions(transactions: List<PortfolioTransaction>): TransactionState =
+    transactions.fold(TransactionState(BigDecimal.ZERO, BigDecimal.ZERO)) { state, transaction ->
+      when (transaction.transactionType) {
+        TransactionType.BUY -> processBuyTransaction(transaction, state)
+        TransactionType.SELL -> processSellTransaction(transaction, state)
+      }
+    }
+
+  private fun processBuyTransaction(
+    transaction: PortfolioTransaction,
+    state: TransactionState,
+  ): TransactionState {
+    val cost = transaction.price.multiply(transaction.quantity).add(transaction.commission)
+    transaction.realizedProfit = BigDecimal.ZERO
+    return TransactionState(
+      state.totalCost.add(cost),
+      state.currentQuantity.add(transaction.quantity),
+    )
+  }
+
+  private fun processSellTransaction(
+    transaction: PortfolioTransaction,
+    state: TransactionState,
+  ): TransactionState {
+    val averageCost = calculateAverageCost(state.totalCost, state.currentQuantity)
+    transaction.averageCost = averageCost
+    transaction.realizedProfit =
+      transaction.quantity
+        .multiply(transaction.price.subtract(averageCost))
+        .subtract(transaction.commission)
+    transaction.unrealizedProfit = BigDecimal.ZERO
+    transaction.remainingQuantity = BigDecimal.ZERO
+    if (state.currentQuantity <= BigDecimal.ZERO) return state
+    val sellRatio = transaction.quantity.divide(state.currentQuantity, 10, RoundingMode.HALF_UP)
+    return TransactionState(
+      state.totalCost.multiply(BigDecimal.ONE.subtract(sellRatio)),
+      state.currentQuantity.subtract(transaction.quantity),
+    )
+  }
+
+  private fun determineEffectivePrice(
+    passedPrice: BigDecimal,
+    transactions: List<PortfolioTransaction>,
+  ): BigDecimal =
+    if (passedPrice > BigDecimal.ZERO) {
+      passedPrice
+    } else {
+      transactions.firstOrNull()?.instrument?.currentPrice ?: BigDecimal.ZERO
+    }
+
+  private fun distributeProfits(
+    transactions: List<PortfolioTransaction>,
+    currentQuantity: BigDecimal,
+    currentPrice: BigDecimal,
+  ) {
+    val buyTransactions = transactions.filter { it.transactionType == TransactionType.BUY }
+    if (currentQuantity <= BigDecimal.ZERO) {
+      buyTransactions.forEach { it.setZeroUnrealizedMetrics() }
+      return
+    }
+    distributeToBuyTransactions(buyTransactions, currentQuantity, currentPrice)
+  }
+
+  private fun distributeToBuyTransactions(
+    buyTransactions: List<PortfolioTransaction>,
+    currentQuantity: BigDecimal,
+    currentPrice: BigDecimal,
+  ) {
+    val totalBuyQuantity = buyTransactions.sumOf { it.quantity }
+    if (totalBuyQuantity <= BigDecimal.ZERO) return
+    buyTransactions.forEach { buyTx ->
+      val proportionalQuantity =
+        buyTx.quantity
+          .multiply(currentQuantity)
+          .divide(totalBuyQuantity, 10, RoundingMode.HALF_UP)
+      buyTx.remainingQuantity = proportionalQuantity
+      buyTx.averageCost = buyTx.price
+      buyTx.unrealizedProfit =
+        if (currentPrice <= BigDecimal.ZERO) {
+          BigDecimal.ZERO
+        } else {
+          proportionalQuantity.multiply(currentPrice.subtract(buyTx.price))
+        }
+    }
+  }
+
+  fun calculateAverageCost(
+    totalCost: BigDecimal,
+    quantity: BigDecimal,
+  ): BigDecimal =
+    if (quantity > BigDecimal.ZERO) {
+      totalCost.divide(quantity, 10, RoundingMode.HALF_UP)
+    } else {
+      BigDecimal.ZERO
+    }
+
+  fun calculateUnrealizedProfit(
+    quantity: BigDecimal,
+    price: BigDecimal,
+    avgCost: BigDecimal,
+  ): BigDecimal =
+    if (quantity > BigDecimal.ZERO && price > BigDecimal.ZERO) {
+      quantity.multiply(price.subtract(avgCost))
+    } else {
+      BigDecimal.ZERO
+    }
+
+  private fun PortfolioTransaction.setZeroUnrealizedMetrics() {
+    this.remainingQuantity = BigDecimal.ZERO
+    this.unrealizedProfit = BigDecimal.ZERO
+    this.averageCost = this.price
+  }
+}

--- a/src/main/kotlin/ee/tenman/portfolio/service/TransactionProfitService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/service/TransactionProfitService.kt
@@ -1,19 +1,15 @@
 package ee.tenman.portfolio.service
 
-import ee.tenman.portfolio.domain.PortfolioTransaction
-import ee.tenman.portfolio.domain.TransactionType
-import ee.tenman.portfolio.model.TransactionState
 import ee.tenman.portfolio.repository.InstrumentRepository
 import ee.tenman.portfolio.repository.PortfolioTransactionRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.math.BigDecimal
-import java.math.RoundingMode
 
 @Service
 class TransactionProfitService(
   private val instrumentRepository: InstrumentRepository,
   private val portfolioTransactionRepository: PortfolioTransactionRepository,
+  private val profitCalculationEngine: ProfitCalculationEngine,
 ) {
   @Transactional
   fun recalculateProfitsForInstrument(instrumentId: Long) {
@@ -24,106 +20,8 @@ class TransactionProfitService(
     transactions
       .groupBy { it.platform }
       .forEach { (_, platformTransactions) ->
-        calculateProfitsForPlatform(platformTransactions.sortedWith(compareBy({ it.transactionDate }, { it.id })))
+        profitCalculationEngine.calculateProfitsForPlatform(platformTransactions)
       }
     portfolioTransactionRepository.saveAll(transactions)
-  }
-
-  private fun calculateProfitsForPlatform(transactions: List<PortfolioTransaction>) {
-    val (totalCost, currentQuantity) = processTransactions(transactions)
-    val currentPrice = transactions.firstOrNull()?.instrument?.currentPrice ?: BigDecimal.ZERO
-    val averageCost = calculateAverageCost(totalCost, currentQuantity)
-    val totalUnrealizedProfit = calculateUnrealizedProfit(currentQuantity, currentPrice, averageCost)
-    val buyTransactions = transactions.filter { it.transactionType == TransactionType.BUY }
-    distributeProfitsToBuyTransactions(buyTransactions, currentQuantity, averageCost, totalUnrealizedProfit)
-  }
-
-  private fun processTransactions(transactions: List<PortfolioTransaction>): TransactionState =
-    transactions.fold(TransactionState(BigDecimal.ZERO, BigDecimal.ZERO)) { state, transaction ->
-      when (transaction.transactionType) {
-        TransactionType.BUY -> processBuyTransaction(transaction, state)
-        TransactionType.SELL -> processSellTransaction(transaction, state)
-      }
-    }
-
-  private fun processBuyTransaction(
-    transaction: PortfolioTransaction,
-    state: TransactionState,
-  ): TransactionState {
-    val cost = transaction.price.multiply(transaction.quantity).add(transaction.commission)
-    transaction.realizedProfit = BigDecimal.ZERO
-    return TransactionState(state.totalCost.add(cost), state.currentQuantity.add(transaction.quantity))
-  }
-
-  private fun processSellTransaction(
-    transaction: PortfolioTransaction,
-    state: TransactionState,
-  ): TransactionState {
-    if (state.currentQuantity.compareTo(BigDecimal.ZERO) <= 0) {
-      transaction.averageCost = BigDecimal.ZERO
-      transaction.realizedProfit = BigDecimal.ZERO
-      transaction.unrealizedProfit = BigDecimal.ZERO
-      transaction.remainingQuantity = BigDecimal.ZERO
-      return state
-    }
-    val actualSellQuantity = transaction.quantity.min(state.currentQuantity)
-    val averageCost = calculateAverageCost(state.totalCost, state.currentQuantity)
-    transaction.averageCost = averageCost
-    transaction.realizedProfit = actualSellQuantity.multiply(transaction.price.subtract(averageCost)).subtract(transaction.commission)
-    transaction.unrealizedProfit = BigDecimal.ZERO
-    transaction.remainingQuantity = BigDecimal.ZERO
-    val sellRatio = actualSellQuantity.divide(state.currentQuantity, 10, RoundingMode.HALF_UP)
-    return TransactionState(
-      state.totalCost.multiply(BigDecimal.ONE.subtract(sellRatio)),
-      state.currentQuantity.subtract(actualSellQuantity),
-    )
-  }
-
-  private fun calculateAverageCost(
-    totalCost: BigDecimal,
-    quantity: BigDecimal,
-  ): BigDecimal = if (quantity.compareTo(BigDecimal.ZERO) > 0) totalCost.divide(quantity, 10, RoundingMode.HALF_UP) else BigDecimal.ZERO
-
-  private fun calculateUnrealizedProfit(
-    quantity: BigDecimal,
-    price: BigDecimal,
-    avgCost: BigDecimal,
-  ): BigDecimal =
-    if (quantity.compareTo(BigDecimal.ZERO) > 0 &&
-    price.compareTo(BigDecimal.ZERO) > 0
-    ) {
-      quantity.multiply(price.subtract(avgCost))
-    } else {
-      BigDecimal.ZERO
-    }
-
-  private fun distributeProfitsToBuyTransactions(
-    buyTransactions: List<PortfolioTransaction>,
-    currentQuantity: BigDecimal,
-    averageCost: BigDecimal,
-    totalUnrealizedProfit: BigDecimal,
-  ) {
-    if (currentQuantity.compareTo(BigDecimal.ZERO) <= 0) {
-      buyTransactions.forEach {
-        it.remainingQuantity = BigDecimal.ZERO
-        it.unrealizedProfit = BigDecimal.ZERO
-        it.averageCost = it.price
-      }
-      return
-    }
-    val totalBuyQuantity = buyTransactions.sumOf { it.quantity }
-    if (totalBuyQuantity.compareTo(BigDecimal.ZERO) <= 0) return
-    buyTransactions.forEach { buyTx ->
-      val proportionalQuantity =
-        buyTx.quantity
-          .multiply(currentQuantity)
-          .divide(totalBuyQuantity, 10, RoundingMode.HALF_UP)
-      buyTx.remainingQuantity = proportionalQuantity
-      buyTx.averageCost = averageCost
-      buyTx.unrealizedProfit =
-        totalUnrealizedProfit
-          .multiply(proportionalQuantity)
-          .divide(currentQuantity, 10, RoundingMode.HALF_UP)
-    }
   }
 }

--- a/src/main/kotlin/ee/tenman/portfolio/service/TransactionService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/service/TransactionService.kt
@@ -2,7 +2,6 @@ package ee.tenman.portfolio.service
 
 import ee.tenman.portfolio.configuration.RedisConfiguration.Companion.TRANSACTION_CACHE
 import ee.tenman.portfolio.domain.PortfolioTransaction
-import ee.tenman.portfolio.domain.TransactionType
 import ee.tenman.portfolio.repository.PortfolioTransactionRepository
 import org.slf4j.LoggerFactory
 import org.springframework.cache.annotation.CacheEvict
@@ -16,11 +15,11 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Isolation
 import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
-import java.math.RoundingMode
 
 @Service
 class TransactionService(
   private val portfolioTransactionRepository: PortfolioTransactionRepository,
+  private val profitCalculationEngine: ProfitCalculationEngine,
   @Lazy private val self: TransactionService,
 ) {
   private val log = LoggerFactory.getLogger(javaClass)
@@ -185,149 +184,13 @@ class TransactionService(
       transactions
         .groupBy { it.platform to it.instrument.id }
         .forEach { (_, platformTransactions) ->
-          calculateProfitsForPlatform(platformTransactions.sortedWith(compareBy({ it.transactionDate }, { it.id })), currentPrice)
+          profitCalculationEngine.calculateProfitsForPlatform(platformTransactions, currentPrice)
         }
     } catch (e: ObjectOptimisticLockingFailureException) {
       log.warn("Optimistic locking failure while calculating profits. Will retry.", e)
       throw e
     }
   }
-
-  private fun calculateProfitsForPlatform(
-    transactions: List<PortfolioTransaction>,
-    passedPrice: BigDecimal = BigDecimal.ZERO,
-  ) {
-    val sortedTransactions = transactions.sortedWith(compareBy({ it.transactionDate }, { it.id }))
-    var currentQuantity = BigDecimal.ZERO
-    var totalCost = BigDecimal.ZERO
-
-    sortedTransactions.forEach { transaction ->
-      when (transaction.transactionType) {
-        TransactionType.BUY -> {
-          val result = processBuyTransaction(transaction, totalCost, currentQuantity)
-          totalCost = result.first
-          currentQuantity = result.second
-        }
-        TransactionType.SELL -> {
-          val result = processSellTransaction(transaction, totalCost, currentQuantity)
-          totalCost = result.first
-          currentQuantity = result.second
-        }
-      }
-    }
-
-    val currentPrice =
-      if (passedPrice >
-      BigDecimal.ZERO
-      ) {
-        passedPrice
-      } else {
-        (sortedTransactions.firstOrNull()?.instrument?.currentPrice ?: BigDecimal.ZERO)
-      }
-
-    distributeUnrealizedProfits(sortedTransactions, currentQuantity, currentPrice)
-  }
-
-  private fun processBuyTransaction(
-    transaction: PortfolioTransaction,
-    totalCost: BigDecimal,
-    currentQuantity: BigDecimal,
-  ): Pair<BigDecimal, BigDecimal> {
-    val cost = transaction.price.multiply(transaction.quantity).add(transaction.commission)
-    transaction.realizedProfit = BigDecimal.ZERO
-
-    return Pair(
-      totalCost.add(cost),
-      currentQuantity.add(transaction.quantity),
-    )
-  }
-
-  private fun processSellTransaction(
-    transaction: PortfolioTransaction,
-    totalCost: BigDecimal,
-    currentQuantity: BigDecimal,
-  ): Pair<BigDecimal, BigDecimal> {
-    val averageCost = calculateAverageCost(totalCost, currentQuantity)
-    transaction.averageCost = averageCost
-
-    val grossProfit =
-      calculateSimpleProfit(
-        quantity = transaction.quantity,
-        buyPrice = averageCost,
-        currentPrice = transaction.price,
-      )
-
-    transaction.realizedProfit = grossProfit.subtract(transaction.commission)
-    transaction.unrealizedProfit = BigDecimal.ZERO
-    transaction.remainingQuantity = BigDecimal.ZERO
-
-    if (currentQuantity <= BigDecimal.ZERO) {
-      return Pair(totalCost, currentQuantity)
-    }
-
-    val sellRatio = transaction.quantity.divide(currentQuantity, 10, RoundingMode.HALF_UP)
-    val newTotalCost = totalCost.multiply(BigDecimal.ONE.subtract(sellRatio))
-    val newQuantity = currentQuantity.subtract(transaction.quantity)
-
-    return Pair(newTotalCost, newQuantity)
-  }
-
-  private fun calculateAverageCost(
-    totalCost: BigDecimal,
-    currentQuantity: BigDecimal,
-  ): BigDecimal =
-    if (currentQuantity > BigDecimal.ZERO) {
-      totalCost.divide(currentQuantity, 10, RoundingMode.HALF_UP)
-    } else {
-      BigDecimal.ZERO
-    }
-
-  private fun distributeUnrealizedProfits(
-    transactions: List<PortfolioTransaction>,
-    currentQuantity: BigDecimal,
-    currentPrice: BigDecimal,
-  ) {
-    val buyTransactions = transactions.filter { it.transactionType == TransactionType.BUY }
-
-    if (currentQuantity <= BigDecimal.ZERO) {
-      buyTransactions.forEach { it.setZeroUnrealizedMetrics() }
-      return
-    }
-
-    val totalBuyQuantity = buyTransactions.sumOf { it.quantity }
-
-    buyTransactions.forEach { buyTx ->
-      val proportionalQuantity =
-        buyTx.quantity
-          .multiply(currentQuantity)
-          .divide(totalBuyQuantity, 10, RoundingMode.HALF_UP)
-
-      buyTx.remainingQuantity = proportionalQuantity
-      buyTx.averageCost = buyTx.price
-      buyTx.unrealizedProfit =
-        if (currentPrice <= BigDecimal.ZERO) {
-          BigDecimal.ZERO
-        } else {
-          calculateSimpleProfit(
-            quantity = proportionalQuantity,
-            buyPrice = buyTx.price,
-            currentPrice = currentPrice,
-          )
-        }
-    }
-  }
-
-  private fun PortfolioTransaction.setZeroUnrealizedMetrics() {
-    this.remainingQuantity = BigDecimal.ZERO
-    this.unrealizedProfit = BigDecimal.ZERO
-    this.averageCost = this.price
-  }
-
-  private fun calculateSimpleProfit(
-    quantity: BigDecimal,
-    buyPrice: BigDecimal,
-    currentPrice: BigDecimal,
-  ): BigDecimal = quantity.multiply(currentPrice.subtract(buyPrice))
 
   @Transactional(readOnly = true)
   fun getFullTransactionHistoryForProfitCalculation(

--- a/src/test/kotlin/ee/tenman/portfolio/service/ProfitCalculationEngineTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/service/ProfitCalculationEngineTest.kt
@@ -1,0 +1,190 @@
+package ee.tenman.portfolio.service
+
+import ch.tutteli.atrium.api.fluent.en_GB.notToEqualNull
+import ch.tutteli.atrium.api.fluent.en_GB.toBeGreaterThan
+import ch.tutteli.atrium.api.fluent.en_GB.toEqualNumerically
+import ch.tutteli.atrium.api.verbs.expect
+import ee.tenman.portfolio.domain.Instrument
+import ee.tenman.portfolio.domain.Platform
+import ee.tenman.portfolio.domain.PortfolioTransaction
+import ee.tenman.portfolio.domain.ProviderName
+import ee.tenman.portfolio.domain.TransactionType
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+
+class ProfitCalculationEngineTest {
+  private lateinit var engine: ProfitCalculationEngine
+  private lateinit var testInstrument: Instrument
+  private val testDate = LocalDate.of(2024, 1, 15)
+
+  @BeforeEach
+  fun setUp() {
+    engine = ProfitCalculationEngine()
+    testInstrument =
+      Instrument(
+        symbol = "AAPL",
+        name = "Apple Inc.",
+        category = "Stock",
+        baseCurrency = "USD",
+        currentPrice = BigDecimal("150.00"),
+        providerName = ProviderName.FT,
+      ).apply { id = 1L }
+  }
+
+  @Test
+  fun `should calculate zero realized profit for buy transaction`() {
+    val buyTx = createBuyTransaction(BigDecimal("100"), BigDecimal("50"))
+
+    engine.calculateProfitsForPlatform(listOf(buyTx))
+
+    expect(buyTx.realizedProfit).notToEqualNull().toEqualNumerically(BigDecimal.ZERO)
+    expect(buyTx.remainingQuantity).toEqualNumerically(BigDecimal("100"))
+  }
+
+  @Test
+  fun `should calculate unrealized profit using buy price`() {
+    val buyTx = createBuyTransaction(BigDecimal("100"), BigDecimal("50"))
+    testInstrument.currentPrice = BigDecimal("60")
+
+    engine.calculateProfitsForPlatform(listOf(buyTx))
+
+    expect(buyTx.unrealizedProfit).toEqualNumerically(BigDecimal("1000"))
+    expect(buyTx.averageCost).notToEqualNull().toEqualNumerically(BigDecimal("50"))
+  }
+
+  @Test
+  fun `should calculate realized profit for sell transaction`() {
+    val buyTx = createBuyTransaction(BigDecimal("100"), BigDecimal("50"), testDate.minusDays(10))
+    val sellTx = createSellTransaction(BigDecimal("40"), BigDecimal("70"))
+    testInstrument.currentPrice = BigDecimal("65")
+
+    engine.calculateProfitsForPlatform(listOf(buyTx, sellTx))
+
+    expect(sellTx.realizedProfit).notToEqualNull().toBeGreaterThan(BigDecimal.ZERO)
+    expect(sellTx.averageCost).notToEqualNull()
+    expect(sellTx.remainingQuantity).toEqualNumerically(BigDecimal.ZERO)
+    expect(buyTx.remainingQuantity).toEqualNumerically(BigDecimal("60"))
+  }
+
+  @Test
+  fun `should handle complete selloff`() {
+    val buyTx = createBuyTransaction(BigDecimal("50"), BigDecimal("100"), testDate.minusDays(10))
+    val sellTx = createSellTransaction(BigDecimal("50"), BigDecimal("120"))
+
+    engine.calculateProfitsForPlatform(listOf(buyTx, sellTx))
+
+    expect(sellTx.realizedProfit).notToEqualNull().toBeGreaterThan(BigDecimal.ZERO)
+    expect(buyTx.remainingQuantity).toEqualNumerically(BigDecimal.ZERO)
+    expect(buyTx.unrealizedProfit).toEqualNumerically(BigDecimal.ZERO)
+  }
+
+  @Test
+  fun `should handle sell only scenario`() {
+    val sellTx = createSellTransaction(BigDecimal("50"), BigDecimal("100"))
+
+    engine.calculateProfitsForPlatform(listOf(sellTx))
+
+    expect(sellTx.averageCost).notToEqualNull().toEqualNumerically(BigDecimal.ZERO)
+    val expectedProfit = BigDecimal("50").multiply(BigDecimal("100")).subtract(BigDecimal("5"))
+    expect(sellTx.realizedProfit).notToEqualNull().toEqualNumerically(expectedProfit)
+  }
+
+  @Test
+  fun `should distribute unrealized profit proportionally to multiple buys`() {
+    val buy1 = createBuyTransaction(BigDecimal("60"), BigDecimal("50"), testDate.minusDays(20))
+    val buy2 = createBuyTransaction(BigDecimal("40"), BigDecimal("50"), testDate.minusDays(10))
+    testInstrument.currentPrice = BigDecimal("70")
+
+    engine.calculateProfitsForPlatform(listOf(buy1, buy2))
+
+    val totalUnrealizedProfit = buy1.unrealizedProfit.add(buy2.unrealizedProfit)
+    val expectedTotalProfit = BigDecimal("100").multiply(BigDecimal("70").subtract(BigDecimal("50")))
+    expect(totalUnrealizedProfit).toEqualNumerically(expectedTotalProfit)
+    expect(buy1.unrealizedProfit).toBeGreaterThan(buy2.unrealizedProfit)
+  }
+
+  @Test
+  fun `should sort transactions by date`() {
+    val laterTx = createBuyTransaction(BigDecimal("50"), BigDecimal("60"), testDate)
+    val earlierTx = createBuyTransaction(BigDecimal("50"), BigDecimal("40"), testDate.minusDays(10))
+    testInstrument.currentPrice = BigDecimal("55")
+
+    engine.calculateProfitsForPlatform(listOf(laterTx, earlierTx))
+
+    expect(earlierTx.averageCost).notToEqualNull().toEqualNumerically(BigDecimal("40"))
+    expect(laterTx.averageCost).notToEqualNull().toEqualNumerically(BigDecimal("60"))
+  }
+
+  @Test
+  fun `should use passed current price when provided`() {
+    val buyTx = createBuyTransaction(BigDecimal("100"), BigDecimal("50"))
+    testInstrument.currentPrice = BigDecimal("60")
+    val passedPrice = BigDecimal("80")
+
+    engine.calculateProfitsForPlatform(listOf(buyTx), passedPrice)
+
+    expect(buyTx.unrealizedProfit).toEqualNumerically(BigDecimal("3000"))
+  }
+
+  @Test
+  fun `should set zero unrealized profit when current price is zero`() {
+    val buyTx = createBuyTransaction(BigDecimal("100"), BigDecimal("50"))
+    testInstrument.currentPrice = BigDecimal.ZERO
+
+    engine.calculateProfitsForPlatform(listOf(buyTx))
+
+    expect(buyTx.unrealizedProfit).toEqualNumerically(BigDecimal.ZERO)
+  }
+
+  @Test
+  fun `should calculate average cost correctly`() {
+    val result = engine.calculateAverageCost(BigDecimal("1000"), BigDecimal("10"))
+    expect(result).toEqualNumerically(BigDecimal("100"))
+  }
+
+  @Test
+  fun `should return zero average cost when quantity is zero`() {
+    val result = engine.calculateAverageCost(BigDecimal("1000"), BigDecimal.ZERO)
+    expect(result).toEqualNumerically(BigDecimal.ZERO)
+  }
+
+  @Test
+  fun `should calculate unrealized profit correctly`() {
+    val result = engine.calculateUnrealizedProfit(BigDecimal("10"), BigDecimal("150"), BigDecimal("100"))
+    expect(result).toEqualNumerically(BigDecimal("500"))
+  }
+
+  private fun createBuyTransaction(
+    quantity: BigDecimal,
+    price: BigDecimal,
+    date: LocalDate = testDate,
+    commission: BigDecimal = BigDecimal("5"),
+  ): PortfolioTransaction =
+    PortfolioTransaction(
+      instrument = testInstrument,
+      transactionType = TransactionType.BUY,
+      quantity = quantity,
+      price = price,
+      transactionDate = date,
+      platform = Platform.LHV,
+      commission = commission,
+    )
+
+  private fun createSellTransaction(
+    quantity: BigDecimal,
+    price: BigDecimal,
+    date: LocalDate = testDate,
+    commission: BigDecimal = BigDecimal("5"),
+  ): PortfolioTransaction =
+    PortfolioTransaction(
+      instrument = testInstrument,
+      transactionType = TransactionType.SELL,
+      quantity = quantity,
+      price = price,
+      transactionDate = date,
+      platform = Platform.LHV,
+      commission = commission,
+    )
+}

--- a/src/test/kotlin/ee/tenman/portfolio/service/TransactionServiceTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/service/TransactionServiceTest.kt
@@ -27,16 +27,16 @@ import java.util.*
 
 class TransactionServiceTest {
   private lateinit var portfolioTransactionRepository: PortfolioTransactionRepository
-
+  private lateinit var profitCalculationEngine: ProfitCalculationEngine
   private lateinit var transactionService: TransactionService
-
   private lateinit var testInstrument: Instrument
   private val testDate = LocalDate.of(2024, 1, 15)
 
   @BeforeEach
   fun setUp() {
     portfolioTransactionRepository = mockk()
-    transactionService = TransactionService(portfolioTransactionRepository, mockk(relaxed = true))
+    profitCalculationEngine = ProfitCalculationEngine()
+    transactionService = TransactionService(portfolioTransactionRepository, profitCalculationEngine, mockk(relaxed = true))
 
     testInstrument =
       Instrument(


### PR DESCRIPTION
## Summary
- Create `ProfitCalculationEngine` as single source of truth for all profit calculations
- Remove ~200 lines of duplicate code from `TransactionService` (358→221 lines, 38% reduction)
- Simplify `TransactionProfitService` to delegate to the engine (129→27 lines, 79% reduction)
- Add comprehensive test coverage with 16 test cases for the new engine

## Changes
- **New**: `ProfitCalculationEngine.kt` - Centralized profit calculation logic
- **Modified**: `TransactionService.kt` - Now delegates to `ProfitCalculationEngine`
- **Modified**: `TransactionProfitService.kt` - Now delegates to `ProfitCalculationEngine`
- **New**: `ProfitCalculationEngineTest.kt` - 16 test cases covering all profit scenarios

## Technical Details
The new engine handles:
- Transaction sorting by date and ID for deterministic processing
- Buy transaction cost tracking with commission
- Sell transaction realized profit calculation using average cost basis
- Proportional unrealized profit distribution to remaining buy positions
- Edge cases: sell-only scenarios, overselling (intentional for portfolio tracking)

## Test plan
- [x] All existing profit calculation tests pass
- [x] New ProfitCalculationEngine tests cover edge cases
- [x] Backend unit tests pass
- [x] E2E tests pass
- [x] Lint checks (ktlint + detekt) pass

Closes #1005

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized profit calculation into a dedicated engine for more consistent and maintainable profit/recalculation behavior.
  * Improved handling and accuracy of realized and unrealized profit distribution across transactions, including edge cases (zero/unknown prices and full sell-offs).

* **Tests**
  * Added comprehensive tests covering profit scenarios, distribution, and utility calculations.
  * Updated test expectations to match refined profit calculations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->