### PR TITLE
Implement circuit breaker with fallback retry for OpenRouter API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ keycloak-data/
 
 ### PlantUML ###
 plantuml*.jar
+
+### macOS ###
+.DS_Store

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,18 @@ This is a **Portfolio Management System** - a production-ready, full-stack appli
 - Infrastructure: Docker, Kubernetes, Caddy reverse proxy
 - Additional Services: Google Cloud Vision API
 
+## Git Branching Strategy
+
+When working on features or bug fixes:
+
+1. **Always create a branch from the related GitHub issue** when possible
+   - Use format: `feature/<issue-number>-<short-description>` (e.g., `feature/1035-circuit-breaker-openrouter`)
+   - For bug fixes: `fix/<issue-number>-<short-description>`
+2. **Never commit directly to main** for non-trivial changes
+3. **Create PRs that reference the issue** with "Closes #XXX" or "Fixes #XXX"
+4. **If CI fails on main**, reset main to the last good commit and move failing changes to a feature branch
+5. **Squash related commits** when moving work to a feature branch to keep history clean and then squash and then close pr and create new pr
+
 ## Essential Commands
 
 ### Quick Start
@@ -531,7 +543,7 @@ This codebase has been systematically refactored following clean code principles
 
 #### 1. Guard Clauses Pattern
 
-Replace nested if-else with early returns:
+Replace nested if-else with early returns. Check for the negative/null case first and return early:
 
 ```kotlin
 fun calculateSummaryForDate(date: LocalDate): PortfolioDailySummary {
@@ -543,6 +555,23 @@ fun calculateSummaryForDate(date: LocalDate): PortfolioDailySummary {
   return calculateHistoricalSummary(date)
 }
 ```
+
+**Null Check Pattern:** Always check for null first and return early, then proceed with the happy path:
+
+```kotlin
+private fun parseResponse(response: Response): Result? {
+  val content = response.content ?: return null
+  val sector = IndustrySector.fromDisplayName(content)
+  if (sector == null) {
+    log.warn("Unknown sector: {}", content)
+    return null
+  }
+  log.info("Classified as {}", sector.displayName)
+  return Result(sector = sector)
+}
+```
+
+**Key principle:** Check for the negative case (`== null`) and return early, keeping the happy path at the end without nesting.
 
 **Benefits:** Reduces nesting from 3 levels to 1, improves readability by 40%
 
@@ -619,18 +648,6 @@ When creating pull requests:
 - Include a Summary section with bullet points
 - Include a Test plan section with checkboxes
 - Reference related issues with "Closes #XXX" or "Fixes #XXX"
-
-## Git Branching Strategy
-
-When working on features or bug fixes:
-
-1. **Always create a branch from the related GitHub issue** when possible
-   - Use format: `feature/<issue-number>-<short-description>` (e.g., `feature/1035-circuit-breaker-openrouter`)
-   - For bug fixes: `fix/<issue-number>-<short-description>`
-2. **Never commit directly to main** for non-trivial changes
-3. **Create PRs that reference the issue** with "Closes #XXX" or "Fixes #XXX"
-4. **If CI fails on main**, reset main to the last good commit and move failing changes to a feature branch
-5. **Squash related commits** when moving work to a feature branch to keep history clean
 
 ## Kotlin/Backend Design Principles
 

--- a/src/main/kotlin/ee/tenman/portfolio/domain/AiModel.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/domain/AiModel.kt
@@ -1,0 +1,14 @@
+package ee.tenman.portfolio.domain
+
+enum class AiModel(
+  val modelId: String,
+  val rateLimitPerMinute: Int,
+) {
+  CLAUDE_3_HAIKU("anthropic/claude-3-haiku", 30),
+  CLAUDE_HAIKU_4_5("anthropic/claude-haiku-4.5", 7),
+  ;
+
+  companion object {
+    fun fromModelId(modelId: String): AiModel? = entries.find { it.modelId.equals(modelId, ignoreCase = true) }
+  }
+}

--- a/src/main/kotlin/ee/tenman/portfolio/domain/EtfHolding.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/domain/EtfHolding.kt
@@ -2,6 +2,8 @@ package ee.tenman.portfolio.domain
 
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import jakarta.persistence.Table
 import jakarta.persistence.UniqueConstraint
 
@@ -19,4 +21,7 @@ class EtfHolding(
   var name: String,
   @Column(length = 150)
   var sector: String? = null,
+  @Enumerated(EnumType.STRING)
+  @Column(name = "classified_by_model", length = 100)
+  var classifiedByModel: AiModel? = null,
 ) : BaseEntity()

--- a/src/main/kotlin/ee/tenman/portfolio/job/EtfHoldingsClassificationJob.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/job/EtfHoldingsClassificationJob.kt
@@ -1,7 +1,6 @@
 package ee.tenman.portfolio.job
 
 import ee.tenman.portfolio.domain.EtfHolding
-import ee.tenman.portfolio.domain.IndustrySector
 import ee.tenman.portfolio.model.ClassificationOutcome
 import ee.tenman.portfolio.model.ClassificationResult
 import ee.tenman.portfolio.service.EtfHoldingPersistenceService
@@ -74,13 +73,13 @@ class EtfHoldingsClassificationJob(
         return ClassificationOutcome.SKIPPED
       }
     log.info("Classifying: ${holding.name}")
-    val sector: IndustrySector? = industryClassificationService.classifyCompany(holding.name)
-    if (sector == null) {
-      log.warn("Classification returned null for: ${holding.name}")
-      return ClassificationOutcome.FAILURE
-    }
-    etfHoldingPersistenceService.updateSector(holdingId, sector.displayName)
-    log.info("Successfully classified '${holding.name}' as '${sector.displayName}'")
+    val result =
+      industryClassificationService.classifyCompanyWithModel(holding.name) ?: run {
+        log.warn("Classification returned null for: ${holding.name}")
+        return ClassificationOutcome.FAILURE
+      }
+    etfHoldingPersistenceService.updateSector(holdingId, result.sector.displayName, result.model)
+    log.info("Successfully classified '${holding.name}' as '${result.sector.displayName}' using model ${result.model}")
     return ClassificationOutcome.SUCCESS
   }
 }

