### PR TITLE
Add EUR cash instrument support for Swedbank holdings

### DIFF
--- a/src/main/kotlin/ee/tenman/portfolio/domain/InstrumentCategory.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/domain/InstrumentCategory.kt
@@ -1,6 +1,7 @@
 package ee.tenman.portfolio.domain
 
 enum class InstrumentCategory {
+  CASH,
   CRYPTO,
   ETF,
 }

--- a/src/main/kotlin/ee/tenman/portfolio/domain/ProviderName.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/domain/ProviderName.kt
@@ -4,5 +4,6 @@ enum class ProviderName {
   BINANCE,
   FT,
   LIGHTYEAR,
+  MANUAL,
   TRADING212,
 }

--- a/src/main/resources/db/migration/V202512161200__add_eur_cash_instrument.sql
+++ b/src/main/resources/db/migration/V202512161200__add_eur_cash_instrument.sql
@@ -1,0 +1,77 @@
+ALTER TABLE instrument
+DROP CONSTRAINT IF EXISTS instrument_provider_check;
+
+ALTER TABLE daily_price
+DROP CONSTRAINT IF EXISTS daily_price_provider_check;
+
+ALTER TABLE instrument
+  ADD CONSTRAINT instrument_provider_check
+    CHECK (provider_name IN ('BINANCE', 'FT', 'LIGHTYEAR', 'MANUAL', 'TRADING212'));
+
+ALTER TABLE daily_price
+  ADD CONSTRAINT daily_price_provider_check
+    CHECK (provider_name IN ('BINANCE', 'FT', 'LIGHTYEAR', 'MANUAL', 'TRADING212'));
+
+INSERT INTO instrument (
+    symbol,
+    name,
+    instrument_category,
+    base_currency,
+    provider_name,
+    current_price,
+    created_at,
+    updated_at,
+    version
+) VALUES (
+    'EUR',
+    'Euro Cash',
+    'CASH',
+    'EUR',
+    'MANUAL',
+    1.0,
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP,
+    0
+);
+
+INSERT INTO portfolio_transaction (
+    instrument_id,
+    transaction_type,
+    quantity,
+    price,
+    transaction_date,
+    platform,
+    commission,
+    currency,
+    realized_profit,
+    unrealized_profit,
+    remaining_quantity
+) VALUES (
+    (SELECT id FROM instrument WHERE symbol = 'EUR'),
+    'BUY',
+    13719.16,
+    1.0,
+    CURRENT_DATE,
+    'SWEDBANK',
+    0,
+    'EUR',
+    0,
+    0,
+    13719.16
+);
+
+INSERT INTO daily_price (
+    instrument_id,
+    entry_date,
+    provider_name,
+    close_price,
+    created_at,
+    updated_at
+) VALUES (
+    (SELECT id FROM instrument WHERE symbol = 'EUR'),
+    CURRENT_DATE,
+    'MANUAL',
+    1.0,
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP
+);

--- a/src/test/kotlin/ee/tenman/portfolio/service/common/EnumServiceTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/service/common/EnumServiceTest.kt
@@ -49,11 +49,11 @@ class EnumServiceTest {
     expect(response.platforms)
       .toContainExactly("AVIVA", "BINANCE", "COINBASE", "IBKR", "LHV", "LIGHTYEAR", "SWEDBANK", "TRADING212", "UNKNOWN")
 
-    expect(response.providers).toContainExactly("BINANCE", "FT", "LIGHTYEAR", "TRADING212")
+    expect(response.providers).toContainExactly("BINANCE", "FT", "LIGHTYEAR", "MANUAL", "TRADING212")
 
     expect(response.transactionTypes).toContainExactly("BUY", "SELL")
 
-    expect(response.categories).toContainExactly("CRYPTO", "ETF")
+    expect(response.categories).toContainExactly("CASH", "CRYPTO", "ETF")
 
     expect(response.currencies).toContainExactly("EUR")
   }

--- a/ui/models/generated/domain-models.ts
+++ b/ui/models/generated/domain-models.ts
@@ -131,6 +131,7 @@ export enum ProviderName {
     BINANCE = "BINANCE",
     FT = "FT",
     LIGHTYEAR = "LIGHTYEAR",
+    MANUAL = "MANUAL",
     TRADING212 = "TRADING212",
 }
 


### PR DESCRIPTION
## Summary
- Add `CASH` to InstrumentCategory enum for cash holdings
- Add `MANUAL` to ProviderName enum for instruments without external price feeds
- Add database migration to update provider constraints and insert EUR cash instrument
- Insert initial EUR balance of 13719.16 on SWEDBANK platform

## Test plan
- [x] Tests updated to expect new enum values
- [x] Backend tests passing
- [x] Frontend tests passing (546 tests)
- [x] TypeScript types regenerated

Closes #1080