### PR TITLE
Use pre-built base image in Dockerfile.e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,10 +145,13 @@ jobs:
           ./gradlew bootJar --build-cache
           JAR_FILE=$(find build/libs -name "*.jar" ! -name "*-plain.jar" | head -1)
           cp "$JAR_FILE" src/app.jar
+      - name: Build base image
+        if: matrix.type == 'e2e'
+        run: docker build -t ghcr.io/ktenman/portfolio-base:firefox -f src/Dockerfile.base src/
       - uses: ScribeMD/docker-cache@0.5.0
         if: matrix.type == 'e2e'
         with:
-          key: docker-${{ runner.os }}-${{ hashFiles('docker-compose.e2e-minimal.yml', 'src/Dockerfile.e2e') }}
+          key: docker-${{ runner.os }}-${{ hashFiles('docker-compose.e2e-minimal.yml', 'src/Dockerfile.e2e', 'src/Dockerfile.base') }}
       - name: Start services
         if: matrix.type == 'e2e'
         env:

--- a/src/Dockerfile.e2e
+++ b/src/Dockerfile.e2e
@@ -1,63 +1,9 @@
-FROM openjdk:25-ea-21-jdk-slim-bookworm
-WORKDIR /app
+FROM ghcr.io/ktenman/portfolio-base:firefox
 
 ARG BUILD_HASH=unknown
 ARG BUILD_TIME=unknown
 ENV BUILD_HASH=${BUILD_HASH}
 ENV BUILD_TIME=${BUILD_TIME}
-
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-        curl \
-        firefox-esr \
-        fonts-liberation \
-        libasound2 \
-        libdbus-glib-1-2 \
-        libfreetype6 \
-        libgtk-3-0 \
-        libx11-xcb1 \
-        libxcb-dri3-0 \
-        libxcomposite1 \
-        libxcursor1 \
-        libxdamage1 \
-        libxfixes3 \
-        libxi6 \
-        libxrandr2 \
-        libxrender1 \
-        libxss1 \
-        libxt6 \
-        libxtst6 \
-        tar && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
-RUN ARCH=$(uname -m); \
-    case ${ARCH} in \
-        aarch64) GECKODRIVER_ARCH="linux-aarch64" ;; \
-        x86_64) GECKODRIVER_ARCH="linux64" ;; \
-        *) echo "Unsupported architecture: ${ARCH}" && exit 1 ;; \
-    esac && \
-    GECKODRIVER_VERSION="v0.36.0" && \
-    echo "Downloading geckodriver ${GECKODRIVER_VERSION} for ${GECKODRIVER_ARCH}" && \
-    curl -sL "https://github.com/mozilla/geckodriver/releases/download/${GECKODRIVER_VERSION}/geckodriver-${GECKODRIVER_VERSION}-${GECKODRIVER_ARCH}.tar.gz" | tar -xz -C /usr/bin/ && \
-    chmod +x /usr/bin/geckodriver && \
-    geckodriver --version
-
-RUN useradd -m -s /bin/bash appuser && \
-    chown -R appuser:appuser /app
-
-ENV JAVA_OPTS="-Xms1024m -Xmx3072m -XX:+UseG1GC -XX:+UseStringDeduplication -Duser.timezone=Europe/Tallinn -Dwebdriver.gecko.driver=/usr/bin/geckodriver -Dwebdriver.firefox.bin=/usr/bin/firefox-esr" \
-    JAVA_TOOL_OPTIONS="-XX:MaxRAMPercentage=85 -XX:+UseContainerSupport -XX:+ExitOnOutOfMemoryError" \
-    SE_GECKO_DRIVER="/usr/bin/geckodriver" \
-    SE_FIREFOX_BINARY="/usr/bin/firefox-esr" \
-    FIREFOX_BIN="/usr/bin/firefox-esr" \
-    PATH="/usr/bin/firefox-esr:/usr/bin/geckodriver:${PATH}" \
-    SERVER_PORT=8080 \
-    MOZ_HEADLESS=1 \
-    MOZ_MEMORY_LIMIT=2048 \
-    MOZ_DISABLE_CONTENT_SANDBOX=1 \
-    GECKODRIVER_ARGS="--log trace" \
-    LC_ALL=C.UTF-8
 
 COPY app.jar app.jar
 


### PR DESCRIPTION
## Summary

Simplifies `Dockerfile.e2e` by using the pre-built base image with Firefox and geckodriver pre-installed, reducing it from 69 lines to 14 lines.

### Changes
- Updated `src/Dockerfile.e2e` to use `ghcr.io/ktenman/portfolio-base:firefox`
- Added "Build base image" step in CI workflow before E2E tests
- Updated docker cache key to include `Dockerfile.base` hash

### How it works
1. CI builds the base image locally before E2E tests (ensures image exists)
2. Once merged to main, the `build-base-image.yml` workflow pushes it to GHCR
3. Future runs can pull the cached base image from GHCR (faster)

### Expected savings
~30-60 seconds per E2E run by not installing Firefox/geckodriver each time.

Closes #1063

## Test plan
- [x] E2E tests pass with the new base image setup
- [x] All other tests unaffected