--- a/src/main/kotlin/ee/tenman/portfolio/openrouter/CircuitBreakerProperties.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/openrouter/CircuitBreakerProperties.kt
@@ -1,0 +1,11 @@
+package ee.tenman.portfolio.openrouter
+
+data class CircuitBreakerProperties(
+  val failureThreshold: Int = 3,
+  val recoveryTimeoutSeconds: Long = 60,
+) {
+  init {
+    require(failureThreshold > 0) { "failureThreshold must be positive" }
+    require(recoveryTimeoutSeconds > 0) { "recoveryTimeoutSeconds must be positive" }
+  }
+}

--- a/src/main/kotlin/ee/tenman/portfolio/openrouter/ModelSelection.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/openrouter/ModelSelection.kt
@@ -1,0 +1,6 @@
+package ee.tenman.portfolio.openrouter
+
+data class ModelSelection(
+  val modelId: String,
+  val isUsingFallback: Boolean,
+)

--- a/src/main/kotlin/ee/tenman/portfolio/openrouter/OpenRouterCircuitBreaker.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/openrouter/OpenRouterCircuitBreaker.kt
@@ -1,0 +1,143 @@
+package ee.tenman.portfolio.openrouter
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import java.time.Clock
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
+
+@Component
+class OpenRouterCircuitBreaker(
+  private val properties: OpenRouterProperties,
+  private val clock: Clock = Clock.systemUTC(),
+) {
+  private val log = LoggerFactory.getLogger(javaClass)
+  private val lastPrimaryRequestTime = AtomicLong(0)
+  private val lastFallbackRequestTime = AtomicLong(0)
+  private val circuitBreaker: CircuitBreaker
+  private val primaryModel = properties.primaryModel
+  private val fallbackModel = properties.fallbackModel
+
+  companion object {
+    private const val MILLISECONDS_PER_MINUTE = 60_000L
+  }
+
+  init {
+    val config =
+      CircuitBreakerConfig
+        .custom()
+        .failureRateThreshold(100f)
+        .slidingWindowType(CircuitBreakerConfig.SlidingWindowType.COUNT_BASED)
+        .slidingWindowSize(properties.circuitBreaker.failureThreshold)
+        .minimumNumberOfCalls(properties.circuitBreaker.failureThreshold)
+        .waitDurationInOpenState(Duration.ofSeconds(properties.circuitBreaker.recoveryTimeoutSeconds))
+        .permittedNumberOfCallsInHalfOpenState(1)
+        .automaticTransitionFromOpenToHalfOpenEnabled(true)
+        .build()
+    val registry = CircuitBreakerRegistry.of(config)
+    circuitBreaker = registry.circuitBreaker("openrouter")
+    circuitBreaker.eventPublisher
+      .onStateTransition { event ->
+        log.info(
+          "Circuit breaker state transition: {} -> {}",
+          event.stateTransition.fromState,
+          event.stateTransition.toState,
+        )
+      }
+  }
+
+  fun selectModel(): ModelSelection {
+    val state = circuitBreaker.state
+    val model =
+      when (state) {
+        CircuitBreaker.State.CLOSED, CircuitBreaker.State.HALF_OPEN -> primaryModel
+        else -> fallbackModel
+      }
+    return ModelSelection(
+      modelId = model.modelId,
+      isUsingFallback = state == CircuitBreaker.State.OPEN,
+    )
+  }
+
+  fun selectFallbackModel(): ModelSelection =
+    ModelSelection(
+      modelId = fallbackModel.modelId,
+      isUsingFallback = true,
+    )
+
+  fun getCurrentModel(): String = selectModel().modelId
+
+  fun isUsingFallback(): Boolean = circuitBreaker.state == CircuitBreaker.State.OPEN
+
+  fun canMakeRequest(): Boolean =
+    when {
+      isUsingFallback() -> canUseFallback()
+      else -> canUsePrimary()
+    }
+
+  fun tryAcquireRateLimit(isUsingFallback: Boolean): Boolean =
+    when {
+      isUsingFallback -> tryAcquireFallback()
+      else -> tryAcquirePrimary()
+    }
+
+  fun tryAcquirePrimary(): Boolean = tryAcquireWithRateLimit(lastPrimaryRequestTime, primaryRateLimitMs(), "Primary")
+
+  fun tryAcquireFallback(): Boolean = tryAcquireWithRateLimit(lastFallbackRequestTime, fallbackRateLimitMs(), "Fallback")
+
+  private fun primaryRateLimitMs(): Long = MILLISECONDS_PER_MINUTE / primaryModel.rateLimitPerMinute
+
+  private fun fallbackRateLimitMs(): Long = MILLISECONDS_PER_MINUTE / fallbackModel.rateLimitPerMinute
+
+  private fun tryAcquireWithRateLimit(
+    lastRequestTime: AtomicLong,
+    rateLimitMs: Long,
+    modelType: String,
+  ): Boolean {
+    while (true) {
+      val now = clock.millis()
+      val lastRequest = lastRequestTime.get()
+      if ((now - lastRequest) < rateLimitMs) {
+        log.debug("{} rate limit active, {} ms until next request allowed", modelType, rateLimitMs - (now - lastRequest))
+        return false
+      }
+      if (lastRequestTime.compareAndSet(lastRequest, now)) {
+        return true
+      }
+    }
+  }
+
+  fun recordSuccess() {
+    circuitBreaker.onSuccess(0, TimeUnit.MILLISECONDS)
+    log.debug("Recorded success, circuit breaker state: {}", circuitBreaker.state)
+  }
+
+  fun recordFailure(throwable: Throwable) {
+    circuitBreaker.onError(0, TimeUnit.MILLISECONDS, throwable)
+    log.warn("Recorded failure, circuit breaker state: {}", circuitBreaker.state)
+  }
+
+  private fun canUsePrimary(): Boolean = (clock.millis() - lastPrimaryRequestTime.get()) >= primaryRateLimitMs()
+
+  private fun canUseFallback(): Boolean = (clock.millis() - lastFallbackRequestTime.get()) >= fallbackRateLimitMs()
+
+  fun getState(): CircuitBreaker.State = circuitBreaker.state
+
+  fun transitionToHalfOpenState() {
+    circuitBreaker.transitionToHalfOpenState()
+  }
+
+  fun reset() {
+    circuitBreaker.reset()
+    resetRateLimits()
+  }
+
+  fun resetRateLimits() {
+    lastPrimaryRequestTime.set(0)
+    lastFallbackRequestTime.set(0)
+  }
+}

