### PR TITLE
Update Telegram car response format with plate number

### DIFF
--- a/src/main/kotlin/ee/tenman/portfolio/service/VehicleInfoService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/service/VehicleInfoService.kt
@@ -65,20 +65,20 @@ class VehicleInfoService(
       auto24Error = auto24Result.error,
       veegoError = veegoResult.error,
       totalDurationSeconds = totalDuration,
-      formattedText = buildFormattedText(veegoResult, marketPrice),
+      formattedText = buildFormattedText(plateNumber, veegoResult, marketPrice),
     )
   }
 
   private fun buildFormattedText(
+    plateNumber: String,
     veegoResult: VeegoResult,
     marketPrice: String?,
   ): String {
     val sb = StringBuilder()
     if (veegoResult.make != null && veegoResult.model != null) {
-      sb.append("🚗 ${veegoResult.make} ${veegoResult.model}\n\n")
+      sb.append("🚗 ${veegoResult.make} ${veegoResult.model} ($plateNumber)\n\n")
     }
     sb.append("📋 Details:\n")
-    veegoResult.group?.let { sb.append("• Type: $it\n") }
     veegoResult.fuel?.let { sb.append("• Engine: $it\n") }
     veegoResult.year?.let { sb.append("• First registration: $it\n") }
     veegoResult.co2?.let { sb.append("• CO2: $it\n") }

--- a/src/test/kotlin/ee/tenman/portfolio/service/VehicleInfoServiceTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/service/VehicleInfoServiceTest.kt
@@ -151,7 +151,7 @@ class VehicleInfoServiceTest {
 
     val result = vehicleInfoService.getVehicleInfo(plateNumber)
 
-    expect(result.formattedText).toContain("🚗 Subaru Forester")
+    expect(result.formattedText).toContain("🚗 Subaru Forester (876BCH)")
   }
 
   @Test
@@ -163,7 +163,6 @@ class VehicleInfoServiceTest {
     val result = vehicleInfoService.getVehicleInfo(plateNumber)
 
     expect(result.formattedText).toContain("📋 Details:")
-    expect(result.formattedText).toContain("• Type: Passenger car")
     expect(result.formattedText).toContain("• Engine: Petrol")
     expect(result.formattedText).toContain("• First registration: 2009")
     expect(result.formattedText).toContain("• CO2: 199")


### PR DESCRIPTION
## Summary
- Add plate number to car header: `🚗 Volvo XC90 (876BCH)`
- Remove "Type" field from details section

## Test plan
- [x] Unit tests updated and passing
- [x] Manual test with Telegram bot