### PR TITLE
Add migration to fix GROK_4_1_FAST enum values

### DIFF
--- a/src/main/resources/db/migration/V202512271100__fix_grok_enum_values.sql
+++ b/src/main/resources/db/migration/V202512271100__fix_grok_enum_values.sql
@@ -1,0 +1,2 @@
+UPDATE etf_holding SET classified_by_model = NULL WHERE classified_by_model = 'GROK_4_1_FAST';
+UPDATE etf_holding SET country_classified_by_model = NULL WHERE country_classified_by_model = 'GROK_4_1_FAST';


### PR DESCRIPTION
Sets classified_by_model and country_classified_by_model to NULL
where they contain the now-removed GROK_4_1_FAST enum value.