### PR TITLE
Extract pure calculation modules for better testability

### DIFF
--- a/src/main/kotlin/ee/tenman/portfolio/service/calculation/XirrCalculationService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/service/calculation/XirrCalculationService.kt
@@ -35,7 +35,7 @@ class XirrCalculationService {
   ): Double {
     if (cashFlows.size < 2) return 0.0
     return runCatching {
-      val xirrResult = Xirr(cashFlows).calculate()
+      val xirrResult = Xirr(cashFlows)()
       val outflows = cashFlows.filter { it.amount < 0 }
       if (outflows.isEmpty()) return@runCatching 0.0
       val weightedDays = calculateWeightedInvestmentAge(outflows, calculationDate)

--- a/src/main/kotlin/ee/tenman/portfolio/service/calculation/xirr/Xirr.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/service/calculation/xirr/Xirr.kt
@@ -25,6 +25,8 @@ class Xirr(
 
   fun getCashFlows(): List<CashFlow> = cashFlows
 
+  operator fun invoke(): Double = calculate()
+
   fun calculate(): Double {
     log.info("Starting XIRR calculation with ${cashFlows.size} cash flows")
     log.info("Start date: $startDate, End date: $endDate")

--- a/src/main/kotlin/ee/tenman/portfolio/service/summary/DailySummaryCalculator.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/service/summary/DailySummaryCalculator.kt
@@ -1,0 +1,82 @@
+package ee.tenman.portfolio.service.summary
+
+import ee.tenman.portfolio.domain.Instrument
+import ee.tenman.portfolio.domain.PortfolioDailySummary
+import ee.tenman.portfolio.domain.PortfolioTransaction
+import ee.tenman.portfolio.model.metrics.PortfolioMetrics
+import ee.tenman.portfolio.service.calculation.InvestmentMetricsService
+import ee.tenman.portfolio.service.calculation.XirrCalculationService
+import org.springframework.stereotype.Component
+import java.math.BigDecimal
+import java.math.RoundingMode
+import java.time.LocalDate
+
+@Component
+class DailySummaryCalculator(
+  private val investmentMetricsService: InvestmentMetricsService,
+  private val xirrCalculationService: XirrCalculationService,
+) {
+  fun calculateFromTransactions(
+    transactions: List<PortfolioTransaction>,
+    date: LocalDate,
+  ): PortfolioDailySummary {
+    if (transactions.isEmpty()) return createEmptySummary(date)
+    val instrumentGroups = transactions.groupBy { it.instrument }
+    return calculateFromInstrumentGroups(instrumentGroups, date)
+  }
+
+  fun calculateFromInstrumentGroups(
+    instrumentGroups: Map<Instrument, List<PortfolioTransaction>>,
+    date: LocalDate,
+  ): PortfolioDailySummary {
+    if (instrumentGroups.isEmpty()) return createEmptySummary(date)
+    val metrics = investmentMetricsService.calculatePortfolioMetrics(instrumentGroups, date)
+    return buildSummary(date, metrics)
+  }
+
+  fun shouldReuseYesterday(
+    yesterdaySummary: PortfolioDailySummary,
+    todaySummary: PortfolioDailySummary,
+  ): Boolean = yesterdaySummary.totalValue.compareTo(todaySummary.totalValue) == 0
+
+  fun calculateEarningsPerDay(
+    totalValue: BigDecimal,
+    xirrRate: BigDecimal,
+  ): BigDecimal =
+    totalValue
+      .multiply(xirrRate)
+      .divide(DAYS_PER_YEAR, CALCULATION_SCALE, RoundingMode.HALF_UP)
+
+  fun createEmptySummary(date: LocalDate): PortfolioDailySummary =
+    PortfolioDailySummary(
+      entryDate = date,
+      totalValue = BigDecimal.ZERO,
+      xirrAnnualReturn = BigDecimal.ZERO,
+      realizedProfit = BigDecimal.ZERO,
+      unrealizedProfit = BigDecimal.ZERO,
+      totalProfit = BigDecimal.ZERO,
+      earningsPerDay = BigDecimal.ZERO,
+    )
+
+  private fun buildSummary(
+    date: LocalDate,
+    metrics: PortfolioMetrics,
+  ): PortfolioDailySummary {
+    val xirr = xirrCalculationService.calculateAdjustedXirr(metrics.xirrCashFlows, date)
+    val earningsPerDay = calculateEarningsPerDay(metrics.totalValue, BigDecimal(xirr))
+    return PortfolioDailySummary(
+      entryDate = date,
+      totalValue = metrics.totalValue.setScale(CALCULATION_SCALE, RoundingMode.HALF_UP),
+      xirrAnnualReturn = BigDecimal(xirr).setScale(CALCULATION_SCALE, RoundingMode.HALF_UP),
+      realizedProfit = metrics.realizedProfit.setScale(CALCULATION_SCALE, RoundingMode.HALF_UP),
+      unrealizedProfit = metrics.unrealizedProfit.setScale(CALCULATION_SCALE, RoundingMode.HALF_UP),
+      totalProfit = metrics.totalProfit.setScale(CALCULATION_SCALE, RoundingMode.HALF_UP),
+      earningsPerDay = earningsPerDay.setScale(CALCULATION_SCALE, RoundingMode.HALF_UP),
+    )
+  }
+
+  companion object {
+    private val DAYS_PER_YEAR = BigDecimal("365.25")
+    private const val CALCULATION_SCALE = 10
+  }
+}

--- a/src/test/kotlin/ee/tenman/portfolio/service/calculation/xirr/XirrTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/service/calculation/xirr/XirrTest.kt
@@ -61,7 +61,7 @@ class XirrTest {
   @ParameterizedTest(name = "{0}")
   @MethodSource("xirrTestCases")
   fun `should calculate correct XIRR value when given transactions`(testCase: XirrTestCase) {
-    val xirrValue = Xirr(testCase.cashFlows).calculate()
+    val xirrValue = Xirr(testCase.cashFlows)()
 
     val tolerance = 1e-14
     expect(Math.abs(xirrValue - testCase.expectedXirr)).toBeLessThan(tolerance)

--- a/src/test/kotlin/ee/tenman/portfolio/service/summary/SummaryServiceTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/service/summary/SummaryServiceTest.kt
@@ -43,6 +43,7 @@ class SummaryServiceTest {
   private val summaryBatchProcessor = mockk<SummaryBatchProcessorService>(relaxed = true)
   private val summaryDeletionService = mockk<SummaryDeletionService>(relaxed = true)
   private val summaryCacheService = mockk<SummaryCacheService>(relaxed = true)
+  private val dailySummaryCalculator = DailySummaryCalculator(investmentMetricsService, xirrCalculationService)
 
   private lateinit var summaryService: SummaryService
 
@@ -60,12 +61,11 @@ class SummaryServiceTest {
         portfolioDailySummaryRepository,
         transactionService,
         cacheManager,
-        investmentMetricsService,
-        xirrCalculationService,
         clock,
         summaryBatchProcessor,
         summaryDeletionService,
         summaryCacheService,
+        dailySummaryCalculator,
       )
 
     testDate = LocalDate.of(2025, 5, 10)

--- a/ui/services/portfolio-growth-calculator.test.ts
+++ b/ui/services/portfolio-growth-calculator.test.ts
@@ -1,0 +1,283 @@
+import { describe, it, expect } from 'vitest'
+import {
+  annualToMonthlyReturnRate,
+  annualToMonthlyGrowthRate,
+  calculateTaxAmount,
+  calculateNetWorth,
+  calculateMonthlyEarnings,
+  simulateYear,
+  calculateProjection,
+  CalculatorInput,
+} from './portfolio-growth-calculator'
+
+describe('portfolio-growth-calculator', () => {
+  describe('annualToMonthlyReturnRate', () => {
+    it('should convert 12% annual to monthly rate', () => {
+      const monthlyRate = annualToMonthlyReturnRate(12)
+      const expectedRate = Math.pow(1.12, 1 / 12) - 1
+      expect(monthlyRate).toBeCloseTo(expectedRate, 10)
+    })
+
+    it('should return 0 for 0% annual rate', () => {
+      expect(annualToMonthlyReturnRate(0)).toBe(0)
+    })
+
+    it('should handle 100% annual rate', () => {
+      const monthlyRate = annualToMonthlyReturnRate(100)
+      const expectedRate = Math.pow(2, 1 / 12) - 1
+      expect(monthlyRate).toBeCloseTo(expectedRate, 10)
+    })
+  })
+
+  describe('annualToMonthlyGrowthRate', () => {
+    it('should convert 12% yearly to 1% monthly', () => {
+      expect(annualToMonthlyGrowthRate(12)).toBeCloseTo(0.01, 10)
+    })
+
+    it('should convert 5% yearly to correct monthly rate', () => {
+      expect(annualToMonthlyGrowthRate(5)).toBeCloseTo(5 / 100 / 12, 10)
+    })
+
+    it('should return 0 for 0% yearly rate', () => {
+      expect(annualToMonthlyGrowthRate(0)).toBe(0)
+    })
+  })
+
+  describe('calculateTaxAmount', () => {
+    it('should calculate 22% tax on profit', () => {
+      expect(calculateTaxAmount(1000, 22)).toBe(220)
+    })
+
+    it('should return 0 when tax rate is 0', () => {
+      expect(calculateTaxAmount(1000, 0)).toBe(0)
+    })
+
+    it('should handle zero profit', () => {
+      expect(calculateTaxAmount(0, 22)).toBe(0)
+    })
+
+    it('should handle negative profit', () => {
+      expect(calculateTaxAmount(-500, 22)).toBe(-110)
+    })
+  })
+
+  describe('calculateNetWorth', () => {
+    it('should calculate net worth correctly', () => {
+      const netWorth = calculateNetWorth(10000, 2000, 440)
+      expect(netWorth).toBe(11560)
+    })
+
+    it('should handle zero values', () => {
+      expect(calculateNetWorth(0, 0, 0)).toBe(0)
+    })
+  })
+
+  describe('calculateMonthlyEarnings', () => {
+    it('should divide net profit by 12', () => {
+      expect(calculateMonthlyEarnings(1200)).toBe(100)
+    })
+
+    it('should handle zero profit', () => {
+      expect(calculateMonthlyEarnings(0)).toBe(0)
+    })
+
+    it('should handle decimal results', () => {
+      expect(calculateMonthlyEarnings(1000)).toBeCloseTo(83.333, 2)
+    })
+  })
+
+  describe('simulateYear', () => {
+    it('should simulate a year with no growth', () => {
+      const result = simulateYear(10000, 10000, 100, 0, 22, 1)
+
+      expect(result.summary.year).toBe(1)
+      expect(result.summary.totalInvested).toBe(11200)
+      expect(result.summary.totalWorth).toBe(11200)
+      expect(result.summary.grossProfit).toBe(0)
+      expect(result.summary.taxAmount).toBe(0)
+      expect(result.summary.netWorth).toBe(11200)
+    })
+
+    it('should simulate a year with positive return', () => {
+      const monthlyRate = annualToMonthlyReturnRate(12)
+      const result = simulateYear(10000, 10000, 0, monthlyRate, 22, 1)
+
+      expect(result.summary.year).toBe(1)
+      expect(result.summary.totalInvested).toBe(10000)
+      expect(result.summary.grossProfit).toBeGreaterThan(0)
+      expect(result.summary.taxAmount).toBeCloseTo(result.summary.grossProfit * 0.22, 2)
+    })
+
+    it('should track ending worth and invested amounts', () => {
+      const result = simulateYear(5000, 5000, 200, 0, 0, 1)
+
+      expect(result.endingWorth).toBe(7400)
+      expect(result.endingInvested).toBe(7400)
+    })
+  })
+
+  describe('calculateProjection', () => {
+    it('should generate correct number of year summaries', () => {
+      const input: CalculatorInput = {
+        initialWorth: 10000,
+        monthlyInvestment: 100,
+        yearlyGrowthRate: 0,
+        annualReturnRate: 0,
+        years: 5,
+        taxRate: 22,
+      }
+
+      const result = calculateProjection(input)
+
+      expect(result.yearSummaries).toHaveLength(5)
+      expect(result.portfolioData).toHaveLength(6)
+    })
+
+    it('should include initial worth in portfolio data', () => {
+      const input: CalculatorInput = {
+        initialWorth: 50000,
+        monthlyInvestment: 0,
+        yearlyGrowthRate: 0,
+        annualReturnRate: 0,
+        years: 3,
+        taxRate: 0,
+      }
+
+      const result = calculateProjection(input)
+
+      expect(result.portfolioData[0]).toBe(50000)
+    })
+
+    it('should calculate compound growth correctly over multiple years', () => {
+      const input: CalculatorInput = {
+        initialWorth: 10000,
+        monthlyInvestment: 500,
+        yearlyGrowthRate: 0,
+        annualReturnRate: 12,
+        years: 1,
+        taxRate: 22,
+      }
+
+      const result = calculateProjection(input)
+      const yearOne = result.yearSummaries[0]
+
+      const monthlyRate = Math.pow(1.12, 1 / 12) - 1
+      let expectedTotal = 10000
+      for (let i = 0; i < 12; i++) {
+        expectedTotal += 500
+        expectedTotal *= 1 + monthlyRate
+      }
+
+      const totalInvested = 10000 + 500 * 12
+      const grossProfit = expectedTotal - totalInvested
+
+      expect(yearOne.totalInvested).toBe(totalInvested)
+      expect(yearOne.grossProfit).toBeCloseTo(grossProfit, 0)
+    })
+
+    it('should apply yearly growth rate to monthly investments', () => {
+      const input: CalculatorInput = {
+        initialWorth: 0,
+        monthlyInvestment: 100,
+        yearlyGrowthRate: 10,
+        annualReturnRate: 0,
+        years: 2,
+        taxRate: 0,
+      }
+
+      const result = calculateProjection(input)
+
+      expect(result.yearSummaries[0].totalInvested).toBe(1200)
+      expect(result.yearSummaries[1].totalInvested).toBeGreaterThan(2400)
+    })
+
+    it('should handle all zero inputs gracefully', () => {
+      const input: CalculatorInput = {
+        initialWorth: 0,
+        monthlyInvestment: 0,
+        yearlyGrowthRate: 0,
+        annualReturnRate: 0,
+        years: 3,
+        taxRate: 0,
+      }
+
+      const result = calculateProjection(input)
+
+      expect(result.yearSummaries).toHaveLength(3)
+      result.yearSummaries.forEach(summary => {
+        expect(summary.totalWorth).toBe(0)
+        expect(summary.grossProfit).toBe(0)
+        expect(summary.netWorth).toBe(0)
+      })
+    })
+
+    it('should calculate tax correctly for each year', () => {
+      const input: CalculatorInput = {
+        initialWorth: 10000,
+        monthlyInvestment: 0,
+        yearlyGrowthRate: 0,
+        annualReturnRate: 10,
+        years: 3,
+        taxRate: 25,
+      }
+
+      const result = calculateProjection(input)
+
+      result.yearSummaries.forEach(summary => {
+        expect(summary.taxAmount).toBeCloseTo(summary.grossProfit * 0.25, 2)
+        expect(summary.netWorth).toBeCloseTo(summary.totalWorth - summary.taxAmount, 2)
+      })
+    })
+
+    it('should calculate monthly earnings based on net profit', () => {
+      const input: CalculatorInput = {
+        initialWorth: 100000,
+        monthlyInvestment: 0,
+        yearlyGrowthRate: 0,
+        annualReturnRate: 12,
+        years: 1,
+        taxRate: 22,
+      }
+
+      const result = calculateProjection(input)
+      const yearOne = result.yearSummaries[0]
+
+      const netProfit = yearOne.grossProfit - yearOne.taxAmount
+      expect(yearOne.monthlyEarnings).toBeCloseTo(netProfit / 12, 2)
+    })
+
+    it('should accumulate investments correctly year over year', () => {
+      const input: CalculatorInput = {
+        initialWorth: 5000,
+        monthlyInvestment: 200,
+        yearlyGrowthRate: 0,
+        annualReturnRate: 0,
+        years: 3,
+        taxRate: 0,
+      }
+
+      const result = calculateProjection(input)
+
+      expect(result.yearSummaries[0].totalInvested).toBe(5000 + 200 * 12)
+      expect(result.yearSummaries[1].totalInvested).toBe(5000 + 200 * 24)
+      expect(result.yearSummaries[2].totalInvested).toBe(5000 + 200 * 36)
+    })
+
+    it('should produce consistent results for same input', () => {
+      const input: CalculatorInput = {
+        initialWorth: 25000,
+        monthlyInvestment: 750,
+        yearlyGrowthRate: 5,
+        annualReturnRate: 8,
+        years: 10,
+        taxRate: 20,
+      }
+
+      const result1 = calculateProjection(input)
+      const result2 = calculateProjection(input)
+
+      expect(result1.yearSummaries).toEqual(result2.yearSummaries)
+      expect(result1.portfolioData).toEqual(result2.portfolioData)
+    })
+  })
+})

--- a/ui/services/portfolio-growth-calculator.ts
+++ b/ui/services/portfolio-growth-calculator.ts
@@ -1,0 +1,119 @@
+export interface CalculatorInput {
+  initialWorth: number
+  monthlyInvestment: number
+  yearlyGrowthRate: number
+  annualReturnRate: number
+  years: number
+  taxRate: number
+}
+
+export interface YearSummary {
+  year: number
+  totalInvested: number
+  totalWorth: number
+  grossProfit: number
+  taxAmount: number
+  netWorth: number
+  monthlyEarnings: number
+}
+
+interface ProjectionResult {
+  yearSummaries: YearSummary[]
+  portfolioData: number[]
+}
+
+export function annualToMonthlyReturnRate(annualRate: number): number {
+  return Math.pow(1 + annualRate / 100, 1 / 12) - 1
+}
+
+export function annualToMonthlyGrowthRate(yearlyGrowthRate: number): number {
+  return yearlyGrowthRate / 100 / 12
+}
+
+export function calculateTaxAmount(grossProfit: number, taxRate: number): number {
+  return grossProfit * (taxRate / 100)
+}
+
+export function calculateNetWorth(
+  totalInvested: number,
+  grossProfit: number,
+  taxAmount: number
+): number {
+  return totalInvested + grossProfit - taxAmount
+}
+
+export function calculateMonthlyEarnings(netProfit: number): number {
+  return netProfit / 12
+}
+
+export function simulateYear(
+  startingWorth: number,
+  startingInvested: number,
+  monthlyInvestment: number,
+  monthlyReturnRate: number,
+  taxRate: number,
+  yearNumber: number
+): { summary: YearSummary; endingWorth: number; endingInvested: number } {
+  let totalWorth = startingWorth
+  let yearlyInvestmentAmount = 0
+
+  for (let month = 1; month <= 12; month++) {
+    yearlyInvestmentAmount += monthlyInvestment
+    totalWorth += monthlyInvestment
+    totalWorth *= 1 + monthlyReturnRate
+  }
+
+  const totalInvested = startingInvested + yearlyInvestmentAmount
+  const grossProfit = totalWorth - totalInvested
+  const taxAmount = calculateTaxAmount(grossProfit, taxRate)
+  const netProfit = grossProfit - taxAmount
+  const grossTotalWorth = totalInvested + grossProfit
+  const netWorth = calculateNetWorth(totalInvested, grossProfit, taxAmount)
+  const monthlyEarnings = calculateMonthlyEarnings(netProfit)
+
+  return {
+    summary: {
+      year: yearNumber,
+      totalInvested,
+      totalWorth: grossTotalWorth,
+      grossProfit,
+      taxAmount,
+      netWorth,
+      monthlyEarnings,
+    },
+    endingWorth: totalWorth,
+    endingInvested: totalInvested,
+  }
+}
+
+export function calculateProjection(input: CalculatorInput): ProjectionResult {
+  const monthlyGrowthRate = annualToMonthlyGrowthRate(input.yearlyGrowthRate)
+  const monthlyReturnRate = annualToMonthlyReturnRate(input.annualReturnRate)
+
+  const yearSummaries: YearSummary[] = []
+  const portfolioData: number[] = [input.initialWorth]
+
+  let totalWorth = input.initialWorth
+  let totalInvested = input.initialWorth
+  let currentMonthlyInvestment = input.monthlyInvestment
+
+  for (let year = 1; year <= input.years; year++) {
+    const result = simulateYear(
+      totalWorth,
+      totalInvested,
+      currentMonthlyInvestment,
+      monthlyReturnRate,
+      input.taxRate,
+      year
+    )
+
+    yearSummaries.push(result.summary)
+    portfolioData.push(result.summary.totalWorth)
+
+    totalWorth = result.endingWorth
+    totalInvested = result.endingInvested
+    currentMonthlyInvestment *= 1 + monthlyGrowthRate
+  }
+
+  return { yearSummaries, portfolioData }
+}

--- a/ui/services/summary-aggregator.test.ts
+++ b/ui/services/summary-aggregator.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect } from 'vitest'
+import {
+  mergeHistoricalWithCurrent,
+  sortSummariesByDateAsc,
+  sortSummariesByDateDesc,
+  findSummaryByDate,
+  flattenPages,
+} from './summary-aggregator'
+import type { PortfolioSummaryDto } from '../models/generated/domain-models'
+
+const createSummary = (date: string, totalValue: number = 1000): PortfolioSummaryDto => ({
+  date,
+  totalValue,
+  xirrAnnualReturn: 0.1,
+  realizedProfit: 100,
+  unrealizedProfit: 50,
+  totalProfit: 150,
+  earningsPerDay: 10,
+  earningsPerMonth: 300,
+  totalProfitChange24h: 5,
+})
+
+describe('summary-aggregator', () => {
+  describe('mergeHistoricalWithCurrent', () => {
+    it('should return historical summaries when current is null', () => {
+      const historical = [createSummary('2024-01-01'), createSummary('2024-01-02')]
+      const result = mergeHistoricalWithCurrent(historical, null)
+      expect(result).toEqual(historical)
+    })
+
+    it('should return historical summaries when current is undefined', () => {
+      const historical = [createSummary('2024-01-01')]
+      const result = mergeHistoricalWithCurrent(historical, undefined)
+      expect(result).toEqual(historical)
+    })
+
+    it('should replace existing summary with same date', () => {
+      const historical = [createSummary('2024-01-01', 1000), createSummary('2024-01-02', 2000)]
+      const current = createSummary('2024-01-02', 2500)
+
+      const result = mergeHistoricalWithCurrent(historical, current)
+
+      expect(result).toHaveLength(2)
+      expect(result[1].totalValue).toBe(2500)
+    })
+
+    it('should append current summary when date not found', () => {
+      const historical = [createSummary('2024-01-01')]
+      const current = createSummary('2024-01-02')
+
+      const result = mergeHistoricalWithCurrent(historical, current)
+
+      expect(result).toHaveLength(2)
+      expect(result[1].date).toBe('2024-01-02')
+    })
+
+    it('should not mutate original array', () => {
+      const historical = [createSummary('2024-01-01')]
+      const current = createSummary('2024-01-02')
+
+      mergeHistoricalWithCurrent(historical, current)
+
+      expect(historical).toHaveLength(1)
+    })
+
+    it('should handle empty historical array', () => {
+      const current = createSummary('2024-01-01')
+      const result = mergeHistoricalWithCurrent([], current)
+
+      expect(result).toHaveLength(1)
+      expect(result[0]).toEqual(current)
+    })
+  })
+
+  describe('sortSummariesByDateAsc', () => {
+    it('should sort summaries by date ascending', () => {
+      const summaries = [
+        createSummary('2024-01-03'),
+        createSummary('2024-01-01'),
+        createSummary('2024-01-02'),
+      ]
+
+      const result = sortSummariesByDateAsc(summaries)
+
+      expect(result[0].date).toBe('2024-01-01')
+      expect(result[1].date).toBe('2024-01-02')
+      expect(result[2].date).toBe('2024-01-03')
+    })
+
+    it('should not mutate original array', () => {
+      const summaries = [createSummary('2024-01-02'), createSummary('2024-01-01')]
+      sortSummariesByDateAsc(summaries)
+      expect(summaries[0].date).toBe('2024-01-02')
+    })
+
+    it('should handle empty array', () => {
+      expect(sortSummariesByDateAsc([])).toEqual([])
+    })
+
+    it('should handle single element', () => {
+      const summaries = [createSummary('2024-01-01')]
+      expect(sortSummariesByDateAsc(summaries)).toEqual(summaries)
+    })
+  })
+
+  describe('sortSummariesByDateDesc', () => {
+    it('should sort summaries by date descending', () => {
+      const summaries = [
+        createSummary('2024-01-01'),
+        createSummary('2024-01-03'),
+        createSummary('2024-01-02'),
+      ]
+
+      const result = sortSummariesByDateDesc(summaries)
+
+      expect(result[0].date).toBe('2024-01-03')
+      expect(result[1].date).toBe('2024-01-02')
+      expect(result[2].date).toBe('2024-01-01')
+    })
+  })
+
+  describe('findSummaryByDate', () => {
+    it('should find summary by date', () => {
+      const summaries = [createSummary('2024-01-01', 1000), createSummary('2024-01-02', 2000)]
+
+      const result = findSummaryByDate(summaries, '2024-01-02')
+
+      expect(result?.totalValue).toBe(2000)
+    })
+
+    it('should return undefined when date not found', () => {
+      const summaries = [createSummary('2024-01-01')]
+      const result = findSummaryByDate(summaries, '2024-01-02')
+      expect(result).toBeUndefined()
+    })
+
+    it('should return undefined for empty array', () => {
+      const result = findSummaryByDate([], '2024-01-01')
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe('flattenPages', () => {
+    it('should flatten pages into single array', () => {
+      const pages = [
+        { content: [createSummary('2024-01-01'), createSummary('2024-01-02')] },
+        { content: [createSummary('2024-01-03')] },
+      ]
+
+      const result = flattenPages(pages)
+
+      expect(result).toHaveLength(3)
+      expect(result[0].date).toBe('2024-01-01')
+      expect(result[2].date).toBe('2024-01-03')
+    })
+
+    it('should return empty array for undefined pages', () => {
+      const result = flattenPages(undefined)
+      expect(result).toEqual([])
+    })
+
+    it('should handle empty pages array', () => {
+      const result = flattenPages([])
+      expect(result).toEqual([])
+    })
+
+    it('should handle pages with empty content', () => {
+      const pages = [
+        { content: [] as PortfolioSummaryDto[] },
+        { content: [createSummary('2024-01-01')] },
+      ]
+      const result = flattenPages(pages)
+      expect(result).toHaveLength(1)
+    })
+  })
+})

--- a/ui/services/summary-aggregator.ts
+++ b/ui/services/summary-aggregator.ts
@@ -1,0 +1,42 @@
+import type { PortfolioSummaryDto } from '../models/generated/domain-models'
+
+export function mergeHistoricalWithCurrent(
+  historicalSummaries: PortfolioSummaryDto[],
+  currentSummary: PortfolioSummaryDto | null | undefined
+): PortfolioSummaryDto[] {
+  if (!currentSummary) {
+    return historicalSummaries
+  }
+
+  const result = [...historicalSummaries]
+  const existingIndex = result.findIndex(item => item.date === currentSummary.date)
+
+  if (existingIndex >= 0) {
+    result[existingIndex] = currentSummary
+  } else {
+    result.push(currentSummary)
+  }
+
+  return result
+}
+
+export function sortSummariesByDateAsc(summaries: PortfolioSummaryDto[]): PortfolioSummaryDto[] {
+  return [...summaries].sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
+}
+
+export function sortSummariesByDateDesc(summaries: PortfolioSummaryDto[]): PortfolioSummaryDto[] {
+  return sortSummariesByDateAsc(summaries).reverse()
+}
+
+export function findSummaryByDate(
+  summaries: PortfolioSummaryDto[],
+  date: string
+): PortfolioSummaryDto | undefined {
+  return summaries.find(summary => summary.date === date)
+}
+
+export function flattenPages<T extends { content: PortfolioSummaryDto[] }>(
+  pages: T[] | undefined
+): PortfolioSummaryDto[] {
+  return pages?.flatMap(page => page.content) ?? []
+}


### PR DESCRIPTION
## Summary

- Extract `PortfolioGrowthCalculator` from `use-calculator.ts` with pure functions for compound growth, tax calculation, and projections (27 unit tests)
- Extract `SummaryAggregator` from `use-portfolio-summary-query.ts` with pure functions for merge, sort, and flatten operations (18 unit tests)
- Extract `DailySummaryCalculator` from `SummaryService.kt` separating calculation logic from persistence orchestration
- Add `invoke` operator to `Xirr` class for cleaner API (`Xirr(cashFlows)()` instead of `.calculate()`)

## Test plan

- [x] All 546 frontend tests pass
- [x] All 261 backend tests pass
- [x] New pure calculator tests cover edge cases (zeros, negative values, compound growth)
- [x] Existing integration tests verify behavior unchanged

Closes #1043