### PR TITLE
Add cascading fallback models for OpenRouter classification

### DIFF
--- a/src/main/kotlin/ee/tenman/portfolio/domain/AiModel.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/domain/AiModel.kt
@@ -3,10 +3,15 @@ package ee.tenman.portfolio.domain
 enum class AiModel(
   val modelId: String,
   val rateLimitPerMinute: Int,
+  val fallbackTier: Int,
 ) {
-  CLAUDE_3_HAIKU("anthropic/claude-3-haiku", 30),
-  CLAUDE_HAIKU_4_5("anthropic/claude-haiku-4.5", 7),
+  CLAUDE_3_HAIKU("anthropic/claude-3-haiku", 30, 0),
+  CLAUDE_HAIKU_4_5("anthropic/claude-haiku-4.5", 7, 1),
+  CLAUDE_SONNET_4_5("anthropic/claude-sonnet-4.5", 2, 2),
+  CLAUDE_OPUS_4_5("anthropic/claude-opus-4.5", 1, 3),
   ;
+
+  fun getNextFallback(): AiModel? = entries.find { it.fallbackTier == this.fallbackTier + 1 }
 
   companion object {
     fun fromModelId(modelId: String): AiModel? = entries.find { it.modelId.equals(modelId, ignoreCase = true) }

--- a/src/main/kotlin/ee/tenman/portfolio/openrouter/ModelSelection.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/openrouter/ModelSelection.kt
@@ -1,6 +1,11 @@
 package ee.tenman.portfolio.openrouter
 
+import ee.tenman.portfolio.domain.AiModel
+
 data class ModelSelection(
-  val modelId: String,
-  val isUsingFallback: Boolean,
-)
+  val model: AiModel,
+  val fallbackTier: Int,
+) {
+  val modelId: String get() = model.modelId
+  val isUsingFallback: Boolean get() = fallbackTier > 0
+}

--- a/src/test/kotlin/ee/tenman/portfolio/openrouter/AiModelTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/openrouter/AiModelTest.kt
@@ -21,6 +21,20 @@ class AiModelTest {
   }
 
   @Test
+  fun `should return CLAUDE_SONNET_4_5 for matching model id`() {
+    val result = AiModel.fromModelId("anthropic/claude-sonnet-4.5")
+
+    expect(result).toEqual(AiModel.CLAUDE_SONNET_4_5)
+  }
+
+  @Test
+  fun `should return CLAUDE_OPUS_4_5 for matching model id`() {
+    val result = AiModel.fromModelId("anthropic/claude-opus-4.5")
+
+    expect(result).toEqual(AiModel.CLAUDE_OPUS_4_5)
+  }
+
+  @Test
   fun `should return null for unknown model id`() {
     val result = AiModel.fromModelId("unknown/model")
 
@@ -42,5 +56,51 @@ class AiModelTest {
   @Test
   fun `should have correct rate limits for CLAUDE_HAIKU_4_5`() {
     expect(AiModel.CLAUDE_HAIKU_4_5.rateLimitPerMinute).toEqual(7)
+  }
+
+  @Test
+  fun `should have correct rate limits for CLAUDE_SONNET_4_5`() {
+    expect(AiModel.CLAUDE_SONNET_4_5.rateLimitPerMinute).toEqual(2)
+  }
+
+  @Test
+  fun `should have correct rate limits for CLAUDE_OPUS_4_5`() {
+    expect(AiModel.CLAUDE_OPUS_4_5.rateLimitPerMinute).toEqual(1)
+  }
+
+  @Test
+  fun `should have correct fallback tiers`() {
+    expect(AiModel.CLAUDE_3_HAIKU.fallbackTier).toEqual(0)
+    expect(AiModel.CLAUDE_HAIKU_4_5.fallbackTier).toEqual(1)
+    expect(AiModel.CLAUDE_SONNET_4_5.fallbackTier).toEqual(2)
+    expect(AiModel.CLAUDE_OPUS_4_5.fallbackTier).toEqual(3)
+  }
+
+  @Test
+  fun `should return next fallback model for CLAUDE_3_HAIKU`() {
+    expect(AiModel.CLAUDE_3_HAIKU.getNextFallback()).toEqual(AiModel.CLAUDE_HAIKU_4_5)
+  }
+
+  @Test
+  fun `should return next fallback model for CLAUDE_HAIKU_4_5`() {
+    expect(AiModel.CLAUDE_HAIKU_4_5.getNextFallback()).toEqual(AiModel.CLAUDE_SONNET_4_5)
+  }
+
+  @Test
+  fun `should return next fallback model for CLAUDE_SONNET_4_5`() {
+    expect(AiModel.CLAUDE_SONNET_4_5.getNextFallback()).toEqual(AiModel.CLAUDE_OPUS_4_5)
+  }
+
+  @Test
+  fun `should return null for CLAUDE_OPUS_4_5 as last fallback`() {
+    expect(AiModel.CLAUDE_OPUS_4_5.getNextFallback()).toEqual(null)
+  }
+
+  @Test
+  fun `should have unique fallback tiers for all models`() {
+    val tiers = AiModel.entries.map { it.fallbackTier }
+    val uniqueTiers = tiers.toSet()
+
+    expect(tiers.size).toEqual(uniqueTiers.size)
   }
 }


### PR DESCRIPTION
## Summary

- Add CLAUDE_SONNET_4_5 (2 req/min) and CLAUDE_OPUS_4_5 (1 req/min) models
- Implement tiered fallback chain: Haiku 4.5 → Sonnet 4.5 → Opus 4.5
- Add per-model rate limiting via ConcurrentHashMap in circuit breaker
- Replace dual fallback methods with single `classifyWithCascadingFallback()` method
- When a model fails, system cascades through progressively more capable models

## Test plan

- [x] All existing tests updated and passing
- [x] New tests for SONNET_4_5 and OPUS_4_5 model IDs
- [x] New tests for fallback tier ordering and getNextFallback() chain
- [x] New tests for per-model rate limiting
- [x] New tests for cascading fallback behavior in classification service

Closes #1045