### PR TITLE
Add BNBEUR instrument and initial buy transaction

### DIFF
--- a/src/main/resources/db/migration/V202512121400__add_bnbeur_instrument.sql
+++ b/src/main/resources/db/migration/V202512121400__add_bnbeur_instrument.sql
@@ -24,7 +24,7 @@ INSERT INTO portfolio_transaction (instrument_id, transaction_type, quantity, pr
 VALUES (
     (SELECT id FROM instrument WHERE symbol = 'BNBEUR'),
     'BUY',
-    0.13289525,
+    0.1330711,
     747.9257,
     '2025-12-12',
     'BINANCE'


### PR DESCRIPTION
## Summary
- Add new BNBEUR (BNB/EUR) cryptocurrency instrument for Binance platform
- Record initial buy transaction: 0.13289525 BNB at 747.93 EUR

## Details
- **Symbol**: BNBEUR
- **Platform**: BINANCE
- **Category**: Cryptocurrency
- **Quantity**: 0.13289525 BNB
- **Price**: 747.9257 EUR
- **Total Cost**: ~99.39 EUR

## Test plan
- [ ] Flyway migration runs successfully
- [ ] Instrument appears in portfolio
- [ ] Price updates work correctly via Binance API

Closes #1060