### PR TITLE
Add SPDR MSCI World (SPPW) instrument and rebalancing transactions

### DIFF
--- a/src/main/kotlin/ee/tenman/portfolio/ft/HistoricalPricesService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/ft/HistoricalPricesService.kt
@@ -32,6 +32,7 @@ private val TICKERS: Map<String, String> =
     "VNRT:AEX:EUR" to "79451207",
     "GB00B0ZDNB53:GBP" to "543017012",
     "VWCE:GER:EUR" to "544541677",
+    "SPPW:GER:EUR" to "519953640",
     "VNRA:GER:EUR" to "544523562",
   )
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -183,6 +183,8 @@ scraping:
         uuid: "1ecf2da3-e426-68b7-a268-3d0ec5cf88ad"
       - symbol: "VWCE:GER:EUR"
         uuid: "1eda0a07-10b3-63e0-b568-6deedaa217e7"
+      - symbol: "SPPW:GER:EUR"
+        uuid: "1ef56330-1354-62df-99c7-5dccd8043f1d"
       - symbol: "VNRA:GER:EUR"
         uuid: "1eda4008-ca17-6926-b60a-654bcfbd8ac3"
     additional-instruments:

--- a/src/main/resources/db/migration/V202512271300__add_sppw_instrument_and_rebalancing.sql
+++ b/src/main/resources/db/migration/V202512271300__add_sppw_instrument_and_rebalancing.sql
@@ -1,0 +1,38 @@
+-- Add SPDR MSCI World instrument
+-- Lightyear ID: 1ef56330-1354-62df-99c7-5dccd8043f1d
+-- Lightyear URL: https://lightyear.com/etf/SPPW:XETRA/holdings
+-- FT Symbol ID: 519953640
+
+INSERT INTO instrument (
+    symbol,
+    name,
+    instrument_category,
+    base_currency,
+    provider_name,
+    provider_external_id,
+    current_price,
+    created_at,
+    updated_at,
+    version
+) VALUES (
+    'SPPW:GER:EUR',
+    'SPDR MSCI World',
+    'ETF',
+    'EUR',
+    'LIGHTYEAR',
+    '1ef56330-1354-62df-99c7-5dccd8043f1d',
+    40.73,
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP,
+    0
+);
+
+-- Portfolio Rebalancing: 2025-12-23 (Lightyear)
+
+-- SELL: Vanguard FTSE All-World
+INSERT INTO portfolio_transaction (instrument_id, transaction_type, quantity, price, transaction_date, platform)
+VALUES ((SELECT id FROM instrument WHERE symbol = 'VWCE:GER:EUR'), 'SELL', 49.455380135, 144.64, '2025-12-23', 'LIGHTYEAR');
+
+-- BUY: SPDR MSCI World
+INSERT INTO portfolio_transaction (instrument_id, transaction_type, quantity, price, transaction_date, platform)
+VALUES ((SELECT id FROM instrument WHERE symbol = 'SPPW:GER:EUR'), 'BUY', 175.638397132, 40.73, '2025-12-23', 'LIGHTYEAR');


### PR DESCRIPTION
## Summary

- Add new ETF instrument SPDR MSCI World (SPPW:GER:EUR) with Lightyear and FT integration
- Add SELL transaction for VWCE (49.455380135 shares at €144.64)
- Add BUY transaction for SPPW (175.638397132 shares at €40.73)
- Configure FT symbol ID (519953640) for historical price fetching
- Configure Lightyear UUID (1ef56330-1354-62df-99c7-5dccd8043f1d) for ETF holdings scraping

Closes #1152

## Test plan

- [ ] Verify migration runs successfully
- [ ] Verify FT data retrieval works for SPPW
- [ ] Verify Lightyear ETF holdings scraping works for SPPW
- [ ] Verify portfolio summary includes the new instrument