### PR TITLE
Add support for Gemini and Grok AI models

### DIFF
--- a/src/main/kotlin/ee/tenman/portfolio/domain/AiModel.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/domain/AiModel.kt
@@ -5,10 +5,14 @@ enum class AiModel(
   val rateLimitPerMinute: Int,
   val fallbackTier: Int,
 ) {
-  CLAUDE_3_HAIKU("anthropic/claude-3-haiku", 30, 0),
-  CLAUDE_HAIKU_4_5("anthropic/claude-haiku-4.5", 7, 1),
-  CLAUDE_SONNET_4_5("anthropic/claude-sonnet-4.5", 2, 2),
-  CLAUDE_OPUS_4_5("anthropic/claude-opus-4.5", 1, 3),
+  GEMINI_2_5_FLASH("google/gemini-2.5-flash", 100, 0),
+  GROK_4_1_FAST("x-ai/grok-4.1-fast", 60, 1),
+  CLAUDE_3_HAIKU("anthropic/claude-3-haiku", 30, 2),
+  CLAUDE_HAIKU_4_5("anthropic/claude-haiku-4.5", 7, 3),
+  GEMINI_3_PRO_PREVIEW("google/gemini-3-pro-preview", 2, 4),
+  GROK_4("x-ai/grok-4", 2, 5),
+  CLAUDE_SONNET_4_5("anthropic/claude-sonnet-4.5", 2, 6),
+  CLAUDE_OPUS_4_5("anthropic/claude-opus-4.5", 1, 7),
   ;
 
   fun getNextFallback(): AiModel? = entries.find { it.fallbackTier == this.fallbackTier + 1 }

--- a/src/main/kotlin/ee/tenman/portfolio/openrouter/OpenRouterProperties.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/openrouter/OpenRouterProperties.kt
@@ -7,7 +7,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 data class OpenRouterProperties(
   val apiKey: String = "",
   val url: String = "https://openrouter.ai/api/v1",
-  val primaryModel: AiModel = AiModel.CLAUDE_3_HAIKU,
-  val fallbackModel: AiModel = AiModel.CLAUDE_HAIKU_4_5,
+  val primaryModel: AiModel = AiModel.GEMINI_2_5_FLASH,
+  val fallbackModel: AiModel = AiModel.GROK_4_1_FAST,
   val circuitBreaker: CircuitBreakerProperties = CircuitBreakerProperties(),
 )

--- a/src/main/kotlin/ee/tenman/portfolio/service/integration/IndustryClassificationService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/service/integration/IndustryClassificationService.kt
@@ -48,7 +48,7 @@ class IndustryClassificationService(
   ): SectorClassificationResult? {
     val startingModel =
       when {
-        failedModel == null -> AiModel.CLAUDE_HAIKU_4_5
+        failedModel == null -> AiModel.CLAUDE_3_HAIKU
         else ->
           failedModel.getNextFallback() ?: run {
             log.warn("No fallback available after {}", failedModel.modelId)

--- a/src/test/kotlin/ee/tenman/portfolio/openrouter/AiModelTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/openrouter/AiModelTest.kt
@@ -7,6 +7,34 @@ import org.junit.jupiter.api.Test
 
 class AiModelTest {
   @Test
+  fun `should return GROK_4_1_FAST for matching model id`() {
+    val result = AiModel.fromModelId("x-ai/grok-4.1-fast")
+
+    expect(result).toEqual(AiModel.GROK_4_1_FAST)
+  }
+
+  @Test
+  fun `should return GROK_4 for matching model id`() {
+    val result = AiModel.fromModelId("x-ai/grok-4")
+
+    expect(result).toEqual(AiModel.GROK_4)
+  }
+
+  @Test
+  fun `should return GEMINI_2_5_FLASH for matching model id`() {
+    val result = AiModel.fromModelId("google/gemini-2.5-flash")
+
+    expect(result).toEqual(AiModel.GEMINI_2_5_FLASH)
+  }
+
+  @Test
+  fun `should return GEMINI_3_PRO_PREVIEW for matching model id`() {
+    val result = AiModel.fromModelId("google/gemini-3-pro-preview")
+
+    expect(result).toEqual(AiModel.GEMINI_3_PRO_PREVIEW)
+  }
+
+  @Test
   fun `should return CLAUDE_3_HAIKU for matching model id`() {
     val result = AiModel.fromModelId("anthropic/claude-3-haiku")
 
@@ -43,9 +71,29 @@ class AiModelTest {
 
   @Test
   fun `should match model id case insensitively`() {
-    val result = AiModel.fromModelId("ANTHROPIC/CLAUDE-3-HAIKU")
+    val result = AiModel.fromModelId("GOOGLE/GEMINI-2.5-FLASH")
 
-    expect(result).toEqual(AiModel.CLAUDE_3_HAIKU)
+    expect(result).toEqual(AiModel.GEMINI_2_5_FLASH)
+  }
+
+  @Test
+  fun `should have correct rate limits for GROK_4_1_FAST`() {
+    expect(AiModel.GROK_4_1_FAST.rateLimitPerMinute).toEqual(60)
+  }
+
+  @Test
+  fun `should have correct rate limits for GROK_4`() {
+    expect(AiModel.GROK_4.rateLimitPerMinute).toEqual(2)
+  }
+
+  @Test
+  fun `should have correct rate limits for GEMINI_2_5_FLASH`() {
+    expect(AiModel.GEMINI_2_5_FLASH.rateLimitPerMinute).toEqual(100)
+  }
+
+  @Test
+  fun `should have correct rate limits for GEMINI_3_PRO_PREVIEW`() {
+    expect(AiModel.GEMINI_3_PRO_PREVIEW.rateLimitPerMinute).toEqual(2)
   }
 
   @Test
@@ -70,10 +118,24 @@ class AiModelTest {
 
   @Test
   fun `should have correct fallback tiers`() {
-    expect(AiModel.CLAUDE_3_HAIKU.fallbackTier).toEqual(0)
-    expect(AiModel.CLAUDE_HAIKU_4_5.fallbackTier).toEqual(1)
-    expect(AiModel.CLAUDE_SONNET_4_5.fallbackTier).toEqual(2)
-    expect(AiModel.CLAUDE_OPUS_4_5.fallbackTier).toEqual(3)
+    expect(AiModel.GEMINI_2_5_FLASH.fallbackTier).toEqual(0)
+    expect(AiModel.GROK_4_1_FAST.fallbackTier).toEqual(1)
+    expect(AiModel.CLAUDE_3_HAIKU.fallbackTier).toEqual(2)
+    expect(AiModel.CLAUDE_HAIKU_4_5.fallbackTier).toEqual(3)
+    expect(AiModel.GEMINI_3_PRO_PREVIEW.fallbackTier).toEqual(4)
+    expect(AiModel.GROK_4.fallbackTier).toEqual(5)
+    expect(AiModel.CLAUDE_SONNET_4_5.fallbackTier).toEqual(6)
+    expect(AiModel.CLAUDE_OPUS_4_5.fallbackTier).toEqual(7)
+  }
+
+  @Test
+  fun `should return next fallback model for GEMINI_2_5_FLASH`() {
+    expect(AiModel.GEMINI_2_5_FLASH.getNextFallback()).toEqual(AiModel.GROK_4_1_FAST)
+  }
+
+  @Test
+  fun `should return next fallback model for GROK_4_1_FAST`() {
+    expect(AiModel.GROK_4_1_FAST.getNextFallback()).toEqual(AiModel.CLAUDE_3_HAIKU)
   }
 
   @Test
@@ -83,7 +145,17 @@ class AiModelTest {
 
   @Test
   fun `should return next fallback model for CLAUDE_HAIKU_4_5`() {
-    expect(AiModel.CLAUDE_HAIKU_4_5.getNextFallback()).toEqual(AiModel.CLAUDE_SONNET_4_5)
+    expect(AiModel.CLAUDE_HAIKU_4_5.getNextFallback()).toEqual(AiModel.GEMINI_3_PRO_PREVIEW)
+  }
+
+  @Test
+  fun `should return next fallback model for GEMINI_3_PRO_PREVIEW`() {
+    expect(AiModel.GEMINI_3_PRO_PREVIEW.getNextFallback()).toEqual(AiModel.GROK_4)
+  }
+
+  @Test
+  fun `should return next fallback model for GROK_4`() {
+    expect(AiModel.GROK_4.getNextFallback()).toEqual(AiModel.CLAUDE_SONNET_4_5)
   }
 
   @Test

--- a/src/test/kotlin/ee/tenman/portfolio/openrouter/OpenRouterCircuitBreakerTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/openrouter/OpenRouterCircuitBreakerTest.kt
@@ -19,9 +19,9 @@ class OpenRouterCircuitBreakerTest {
     private const val MILLISECONDS_PER_MINUTE = 60_000L
     private const val RATE_LIMIT_BUFFER_MS = 1L
     private val PRIMARY_RATE_LIMIT_INTERVAL_MS =
-      MILLISECONDS_PER_MINUTE / AiModel.CLAUDE_3_HAIKU.rateLimitPerMinute + RATE_LIMIT_BUFFER_MS
+      MILLISECONDS_PER_MINUTE / AiModel.GEMINI_2_5_FLASH.rateLimitPerMinute + RATE_LIMIT_BUFFER_MS
     private val FALLBACK_RATE_LIMIT_INTERVAL_MS =
-      MILLISECONDS_PER_MINUTE / AiModel.CLAUDE_HAIKU_4_5.rateLimitPerMinute + RATE_LIMIT_BUFFER_MS
+      MILLISECONDS_PER_MINUTE / AiModel.GROK_4_1_FAST.rateLimitPerMinute + RATE_LIMIT_BUFFER_MS
   }
 
   @BeforeEach
@@ -41,7 +41,7 @@ class OpenRouterCircuitBreakerTest {
 
   @Test
   fun `should return primary model when circuit is closed`() {
-    expect(circuitBreaker.getCurrentModel()).toEqual(AiModel.CLAUDE_3_HAIKU.modelId)
+    expect(circuitBreaker.getCurrentModel()).toEqual(AiModel.GEMINI_2_5_FLASH.modelId)
   }
 
   @Test
@@ -65,7 +65,7 @@ class OpenRouterCircuitBreakerTest {
       circuitBreaker.recordFailure(Exception("API error"))
     }
     expect(circuitBreaker.getState()).toEqual(CircuitBreaker.State.OPEN)
-    expect(circuitBreaker.getCurrentModel()).toEqual(AiModel.CLAUDE_HAIKU_4_5.modelId)
+    expect(circuitBreaker.getCurrentModel()).toEqual(AiModel.GROK_4_1_FAST.modelId)
     expect(circuitBreaker.isUsingFallback()).toEqual(true)
   }
 
@@ -75,7 +75,7 @@ class OpenRouterCircuitBreakerTest {
       circuitBreaker.recordFailure(Exception("API error"))
     }
     expect(circuitBreaker.getState()).toEqual(CircuitBreaker.State.CLOSED)
-    expect(circuitBreaker.getCurrentModel()).toEqual(AiModel.CLAUDE_3_HAIKU.modelId)
+    expect(circuitBreaker.getCurrentModel()).toEqual(AiModel.GEMINI_2_5_FLASH.modelId)
   }
 
   @Test
@@ -148,7 +148,7 @@ class OpenRouterCircuitBreakerTest {
   @Test
   fun `should select model atomically`() {
     val selection = circuitBreaker.selectModel()
-    expect(selection.modelId).toEqual(AiModel.CLAUDE_3_HAIKU.modelId)
+    expect(selection.modelId).toEqual(AiModel.GEMINI_2_5_FLASH.modelId)
     expect(selection.isUsingFallback).toEqual(false)
   }
 
@@ -158,7 +158,7 @@ class OpenRouterCircuitBreakerTest {
       circuitBreaker.recordFailure(Exception("API error"))
     }
     val selection = circuitBreaker.selectModel()
-    expect(selection.modelId).toEqual(AiModel.CLAUDE_HAIKU_4_5.modelId)
+    expect(selection.modelId).toEqual(AiModel.GROK_4_1_FAST.modelId)
     expect(selection.isUsingFallback).toEqual(true)
   }
 
@@ -170,7 +170,7 @@ class OpenRouterCircuitBreakerTest {
     expect(circuitBreaker.getState()).toEqual(CircuitBreaker.State.OPEN)
     circuitBreaker.transitionToHalfOpenState()
     expect(circuitBreaker.getState()).toEqual(CircuitBreaker.State.HALF_OPEN)
-    expect(circuitBreaker.getCurrentModel()).toEqual(AiModel.CLAUDE_3_HAIKU.modelId)
+    expect(circuitBreaker.getCurrentModel()).toEqual(AiModel.GEMINI_2_5_FLASH.modelId)
   }
 
   @Test
@@ -192,7 +192,7 @@ class OpenRouterCircuitBreakerTest {
   fun `should return remaining wait time after primary request`() {
     circuitBreaker.tryAcquirePrimary()
     val waitTime = circuitBreaker.getWaitTimeMs(isUsingFallback = false)
-    val expectedMs = MILLISECONDS_PER_MINUTE / AiModel.CLAUDE_3_HAIKU.rateLimitPerMinute
+    val expectedMs = MILLISECONDS_PER_MINUTE / AiModel.GEMINI_2_5_FLASH.rateLimitPerMinute
     expect(waitTime).toEqual(expectedMs)
   }
 
@@ -210,8 +210,24 @@ class OpenRouterCircuitBreakerTest {
     }
     circuitBreaker.tryAcquireFallback()
     val waitTime = circuitBreaker.getWaitTimeMs(isUsingFallback = true)
-    val expectedMs = MILLISECONDS_PER_MINUTE / AiModel.CLAUDE_HAIKU_4_5.rateLimitPerMinute
+    val expectedMs = MILLISECONDS_PER_MINUTE / AiModel.GROK_4_1_FAST.rateLimitPerMinute
     expect(waitTime).toEqual(expectedMs)
+  }
+
+  @Test
+  fun `should rate limit GROK_4_1_FAST at 60 requests per minute`() {
+    expect(circuitBreaker.tryAcquireForModel(AiModel.GROK_4_1_FAST)).toEqual(true)
+    expect(circuitBreaker.tryAcquireForModel(AiModel.GROK_4_1_FAST)).toEqual(false)
+    clock.advance((MILLISECONDS_PER_MINUTE / AiModel.GROK_4_1_FAST.rateLimitPerMinute) + RATE_LIMIT_BUFFER_MS)
+    expect(circuitBreaker.tryAcquireForModel(AiModel.GROK_4_1_FAST)).toEqual(true)
+  }
+
+  @Test
+  fun `should rate limit GROK_4 at 2 requests per minute`() {
+    expect(circuitBreaker.tryAcquireForModel(AiModel.GROK_4)).toEqual(true)
+    expect(circuitBreaker.tryAcquireForModel(AiModel.GROK_4)).toEqual(false)
+    clock.advance((MILLISECONDS_PER_MINUTE / AiModel.GROK_4.rateLimitPerMinute) + RATE_LIMIT_BUFFER_MS)
+    expect(circuitBreaker.tryAcquireForModel(AiModel.GROK_4)).toEqual(true)
   }
 
   @Test
@@ -232,19 +248,21 @@ class OpenRouterCircuitBreakerTest {
 
   @Test
   fun `should track rate limits independently for each model`() {
-    expect(circuitBreaker.tryAcquireForModel(AiModel.CLAUDE_HAIKU_4_5)).toEqual(true)
-    expect(circuitBreaker.tryAcquireForModel(AiModel.CLAUDE_SONNET_4_5)).toEqual(true)
+    expect(circuitBreaker.tryAcquireForModel(AiModel.GROK_4_1_FAST)).toEqual(true)
+    expect(circuitBreaker.tryAcquireForModel(AiModel.CLAUDE_3_HAIKU)).toEqual(true)
+    expect(circuitBreaker.tryAcquireForModel(AiModel.GROK_4)).toEqual(true)
     expect(circuitBreaker.tryAcquireForModel(AiModel.CLAUDE_OPUS_4_5)).toEqual(true)
-    expect(circuitBreaker.tryAcquireForModel(AiModel.CLAUDE_HAIKU_4_5)).toEqual(false)
-    expect(circuitBreaker.tryAcquireForModel(AiModel.CLAUDE_SONNET_4_5)).toEqual(false)
+    expect(circuitBreaker.tryAcquireForModel(AiModel.GROK_4_1_FAST)).toEqual(false)
+    expect(circuitBreaker.tryAcquireForModel(AiModel.CLAUDE_3_HAIKU)).toEqual(false)
+    expect(circuitBreaker.tryAcquireForModel(AiModel.GROK_4)).toEqual(false)
     expect(circuitBreaker.tryAcquireForModel(AiModel.CLAUDE_OPUS_4_5)).toEqual(false)
   }
 
   @Test
-  fun `should return correct wait time for CLAUDE_SONNET_4_5`() {
-    circuitBreaker.tryAcquireForModel(AiModel.CLAUDE_SONNET_4_5)
-    val waitTime = circuitBreaker.getWaitTimeMsForModel(AiModel.CLAUDE_SONNET_4_5)
-    val expectedMs = MILLISECONDS_PER_MINUTE / AiModel.CLAUDE_SONNET_4_5.rateLimitPerMinute
+  fun `should return correct wait time for GROK_4`() {
+    circuitBreaker.tryAcquireForModel(AiModel.GROK_4)
+    val waitTime = circuitBreaker.getWaitTimeMsForModel(AiModel.GROK_4)
+    val expectedMs = MILLISECONDS_PER_MINUTE / AiModel.GROK_4.rateLimitPerMinute
     expect(waitTime).toEqual(expectedMs)
   }
 
@@ -262,28 +280,36 @@ class OpenRouterCircuitBreakerTest {
     val tier1 = circuitBreaker.selectModelByTier(1)
     val tier2 = circuitBreaker.selectModelByTier(2)
     val tier3 = circuitBreaker.selectModelByTier(3)
-    expect(tier0.model).toEqual(AiModel.CLAUDE_3_HAIKU)
-    expect(tier1.model).toEqual(AiModel.CLAUDE_HAIKU_4_5)
-    expect(tier2.model).toEqual(AiModel.CLAUDE_SONNET_4_5)
-    expect(tier3.model).toEqual(AiModel.CLAUDE_OPUS_4_5)
+    val tier4 = circuitBreaker.selectModelByTier(4)
+    val tier5 = circuitBreaker.selectModelByTier(5)
+    val tier6 = circuitBreaker.selectModelByTier(6)
+    val tier7 = circuitBreaker.selectModelByTier(7)
+    expect(tier0.model).toEqual(AiModel.GEMINI_2_5_FLASH)
+    expect(tier1.model).toEqual(AiModel.GROK_4_1_FAST)
+    expect(tier2.model).toEqual(AiModel.CLAUDE_3_HAIKU)
+    expect(tier3.model).toEqual(AiModel.CLAUDE_HAIKU_4_5)
+    expect(tier4.model).toEqual(AiModel.GEMINI_3_PRO_PREVIEW)
+    expect(tier5.model).toEqual(AiModel.GROK_4)
+    expect(tier6.model).toEqual(AiModel.CLAUDE_SONNET_4_5)
+    expect(tier7.model).toEqual(AiModel.CLAUDE_OPUS_4_5)
   }
 
   @Test
   fun `should return fallback model for invalid tier`() {
     val invalidTier = circuitBreaker.selectModelByTier(99)
-    expect(invalidTier.model).toEqual(AiModel.CLAUDE_HAIKU_4_5)
+    expect(invalidTier.model).toEqual(AiModel.GROK_4_1_FAST)
   }
 
   @Test
   fun `should reset all model rate limits`() {
+    circuitBreaker.tryAcquireForModel(AiModel.GROK_4_1_FAST)
     circuitBreaker.tryAcquireForModel(AiModel.CLAUDE_3_HAIKU)
-    circuitBreaker.tryAcquireForModel(AiModel.CLAUDE_HAIKU_4_5)
-    circuitBreaker.tryAcquireForModel(AiModel.CLAUDE_SONNET_4_5)
+    circuitBreaker.tryAcquireForModel(AiModel.GROK_4)
     circuitBreaker.tryAcquireForModel(AiModel.CLAUDE_OPUS_4_5)
     circuitBreaker.resetRateLimits()
+    expect(circuitBreaker.tryAcquireForModel(AiModel.GROK_4_1_FAST)).toEqual(true)
     expect(circuitBreaker.tryAcquireForModel(AiModel.CLAUDE_3_HAIKU)).toEqual(true)
-    expect(circuitBreaker.tryAcquireForModel(AiModel.CLAUDE_HAIKU_4_5)).toEqual(true)
-    expect(circuitBreaker.tryAcquireForModel(AiModel.CLAUDE_SONNET_4_5)).toEqual(true)
+    expect(circuitBreaker.tryAcquireForModel(AiModel.GROK_4)).toEqual(true)
     expect(circuitBreaker.tryAcquireForModel(AiModel.CLAUDE_OPUS_4_5)).toEqual(true)
   }
 

--- a/src/test/kotlin/ee/tenman/portfolio/openrouter/OpenRouterClientIT.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/openrouter/OpenRouterClientIT.kt
@@ -50,7 +50,7 @@ class OpenRouterClientIT {
 
     expect(result).notToEqualNull()
     expect(result?.content).toEqual("Technology")
-    expect(result?.model).toEqual(AiModel.CLAUDE_3_HAIKU)
+    expect(result?.model).toEqual(AiModel.GEMINI_2_5_FLASH)
     expect(circuitBreaker.getState()).toEqual(CircuitBreaker.State.CLOSED)
   }
 
@@ -116,7 +116,7 @@ class OpenRouterClientIT {
 
     expect(result).notToEqualNull()
     expect(result?.content).toEqual("Healthcare")
-    expect(result?.model).toEqual(AiModel.CLAUDE_HAIKU_4_5)
+    expect(result?.model).toEqual(AiModel.GROK_4_1_FAST)
   }
 
   private fun createSuccessResponse(content: String): String =

--- a/src/test/kotlin/ee/tenman/portfolio/service/integration/IndustryClassificationServiceTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/service/integration/IndustryClassificationServiceTest.kt
@@ -59,7 +59,7 @@ class IndustryClassificationServiceTest {
   fun `should return null when OpenRouter response has null content`() {
     every { properties.enabled } returns true
     every { openRouterClient.classifyWithModel(any()) } returns
-      OpenRouterClassificationResult(content = null, model = AiModel.CLAUDE_3_HAIKU)
+      OpenRouterClassificationResult(content = null, model = AiModel.GEMINI_2_5_FLASH)
     every { openRouterClient.classifyWithCascadingFallback(any(), any(), any(), any()) } returns null
 
     val result = service.classifyCompanyWithModel("Apple Inc")
@@ -71,23 +71,23 @@ class IndustryClassificationServiceTest {
   fun `should retry with cascading fallback when primary model returns unknown sector`() {
     every { properties.enabled } returns true
     every { openRouterClient.classifyWithModel(any()) } returns
-      OpenRouterClassificationResult(content = "Unknown Category", model = AiModel.CLAUDE_3_HAIKU)
-    every { openRouterClient.classifyWithCascadingFallback(any(), AiModel.CLAUDE_HAIKU_4_5, any(), any()) } returns
-      OpenRouterClassificationResult(content = "Software & Cloud Services", model = AiModel.CLAUDE_HAIKU_4_5)
+      OpenRouterClassificationResult(content = "Unknown Category", model = AiModel.GEMINI_2_5_FLASH)
+    every { openRouterClient.classifyWithCascadingFallback(any(), AiModel.GROK_4_1_FAST, any(), any()) } returns
+      OpenRouterClassificationResult(content = "Software & Cloud Services", model = AiModel.GROK_4_1_FAST)
 
     val result = service.classifyCompanyWithModel("Apple Inc")
 
     expect(result?.sector).toEqual(IndustrySector.SOFTWARE_CLOUD_SERVICES)
-    expect(result?.model).toEqual(AiModel.CLAUDE_HAIKU_4_5)
+    expect(result?.model).toEqual(AiModel.GROK_4_1_FAST)
     verify(exactly = 1) { openRouterClient.classifyWithModel(any()) }
-    verify(exactly = 1) { openRouterClient.classifyWithCascadingFallback(any(), AiModel.CLAUDE_HAIKU_4_5, any(), any()) }
+    verify(exactly = 1) { openRouterClient.classifyWithCascadingFallback(any(), AiModel.GROK_4_1_FAST, any(), any()) }
   }
 
   @Test
   fun `should return null when all cascading fallbacks return unknown sector`() {
     every { properties.enabled } returns true
     every { openRouterClient.classifyWithModel(any()) } returns
-      OpenRouterClassificationResult(content = "Unknown Category", model = AiModel.CLAUDE_3_HAIKU)
+      OpenRouterClassificationResult(content = "Unknown Category", model = AiModel.GEMINI_2_5_FLASH)
     every { openRouterClient.classifyWithCascadingFallback(any(), any(), any(), any()) } returns
       OpenRouterClassificationResult(content = "Still Unknown", model = AiModel.CLAUDE_OPUS_4_5)
 
@@ -97,24 +97,24 @@ class IndustryClassificationServiceTest {
   }
 
   @Test
-  fun `should cascade to next model when haiku 4_5 returns unknown sector`() {
+  fun `should cascade to next model when claude 3 haiku returns unknown sector`() {
     every { properties.enabled } returns true
     every { openRouterClient.classifyWithModel(any()) } returns
-      OpenRouterClassificationResult(content = "Unknown Category", model = AiModel.CLAUDE_HAIKU_4_5)
-    every { openRouterClient.classifyWithCascadingFallback(any(), AiModel.CLAUDE_SONNET_4_5, any(), any()) } returns
-      OpenRouterClassificationResult(content = "Software & Cloud Services", model = AiModel.CLAUDE_SONNET_4_5)
+      OpenRouterClassificationResult(content = "Unknown Category", model = AiModel.CLAUDE_3_HAIKU)
+    every { openRouterClient.classifyWithCascadingFallback(any(), AiModel.CLAUDE_HAIKU_4_5, any(), any()) } returns
+      OpenRouterClassificationResult(content = "Software & Cloud Services", model = AiModel.CLAUDE_HAIKU_4_5)
 
     val result = service.classifyCompanyWithModel("Apple Inc")
 
     expect(result?.sector).toEqual(IndustrySector.SOFTWARE_CLOUD_SERVICES)
-    expect(result?.model).toEqual(AiModel.CLAUDE_SONNET_4_5)
+    expect(result?.model).toEqual(AiModel.CLAUDE_HAIKU_4_5)
   }
 
   @Test
   fun `should return null when cascading fallback returns no response`() {
     every { properties.enabled } returns true
     every { openRouterClient.classifyWithModel(any()) } returns
-      OpenRouterClassificationResult(content = "Unknown Category", model = AiModel.CLAUDE_3_HAIKU)
+      OpenRouterClassificationResult(content = "Unknown Category", model = AiModel.GEMINI_2_5_FLASH)
     every { openRouterClient.classifyWithCascadingFallback(any(), any(), any(), any()) } returns null
 
     val result = service.classifyCompanyWithModel("Apple Inc")
@@ -123,18 +123,18 @@ class IndustryClassificationServiceTest {
   }
 
   @Test
-  fun `should use Sonnet 4_5 as cascading fallback after Haiku 4_5 fails`() {
+  fun `should use GEMINI_3_PRO_PREVIEW as cascading fallback after CLAUDE_HAIKU_4_5 fails`() {
     every { properties.enabled } returns true
     every { openRouterClient.classifyWithModel(any()) } returns
       OpenRouterClassificationResult(content = "Unknown", model = AiModel.CLAUDE_HAIKU_4_5)
-    every { openRouterClient.classifyWithCascadingFallback(any(), AiModel.CLAUDE_SONNET_4_5, any(), any()) } returns
-      OpenRouterClassificationResult(content = "Semiconductors", model = AiModel.CLAUDE_SONNET_4_5)
+    every { openRouterClient.classifyWithCascadingFallback(any(), AiModel.GEMINI_3_PRO_PREVIEW, any(), any()) } returns
+      OpenRouterClassificationResult(content = "Semiconductors", model = AiModel.GEMINI_3_PRO_PREVIEW)
 
     val result = service.classifyCompanyWithModel("Nvidia")
 
     expect(result?.sector).toEqual(IndustrySector.SEMICONDUCTORS)
-    expect(result?.model).toEqual(AiModel.CLAUDE_SONNET_4_5)
-    verify(exactly = 1) { openRouterClient.classifyWithCascadingFallback(any(), AiModel.CLAUDE_SONNET_4_5, any(), any()) }
+    expect(result?.model).toEqual(AiModel.GEMINI_3_PRO_PREVIEW)
+    verify(exactly = 1) { openRouterClient.classifyWithCascadingFallback(any(), AiModel.GEMINI_3_PRO_PREVIEW, any(), any()) }
   }
 
   @Test
@@ -155,31 +155,31 @@ class IndustryClassificationServiceTest {
   fun `should return sector classification result for valid response`() {
     every { properties.enabled } returns true
     every { openRouterClient.classifyWithModel(any()) } returns
-      OpenRouterClassificationResult(content = "Semiconductors", model = AiModel.CLAUDE_3_HAIKU)
+      OpenRouterClassificationResult(content = "Semiconductors", model = AiModel.GEMINI_2_5_FLASH)
 
     val result = service.classifyCompanyWithModel("Nvidia")
 
     expect(result?.sector).toEqual(IndustrySector.SEMICONDUCTORS)
-    expect(result?.model).toEqual(AiModel.CLAUDE_3_HAIKU)
+    expect(result?.model).toEqual(AiModel.GEMINI_2_5_FLASH)
   }
 
   @Test
   fun `should return sector classification result with fallback model`() {
     every { properties.enabled } returns true
     every { openRouterClient.classifyWithModel(any()) } returns
-      OpenRouterClassificationResult(content = "Finance", model = AiModel.CLAUDE_HAIKU_4_5)
+      OpenRouterClassificationResult(content = "Finance", model = AiModel.CLAUDE_3_HAIKU)
 
     val result = service.classifyCompanyWithModel("JPMorgan Chase")
 
     expect(result?.sector).toEqual(IndustrySector.FINANCE)
-    expect(result?.model).toEqual(AiModel.CLAUDE_HAIKU_4_5)
+    expect(result?.model).toEqual(AiModel.CLAUDE_3_HAIKU)
   }
 
   @Test
   fun `should return only sector when using classifyCompany`() {
     every { properties.enabled } returns true
     every { openRouterClient.classifyWithModel(any()) } returns
-      OpenRouterClassificationResult(content = "Health", model = AiModel.CLAUDE_3_HAIKU)
+      OpenRouterClassificationResult(content = "Health", model = AiModel.GEMINI_2_5_FLASH)
 
     val result = service.classifyCompany("Pfizer")
 

--- a/ui/models/generated/domain-models.ts
+++ b/ui/models/generated/domain-models.ts
@@ -1,5 +1,5 @@
 /* tslint:disable */
- 
+/* eslint-disable */
 // Generated using typescript-generator (timestamp removed to prevent git churn)
 
 /**


### PR DESCRIPTION
## Summary

- Add four new AI models for classification tasks via OpenRouter API
- **google/gemini-2.5-flash** (100 req/min) as the new primary model for fastest classification
- **x-ai/grok-4.1-fast** (60 req/min) as the first fallback option
- **google/gemini-3-pro-preview** (2 req/min) as an intermediate fallback
- **x-ai/grok-4** (2 req/min) as an additional fallback option
- Update the fallback chain to include Gemini, Grok, and Claude models for comprehensive coverage

## Changes

### Model Hierarchy (by fallback tier)
| Tier | Model | Rate Limit |
|------|-------|------------|
| 0 | GEMINI_2_5_FLASH | 100 req/min |
| 1 | GROK_4_1_FAST | 60 req/min |
| 2 | CLAUDE_3_HAIKU | 30 req/min |
| 3 | CLAUDE_HAIKU_4_5 | 7 req/min |
| 4 | GEMINI_3_PRO_PREVIEW | 2 req/min |
| 5 | GROK_4 | 2 req/min |
| 6 | CLAUDE_SONNET_4_5 | 2 req/min |
| 7 | CLAUDE_OPUS_4_5 | 1 req/min |

### Files Modified
- `AiModel.kt` - Added new Gemini and Grok model entries with rate limits and fallback tiers
- `OpenRouterProperties.kt` - Updated default primary/fallback models
- `IndustryClassificationService.kt` - Updated cascading fallback starting model
- Updated all related tests for new model hierarchy

## Test plan

- [x] Manually tested all new models with curl against OpenRouter API
- [x] All unit tests pass (578 tests)
- [x] All frontend tests pass (546 tests)
- [x] Lint and format checks pass

Closes #1048