### PR TITLE
Add Xtrackers MSCI World Ex USA (EXUS) instrument

### DIFF
--- a/src/main/kotlin/ee/tenman/portfolio/ft/HistoricalPricesService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/ft/HistoricalPricesService.kt
@@ -35,6 +35,7 @@ private val TICKERS: Map<String, String> =
     "SPPW:GER:EUR" to "519953640",
     "VNRA:GER:EUR" to "544523562",
     "XNAS:GER:EUR" to "640687109",
+    "EXUS:GER:EUR" to "871264993",
   )
 
 private val REQUEST_DATE_FORMATTER: DateTimeFormatter =

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -189,6 +189,8 @@ scraping:
         uuid: "1eda4008-ca17-6926-b60a-654bcfbd8ac3"
       - symbol: "XNAS:GER:EUR"
         uuid: "1f098996-8150-6170-8254-e77b526cb347"
+      - symbol: "EXUS:GER:EUR"
+        uuid: "1ef669d5-871f-60c2-9d43-eb48e3c470cb"
     additional-instruments:
       - symbol: "WTAI:MIL:EUR"
         uuid: "1f02fdcc-38f9-67b8-ad1b-a71ae2564bd4"

--- a/src/main/resources/db/migration/V202512282113__add_exus_instrument.sql
+++ b/src/main/resources/db/migration/V202512282113__add_exus_instrument.sql
@@ -1,0 +1,23 @@
+INSERT INTO instrument (
+    symbol,
+    name,
+    instrument_category,
+    base_currency,
+    provider_name,
+    provider_external_id,
+    current_price,
+    created_at,
+    updated_at,
+    version
+) VALUES (
+    'EXUS:GER:EUR',
+    'Xtrackers MSCI World Ex USA',
+    'ETF',
+    'EUR',
+    'LIGHTYEAR',
+    '1ef669d5-871f-60c2-9d43-eb48e3c470cb',
+    0,
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP,
+    0
+);


### PR DESCRIPTION
## Summary

- Add database migration for EXUS instrument (Xtrackers MSCI World Ex USA)
- Add Lightyear UUID to application.yml for ETF holdings scraping
- Add FT ID to HistoricalPricesService for price updates

## ETF Details

| Field | Value |
|-------|-------|
| Symbol | EXUS:GER:EUR |
| Name | Xtrackers MSCI World Ex USA |
| ISIN | IE0006WW1TQ4 |
| Exchange | XETRA |
| Currency | EUR |
| TER | 0.15% |
| Lightyear UUID | 1ef669d5-871f-60c2-9d43-eb48e3c470cb |
| FT ID | 871264993 |

Closes #1157

## Test plan

- [ ] Verify database migration runs successfully
- [ ] Verify EXUS appears in Lightyear ETF scraping
- [ ] Verify FT price updates work for EXUS