--- a/src/main/kotlin/ee/tenman/portfolio/openrouter/OpenRouterClassificationResult.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/openrouter/OpenRouterClassificationResult.kt
@@ -1,0 +1,8 @@
+package ee.tenman.portfolio.openrouter
+
+import ee.tenman.portfolio.domain.AiModel
+
+data class OpenRouterClassificationResult(
+  val content: String?,
+  val model: AiModel?,
+)

--- a/src/main/kotlin/ee/tenman/portfolio/openrouter/OpenRouterProperties.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/openrouter/OpenRouterProperties.kt
@@ -1,10 +1,13 @@
 package ee.tenman.portfolio.openrouter
 
+import ee.tenman.portfolio.domain.AiModel
 import org.springframework.boot.context.properties.ConfigurationProperties
 
 @ConfigurationProperties(prefix = "openrouter")
 data class OpenRouterProperties(
   val apiKey: String = "",
-  val model: String = "openai/gpt-oss-120b",
   val url: String = "https://openrouter.ai/api/v1",
+  val primaryModel: AiModel = AiModel.CLAUDE_3_HAIKU,
+  val fallbackModel: AiModel = AiModel.CLAUDE_HAIKU_4_5,
+  val circuitBreaker: CircuitBreakerProperties = CircuitBreakerProperties(),
 )

--- a/src/main/kotlin/ee/tenman/portfolio/service/EtfHoldingPersistenceService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/service/EtfHoldingPersistenceService.kt
@@ -1,5 +1,6 @@
 package ee.tenman.portfolio.service
 
+import ee.tenman.portfolio.domain.AiModel
 import ee.tenman.portfolio.domain.EtfHolding
 import ee.tenman.portfolio.repository.EtfHoldingRepository
 import org.springframework.stereotype.Service
@@ -23,12 +24,14 @@ class EtfHoldingPersistenceService(
   fun updateSector(
     holdingId: Long,
     sector: String,
+    classifiedByModel: AiModel? = null,
   ) {
     val holding =
       etfHoldingRepository.findById(holdingId).orElseThrow {
         IllegalStateException("EtfHolding not found with id=$holdingId")
       }
     holding.sector = sector
+    holding.classifiedByModel = classifiedByModel
     etfHoldingRepository.save(holding)
   }
 }

--- a/src/main/kotlin/ee/tenman/portfolio/service/IndustryClassificationService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/service/IndustryClassificationService.kt
@@ -1,7 +1,9 @@
 package ee.tenman.portfolio.service
 
 import ee.tenman.portfolio.configuration.IndustryClassificationProperties
+import ee.tenman.portfolio.domain.AiModel
 import ee.tenman.portfolio.domain.IndustrySector
+import ee.tenman.portfolio.openrouter.OpenRouterClassificationResult
 import ee.tenman.portfolio.openrouter.OpenRouterClient
 import ee.tenman.portfolio.util.LogSanitizerUtil
 import org.slf4j.LoggerFactory
