### PR TITLE
Add rate-limit-aware processing to ETF holdings classification job

### DIFF
--- a/src/main/kotlin/ee/tenman/portfolio/openrouter/OpenRouterCircuitBreaker.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/openrouter/OpenRouterCircuitBreaker.kt
@@ -89,6 +89,13 @@ class OpenRouterCircuitBreaker(
 
   fun tryAcquireFallback(): Boolean = tryAcquireWithRateLimit(lastFallbackRequestTime, fallbackRateLimitMs(), "Fallback")
 
+  fun getWaitTimeMs(isUsingFallback: Boolean): Long {
+    val lastRequestTime = if (isUsingFallback) lastFallbackRequestTime else lastPrimaryRequestTime
+    val rateLimitMs = if (isUsingFallback) fallbackRateLimitMs() else primaryRateLimitMs()
+    val elapsed = clock.millis() - lastRequestTime.get()
+    return maxOf(0, rateLimitMs - elapsed)
+  }
+
   private fun primaryRateLimitMs(): Long = MILLISECONDS_PER_MINUTE / primaryModel.rateLimitPerMinute
 
   private fun fallbackRateLimitMs(): Long = MILLISECONDS_PER_MINUTE / fallbackModel.rateLimitPerMinute


### PR DESCRIPTION
## Summary

- Add dynamic rate-limit delays to ETF holdings classification job
- Add `getWaitTimeMs()` method to circuit breaker for calculating required wait time
- Add progress logging every 50 holdings for observability

## Problem

The classification job was failing with **99.5% failure rate** (796/800 failed). Root cause:
- Job processed 800+ holdings in a tight synchronous loop
- After 2-3 successful API calls, rate limiter kicked in
- All subsequent requests were immediately skipped (not retried)

## Solution

- Use dynamic wait time calculation via `circuitBreaker.getWaitTimeMs()`
- Wait only the remaining time needed to respect rate limits
- Automatically handles switching between primary (30 RPM) and fallback (7 RPM) models
- Add 100ms buffer for safety margin

## Test plan

- [x] Circuit breaker tests pass (including new tests for `getWaitTimeMs()`)
- [x] All backend tests pass
- [x] Frontend linting passes
- [x] Code review completed

Fixes #1040