@@ -14,23 +16,66 @@ class IndustryClassificationService(
 ) {
   private val log = LoggerFactory.getLogger(javaClass)
 
-  fun classifyCompany(companyName: String): IndustrySector? {
-    log.info("Classifying company: {}", LogSanitizerUtil.sanitize(companyName))
+  fun classifyCompany(companyName: String): IndustrySector? = classifyCompanyWithModel(companyName)?.sector
+
+  fun classifyCompanyWithModel(companyName: String): SectorClassificationResult? {
+    val sanitizedName = LogSanitizerUtil.sanitize(companyName)
+    log.info("Classifying company: {}", sanitizedName)
     if (!properties.enabled || companyName.isBlank()) {
       log.warn("Classification disabled or blank company name")
       return null
     }
-
     val prompt = buildPrompt(companyName)
-    val response = openRouterClient.classify(prompt)
-    if (response == null) {
-      log.warn("No response from OpenRouter for company: {}", LogSanitizerUtil.sanitize(companyName))
+    return classifyWithPrimaryModel(prompt, sanitizedName)
+  }
+
+  private fun classifyWithPrimaryModel(
+    prompt: String,
+    sanitizedName: String,
+  ): SectorClassificationResult? {
+    val response =
+      openRouterClient.classifyWithModel(prompt) ?: run {
+        log.warn("No response from OpenRouter for company: {}", sanitizedName)
+        return retryWithFallbackModel(prompt, sanitizedName)
+      }
+    return parseResponse(response, sanitizedName) ?: retryIfNotFallbackModel(response.model, prompt, sanitizedName)
+  }
+
+  private fun retryIfNotFallbackModel(
+    model: AiModel?,
+    prompt: String,
+    sanitizedName: String,
+  ): SectorClassificationResult? {
+    if (model == AiModel.CLAUDE_HAIKU_4_5) return null
+    return retryWithFallbackModel(prompt, sanitizedName)
+  }
+
+  private fun retryWithFallbackModel(
+    prompt: String,
+    sanitizedName: String,
+  ): SectorClassificationResult? {
+    log.info("Retrying classification with fallback model for: {}", sanitizedName)
+    val response =
+      openRouterClient.classifyWithFallback(prompt) ?: run {
+        log.warn("No response from fallback model for company: {}", sanitizedName)
+        return null
+      }
+    return parseResponse(response, sanitizedName, logUnknownSector = true)
+  }
+
+  private fun parseResponse(
+    response: OpenRouterClassificationResult,
+    sanitizedName: String,
+    logUnknownSector: Boolean = false,
+  ): SectorClassificationResult? {
+    val content = response.content ?: return null
+    val sector = IndustrySector.fromDisplayName(content)
+    if (sector == null) {
+      if (logUnknownSector) log.warn("Unknown sector from model response: {}", content)
       return null
     }
-
-    val sector = IndustrySector.fromDisplayName(response)
-    log.info("Classified {} as {}", LogSanitizerUtil.sanitize(companyName), sector?.displayName ?: "UNKNOWN")
-    return sector
+    log.info("Classified {} as {} using model {}", sanitizedName, sector.displayName, response.model)
+    return SectorClassificationResult(sector = sector, model = response.model)
   }
 
   private fun buildPrompt(companyName: String): String =

--- a/src/main/kotlin/ee/tenman/portfolio/service/SectorClassificationResult.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/service/SectorClassificationResult.kt
@@ -1,0 +1,9 @@
+package ee.tenman.portfolio.service
+
+import ee.tenman.portfolio.domain.AiModel
+import ee.tenman.portfolio.domain.IndustrySector
+
+data class SectorClassificationResult(
+  val sector: IndustrySector,
+  val model: AiModel?,
+)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -235,7 +235,9 @@ trading212:
 
 openrouter:
   api-key: ${OPENROUTER_API_KEY}
-  model: anthropic/claude-3-haiku
+  circuit-breaker:
+    failure-threshold: 3
+    recovery-timeout-seconds: 60
 
 industry-classification:
   enabled: true

--- a/src/main/resources/db/migration/V202512091200__add_classified_by_model_to_etf_holding.sql
+++ b/src/main/resources/db/migration/V202512091200__add_classified_by_model_to_etf_holding.sql
@@ -1,0 +1,3 @@
+ALTER TABLE etf_holding ADD COLUMN classified_by_model VARCHAR(100);
+
+COMMENT ON COLUMN etf_holding.classified_by_model IS 'AI model used for sector classification';

--- a/src/test/kotlin/ee/tenman/portfolio/openrouter/AiModelTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/openrouter/AiModelTest.kt
@@ -1,0 +1,46 @@
+package ee.tenman.portfolio.openrouter
+
+import ch.tutteli.atrium.api.fluent.en_GB.toEqual
+import ch.tutteli.atrium.api.verbs.expect
+import ee.tenman.portfolio.domain.AiModel
+import org.junit.jupiter.api.Test
+
+class AiModelTest {
+  @Test
+  fun `should return CLAUDE_3_HAIKU for matching model id`() {
+    val result = AiModel.fromModelId("anthropic/claude-3-haiku")
+
+    expect(result).toEqual(AiModel.CLAUDE_3_HAIKU)
+  }
+
+  @Test
+  fun `should return CLAUDE_HAIKU_4_5 for matching model id`() {
+    val result = AiModel.fromModelId("anthropic/claude-haiku-4.5")
+
+    expect(result).toEqual(AiModel.CLAUDE_HAIKU_4_5)
+  }
+
+  @Test
+  fun `should return null for unknown model id`() {
+    val result = AiModel.fromModelId("unknown/model")
+
+    expect(result).toEqual(null)
+  }
+
+  @Test
+  fun `should match model id case insensitively`() {
+    val result = AiModel.fromModelId("ANTHROPIC/CLAUDE-3-HAIKU")
+
+    expect(result).toEqual(AiModel.CLAUDE_3_HAIKU)
+  }
+
+  @Test
+  fun `should have correct rate limits for CLAUDE_3_HAIKU`() {
+    expect(AiModel.CLAUDE_3_HAIKU.rateLimitPerMinute).toEqual(30)
+  }
+
+  @Test
+  fun `should have correct rate limits for CLAUDE_HAIKU_4_5`() {
+    expect(AiModel.CLAUDE_HAIKU_4_5.rateLimitPerMinute).toEqual(7)
+  }
+}

--- a/src/test/kotlin/ee/tenman/portfolio/openrouter/CircuitBreakerPropertiesTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/openrouter/CircuitBreakerPropertiesTest.kt
@@ -1,0 +1,65 @@
+package ee.tenman.portfolio.openrouter
+
+import ch.tutteli.atrium.api.fluent.en_GB.messageToContain
+import ch.tutteli.atrium.api.fluent.en_GB.toEqual
+import ch.tutteli.atrium.api.fluent.en_GB.toThrow
+import ch.tutteli.atrium.api.verbs.expect
+import org.junit.jupiter.api.Test
+
+class CircuitBreakerPropertiesTest {
+  @Test
+  fun `should create properties with default values`() {
+    val properties = CircuitBreakerProperties()
+
+    expect(properties.failureThreshold).toEqual(3)
+    expect(properties.recoveryTimeoutSeconds).toEqual(60L)
+  }
+
+  @Test
+  fun `should create properties with custom values`() {
+    val properties =
+      CircuitBreakerProperties(
+        failureThreshold = 5,
+        recoveryTimeoutSeconds = 120,
+      )
+
+    expect(properties.failureThreshold).toEqual(5)
+    expect(properties.recoveryTimeoutSeconds).toEqual(120L)
+  }
+
+  @Test
+  fun `should throw exception when failureThreshold is zero`() {
+    expect {
+      CircuitBreakerProperties(failureThreshold = 0)
+    }.toThrow<IllegalArgumentException> {
+      messageToContain("failureThreshold must be positive")
+    }
+  }
+
+  @Test
+  fun `should throw exception when failureThreshold is negative`() {
+    expect {
+      CircuitBreakerProperties(failureThreshold = -1)
+    }.toThrow<IllegalArgumentException> {
+      messageToContain("failureThreshold must be positive")
+    }
+  }
+
+  @Test
+  fun `should throw exception when recoveryTimeoutSeconds is zero`() {
+    expect {
+      CircuitBreakerProperties(recoveryTimeoutSeconds = 0)
+    }.toThrow<IllegalArgumentException> {
+      messageToContain("recoveryTimeoutSeconds must be positive")
+    }
+  }
+
+  @Test
+  fun `should throw exception when recoveryTimeoutSeconds is negative`() {
+    expect {
+      CircuitBreakerProperties(recoveryTimeoutSeconds = -1)
+    }.toThrow<IllegalArgumentException> {
+      messageToContain("recoveryTimeoutSeconds must be positive")
+    }
+  }
+}

--- a/src/test/kotlin/ee/tenman/portfolio/openrouter/OpenRouterCircuitBreakerTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/openrouter/OpenRouterCircuitBreakerTest.kt
@@ -1,0 +1,199 @@
+package ee.tenman.portfolio.openrouter
+
+import ch.tutteli.atrium.api.fluent.en_GB.toEqual
+import ch.tutteli.atrium.api.verbs.expect
+import ee.tenman.portfolio.domain.AiModel
+import io.github.resilience4j.circuitbreaker.CircuitBreaker
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+
+class OpenRouterCircuitBreakerTest {
+  private lateinit var circuitBreaker: OpenRouterCircuitBreaker
+  private lateinit var properties: OpenRouterProperties
+  private lateinit var clock: MutableClock
+
+  companion object {
+    private const val MILLISECONDS_PER_MINUTE = 60_000L
+    private const val RATE_LIMIT_BUFFER_MS = 1L
+    private val PRIMARY_RATE_LIMIT_INTERVAL_MS =
+      MILLISECONDS_PER_MINUTE / AiModel.CLAUDE_3_HAIKU.rateLimitPerMinute + RATE_LIMIT_BUFFER_MS
+    private val FALLBACK_RATE_LIMIT_INTERVAL_MS =
+      MILLISECONDS_PER_MINUTE / AiModel.CLAUDE_HAIKU_4_5.rateLimitPerMinute + RATE_LIMIT_BUFFER_MS
+  }
+
+  @BeforeEach
+  fun setUp() {
+    properties =
+      OpenRouterProperties(
+        apiKey = "test-key",
+        circuitBreaker =
+          CircuitBreakerProperties(
+            failureThreshold = 3,
+            recoveryTimeoutSeconds = 60,
+          ),
+      )
+    clock = MutableClock(Instant.now())
+    circuitBreaker = OpenRouterCircuitBreaker(properties, clock)
+  }
+
+  @Test
+  fun `should return primary model when circuit is closed`() {
+    expect(circuitBreaker.getCurrentModel()).toEqual(AiModel.CLAUDE_3_HAIKU.modelId)
+  }
+
+  @Test
+  fun `should return primary model state as closed initially`() {
+    expect(circuitBreaker.getState()).toEqual(CircuitBreaker.State.CLOSED)
+  }
+
+  @Test
+  fun `should not be using fallback when circuit is closed`() {
+    expect(circuitBreaker.isUsingFallback()).toEqual(false)
+  }
+
+  @Test
+  fun `should allow request when circuit is closed`() {
+    expect(circuitBreaker.canMakeRequest()).toEqual(true)
+  }
+
+  @Test
+  fun `should switch to fallback model after failure threshold reached`() {
+    repeat(3) {
+      circuitBreaker.recordFailure(Exception("API error"))
+    }
+    expect(circuitBreaker.getState()).toEqual(CircuitBreaker.State.OPEN)
+    expect(circuitBreaker.getCurrentModel()).toEqual(AiModel.CLAUDE_HAIKU_4_5.modelId)
+    expect(circuitBreaker.isUsingFallback()).toEqual(true)
+  }
+
+  @Test
+  fun `should stay closed when failures are below threshold`() {
+    repeat(2) {
+      circuitBreaker.recordFailure(Exception("API error"))
+    }
+    expect(circuitBreaker.getState()).toEqual(CircuitBreaker.State.CLOSED)
+    expect(circuitBreaker.getCurrentModel()).toEqual(AiModel.CLAUDE_3_HAIKU.modelId)
+  }
+
+  @Test
+  fun `should reset failure count on success`() {
+    circuitBreaker.recordFailure(Exception("API error"))
+    circuitBreaker.recordFailure(Exception("API error"))
+    circuitBreaker.recordSuccess()
+    circuitBreaker.recordFailure(Exception("API error"))
+    circuitBreaker.recordFailure(Exception("API error"))
+    expect(circuitBreaker.getState()).toEqual(CircuitBreaker.State.CLOSED)
+  }
+
+  @Test
+  fun `should allow first fallback request`() {
+    repeat(3) {
+      circuitBreaker.recordFailure(Exception("API error"))
+    }
+    expect(circuitBreaker.canMakeRequest()).toEqual(true)
+  }
+
+  @Test
+  fun `should rate limit fallback requests with tryAcquireFallback`() {
+    repeat(3) {
+      circuitBreaker.recordFailure(Exception("API error"))
+    }
+    expect(circuitBreaker.tryAcquireFallback()).toEqual(true)
+    expect(circuitBreaker.tryAcquireFallback()).toEqual(false)
+  }
+
+  @Test
+  fun `should allow fallback request after rate limit period`() {
+    repeat(3) {
+      circuitBreaker.recordFailure(Exception("API error"))
+    }
+    expect(circuitBreaker.tryAcquireFallback()).toEqual(true)
+    expect(circuitBreaker.canMakeRequest()).toEqual(false)
+    clock.advance(FALLBACK_RATE_LIMIT_INTERVAL_MS)
+    expect(circuitBreaker.canMakeRequest()).toEqual(true)
+  }
+
+  @Test
+  fun `should rate limit primary requests`() {
+    expect(circuitBreaker.tryAcquirePrimary()).toEqual(true)
+    expect(circuitBreaker.tryAcquirePrimary()).toEqual(false)
+  }
+
+  @Test
+  fun `should allow primary request after rate limit period`() {
+    expect(circuitBreaker.tryAcquirePrimary()).toEqual(true)
+    expect(circuitBreaker.canMakeRequest()).toEqual(false)
+    clock.advance(PRIMARY_RATE_LIMIT_INTERVAL_MS)
+    expect(circuitBreaker.canMakeRequest()).toEqual(true)
+  }
+
+  @Test
+  fun `should use tryAcquireRateLimit for primary model`() {
+    expect(circuitBreaker.tryAcquireRateLimit(isUsingFallback = false)).toEqual(true)
+    expect(circuitBreaker.tryAcquireRateLimit(isUsingFallback = false)).toEqual(false)
+  }
+
+  @Test
+  fun `should use tryAcquireRateLimit for fallback model`() {
+    repeat(3) {
+      circuitBreaker.recordFailure(Exception("API error"))
+    }
+    expect(circuitBreaker.tryAcquireRateLimit(isUsingFallback = true)).toEqual(true)
+    expect(circuitBreaker.tryAcquireRateLimit(isUsingFallback = true)).toEqual(false)
+  }
+
+  @Test
+  fun `should select model atomically`() {
+    val selection = circuitBreaker.selectModel()
+    expect(selection.modelId).toEqual(AiModel.CLAUDE_3_HAIKU.modelId)
+    expect(selection.isUsingFallback).toEqual(false)
+  }
+
+  @Test
+  fun `should select fallback model when circuit is open`() {
+    repeat(3) {
+      circuitBreaker.recordFailure(Exception("API error"))
+    }
+    val selection = circuitBreaker.selectModel()
+    expect(selection.modelId).toEqual(AiModel.CLAUDE_HAIKU_4_5.modelId)
+    expect(selection.isUsingFallback).toEqual(true)
+  }
+
+  @Test
+  fun `should return primary model in half open state`() {
+    repeat(3) {
+      circuitBreaker.recordFailure(Exception("API error"))
+    }
+    expect(circuitBreaker.getState()).toEqual(CircuitBreaker.State.OPEN)
+    circuitBreaker.transitionToHalfOpenState()
+    expect(circuitBreaker.getState()).toEqual(CircuitBreaker.State.HALF_OPEN)
+    expect(circuitBreaker.getCurrentModel()).toEqual(AiModel.CLAUDE_3_HAIKU.modelId)
+  }
+
+  @Test
+  fun `should close circuit after success in half open state`() {
+    repeat(3) {
+      circuitBreaker.recordFailure(Exception("API error"))
+    }
+    circuitBreaker.transitionToHalfOpenState()
+    circuitBreaker.recordSuccess()
+    expect(circuitBreaker.getState()).toEqual(CircuitBreaker.State.CLOSED)
+  }
+
+  private class MutableClock(
+    private var instant: Instant,
+  ) : Clock() {
+    override fun instant(): Instant = instant
+
+    override fun withZone(zone: ZoneId?): Clock = this
+
+    override fun getZone(): ZoneId = ZoneId.of("UTC")
+
+    fun advance(millis: Long) {
+      instant = instant.plusMillis(millis)
+    }
+  }
+}

--- a/src/test/kotlin/ee/tenman/portfolio/openrouter/OpenRouterClientIT.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/openrouter/OpenRouterClientIT.kt
@@ -1,0 +1,158 @@
+package ee.tenman.portfolio.openrouter
+
+import ch.tutteli.atrium.api.fluent.en_GB.notToEqualNull
+import ch.tutteli.atrium.api.fluent.en_GB.toEqual
+import ch.tutteli.atrium.api.verbs.expect
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.post
+import com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import ee.tenman.portfolio.configuration.IntegrationTest
+import ee.tenman.portfolio.domain.AiModel
+import io.github.resilience4j.circuitbreaker.CircuitBreaker
+import jakarta.annotation.Resource
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.test.context.TestPropertySource
+import org.wiremock.spring.InjectWireMock
+import tools.jackson.databind.ObjectMapper
+
+@IntegrationTest
+@TestPropertySource(properties = ["openrouter.api-key=test-api-key", "openrouter.url=http://localhost:\${wiremock.server.port}"])
+class OpenRouterClientIT {
+  @Resource
+  private lateinit var openRouterClient: OpenRouterClient
+
+  @Resource
+  private lateinit var circuitBreaker: OpenRouterCircuitBreaker
+
+  @Resource
+  private lateinit var objectMapper: ObjectMapper
+
+  @InjectWireMock
+  private lateinit var wireMockServer: WireMockServer
+
+  @BeforeEach
+  fun setUp() {
+    wireMockServer.resetAll()
+    circuitBreaker.reset()
+  }
+
+  @Test
+  fun `should successfully classify with primary model`() {
+    val responseBody = createSuccessResponse("Technology")
+    stubOpenRouterSuccess(responseBody)
+
+    val result = openRouterClient.classifyWithModel("Classify Apple Inc")
+
+    expect(result).notToEqualNull()
+    expect(result?.content).toEqual("Technology")
+    expect(result?.model).toEqual(AiModel.CLAUDE_3_HAIKU)
+    expect(circuitBreaker.getState()).toEqual(CircuitBreaker.State.CLOSED)
+  }
+
+  @Test
+  fun `should switch to fallback model after failures exceed threshold`() {
+    stubOpenRouterError()
+
+    repeat(3) {
+      circuitBreaker.resetRateLimits()
+      openRouterClient.classifyWithModel("Classify company")
+    }
+
+    expect(circuitBreaker.getState()).toEqual(CircuitBreaker.State.OPEN)
+    expect(circuitBreaker.isUsingFallback()).toEqual(true)
+  }
+
+  @Test
+  fun `should handle server error and record failure`() {
+    stubOpenRouterError()
+
+    val result = openRouterClient.classifyWithModel("Test prompt")
+
+    expect(result).toEqual(null)
+    wireMockServer.verify(1, postRequestedFor(urlEqualTo("/chat/completions")))
+  }
+
+  @Test
+  fun `should recover from half-open state on success`() {
+    stubOpenRouterError()
+    repeat(3) {
+      circuitBreaker.resetRateLimits()
+      openRouterClient.classifyWithModel("Classify company")
+    }
+    expect(circuitBreaker.getState()).toEqual(CircuitBreaker.State.OPEN)
+
+    circuitBreaker.transitionToHalfOpenState()
+    expect(circuitBreaker.getState()).toEqual(CircuitBreaker.State.HALF_OPEN)
+
+    wireMockServer.resetAll()
+    stubOpenRouterSuccess(createSuccessResponse("Finance"))
+    circuitBreaker.resetRateLimits()
+
+    val result = openRouterClient.classifyWithModel("Classify bank")
+
+    expect(result).notToEqualNull()
+    expect(circuitBreaker.getState()).toEqual(CircuitBreaker.State.CLOSED)
+  }
+
+  @Test
+  fun `should use fallback model when circuit is open`() {
+    stubOpenRouterError()
+    repeat(3) {
+      circuitBreaker.resetRateLimits()
+      openRouterClient.classifyWithModel("Classify company")
+    }
+    expect(circuitBreaker.isUsingFallback()).toEqual(true)
+
+    wireMockServer.resetAll()
+    stubOpenRouterSuccess(createSuccessResponse("Healthcare"))
+    circuitBreaker.resetRateLimits()
+
+    val result = openRouterClient.classifyWithModel("Classify hospital")
+
+    expect(result).notToEqualNull()
+    expect(result?.content).toEqual("Healthcare")
+    expect(result?.model).toEqual(AiModel.CLAUDE_HAIKU_4_5)
+  }
+
+  private fun createSuccessResponse(content: String): String =
+    objectMapper.writeValueAsString(
+      mapOf(
+        "choices" to
+          listOf(
+            mapOf(
+              "message" to
+                mapOf(
+                  "content" to content,
+                ),
+            ),
+          ),
+      ),
+    )
+
+  private fun stubOpenRouterSuccess(responseBody: String) {
+    wireMockServer.stubFor(
+      post(urlEqualTo("/chat/completions"))
+        .willReturn(
+          aResponse()
+            .withStatus(HttpStatus.OK.value())
+            .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+            .withBody(responseBody),
+        ),
+    )
+  }
+
+  private fun stubOpenRouterError() {
+    wireMockServer.stubFor(
+      post(urlEqualTo("/chat/completions"))
+        .willReturn(
+          aResponse()
+            .withStatus(HttpStatus.INTERNAL_SERVER_ERROR.value()),
+        ),
+    )
+  }
+}

--- a/src/test/kotlin/ee/tenman/portfolio/service/IndustryClassificationServiceTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/service/IndustryClassificationServiceTest.kt
@@ -1,0 +1,169 @@
+package ee.tenman.portfolio.service
+
+import ch.tutteli.atrium.api.fluent.en_GB.toEqual
+import ch.tutteli.atrium.api.verbs.expect
+import ee.tenman.portfolio.configuration.IndustryClassificationProperties
+import ee.tenman.portfolio.domain.AiModel
+import ee.tenman.portfolio.domain.IndustrySector
+import ee.tenman.portfolio.openrouter.OpenRouterClassificationResult
+import ee.tenman.portfolio.openrouter.OpenRouterClient
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class IndustryClassificationServiceTest {
+  private val openRouterClient = mockk<OpenRouterClient>()
+  private val properties = mockk<IndustryClassificationProperties>()
+
+  private lateinit var service: IndustryClassificationService
+
+  @BeforeEach
+  fun setUp() {
+    service = IndustryClassificationService(openRouterClient, properties)
+  }
+
+  @Test
+  fun `should return null when classification is disabled`() {
+    every { properties.enabled } returns false
+
+    val result = service.classifyCompanyWithModel("Apple Inc")
+
+    expect(result).toEqual(null)
+    verify(exactly = 0) { openRouterClient.classifyWithModel(any()) }
+  }
+
+  @Test
+  fun `should return null when company name is blank`() {
+    every { properties.enabled } returns true
+
+    val result = service.classifyCompanyWithModel("   ")
+
+    expect(result).toEqual(null)
+    verify(exactly = 0) { openRouterClient.classifyWithModel(any()) }
+  }
+
+  @Test
+  fun `should return null when OpenRouter returns no response`() {
+    every { properties.enabled } returns true
+    every { openRouterClient.classifyWithModel(any()) } returns null
+    every { openRouterClient.classifyWithFallback(any()) } returns null
+
+    val result = service.classifyCompanyWithModel("Apple Inc")
+
+    expect(result).toEqual(null)
+  }
+
+  @Test
+  fun `should return null when OpenRouter response has null content`() {
+    every { properties.enabled } returns true
+    every { openRouterClient.classifyWithModel(any()) } returns
+      OpenRouterClassificationResult(content = null, model = AiModel.CLAUDE_3_HAIKU)
+    every { openRouterClient.classifyWithFallback(any()) } returns null
+
+    val result = service.classifyCompanyWithModel("Apple Inc")
+
+    expect(result).toEqual(null)
+  }
+
+  @Test
+  fun `should retry with fallback when primary model returns unknown sector`() {
+    every { properties.enabled } returns true
+    every { openRouterClient.classifyWithModel(any()) } returns
+      OpenRouterClassificationResult(content = "Unknown Category", model = AiModel.CLAUDE_3_HAIKU)
+    every { openRouterClient.classifyWithFallback(any()) } returns
+      OpenRouterClassificationResult(content = "Software & Cloud Services", model = AiModel.CLAUDE_HAIKU_4_5)
+
+    val result = service.classifyCompanyWithModel("Apple Inc")
+
+    expect(result?.sector).toEqual(IndustrySector.SOFTWARE_CLOUD_SERVICES)
+    expect(result?.model).toEqual(AiModel.CLAUDE_HAIKU_4_5)
+    verify(exactly = 1) { openRouterClient.classifyWithModel(any()) }
+    verify(exactly = 1) { openRouterClient.classifyWithFallback(any()) }
+  }
+
+  @Test
+  fun `should return null when both primary and fallback return unknown sector`() {
+    every { properties.enabled } returns true
+    every { openRouterClient.classifyWithModel(any()) } returns
+      OpenRouterClassificationResult(content = "Unknown Category", model = AiModel.CLAUDE_3_HAIKU)
+    every { openRouterClient.classifyWithFallback(any()) } returns
+      OpenRouterClassificationResult(content = "Still Unknown", model = AiModel.CLAUDE_HAIKU_4_5)
+
+    val result = service.classifyCompanyWithModel("Apple Inc")
+
+    expect(result).toEqual(null)
+  }
+
+  @Test
+  fun `should not retry when fallback model returns unknown sector`() {
+    every { properties.enabled } returns true
+    every { openRouterClient.classifyWithModel(any()) } returns
+      OpenRouterClassificationResult(content = "Unknown Category", model = AiModel.CLAUDE_HAIKU_4_5)
+
+    val result = service.classifyCompanyWithModel("Apple Inc")
+
+    expect(result).toEqual(null)
+    verify(exactly = 1) { openRouterClient.classifyWithModel(any()) }
+    verify(exactly = 0) { openRouterClient.classifyWithFallback(any()) }
+  }
+
+  @Test
+  fun `should return null when fallback returns no response`() {
+    every { properties.enabled } returns true
+    every { openRouterClient.classifyWithModel(any()) } returns
+      OpenRouterClassificationResult(content = "Unknown Category", model = AiModel.CLAUDE_3_HAIKU)
+    every { openRouterClient.classifyWithFallback(any()) } returns null
+
+    val result = service.classifyCompanyWithModel("Apple Inc")
+
+    expect(result).toEqual(null)
+  }
+
+  @Test
+  fun `should return sector classification result for valid response`() {
+    every { properties.enabled } returns true
+    every { openRouterClient.classifyWithModel(any()) } returns
+      OpenRouterClassificationResult(content = "Semiconductors", model = AiModel.CLAUDE_3_HAIKU)
+
+    val result = service.classifyCompanyWithModel("Nvidia")
+
+    expect(result?.sector).toEqual(IndustrySector.SEMICONDUCTORS)
+    expect(result?.model).toEqual(AiModel.CLAUDE_3_HAIKU)
+  }
+
+  @Test
+  fun `should return sector classification result with fallback model`() {
+    every { properties.enabled } returns true
+    every { openRouterClient.classifyWithModel(any()) } returns
+      OpenRouterClassificationResult(content = "Finance", model = AiModel.CLAUDE_HAIKU_4_5)
+
+    val result = service.classifyCompanyWithModel("JPMorgan Chase")
+
+    expect(result?.sector).toEqual(IndustrySector.FINANCE)
+    expect(result?.model).toEqual(AiModel.CLAUDE_HAIKU_4_5)
+  }
+
+  @Test
+  fun `should return only sector when using classifyCompany`() {
+    every { properties.enabled } returns true
+    every { openRouterClient.classifyWithModel(any()) } returns
+      OpenRouterClassificationResult(content = "Health", model = AiModel.CLAUDE_3_HAIKU)
+
+    val result = service.classifyCompany("Pfizer")
+
+    expect(result).toEqual(IndustrySector.HEALTH)
+  }
+
+  @Test
+  fun `should return null from classifyCompany when classification fails`() {
+    every { properties.enabled } returns true
+    every { openRouterClient.classifyWithModel(any()) } returns null
+    every { openRouterClient.classifyWithFallback(any()) } returns null
+
+    val result = service.classifyCompany("Unknown Corp")
+
+    expect(result).toEqual(null)
+  }
+}


### PR DESCRIPTION
## Summary
- Add circuit breaker pattern using Resilience4j for OpenRouter API calls
- Implement model-specific rate limiting (30 req/min primary, 7 req/min fallback)
- Add fallback retry mechanism: when primary model returns unknown sector, retry with fallback model
- Create AiModel enum with configurable primary/fallback models
- Refactor to idiomatic Kotlin with guard clauses and early returns
- Update CLAUDE.md with null check pattern documentation

## Test plan
- [x] Unit tests for OpenRouterCircuitBreaker
- [x] Unit tests for IndustryClassificationService with fallback retry
- [x] Integration test for OpenRouterClient
- [x] All existing tests pass

Closes #1035