### PR TITLE
Extract ImageDownloadService and fix ticker-based name updates

### DIFF
--- a/src/main/kotlin/ee/tenman/portfolio/auto24/Auto24Service.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/auto24/Auto24Service.kt
@@ -14,7 +14,7 @@ class Auto24Service(
 
   @Retryable(backoff = Backoff(delay = 1000))
   fun findCarPrice(regNr: String): CarPriceResult {
-    log.info("Fetching market price for registration number: {}", regNr)
+    log.info("Fetching market price for registration number: $regNr")
     val response = auto24Client.getMarketPrice(regNr)
     return handleResponse(regNr, response)
   }
@@ -25,10 +25,10 @@ class Auto24Service(
   ): CarPriceResult {
     if (response.error != null) return handleError(regNr, response.error, response.durationSeconds)
     if (response.marketPrice == null) {
-      log.warn("No price found for registration number: {}", regNr)
+      log.warn("No price found for registration number: $regNr")
       return CarPriceResult(price = null, error = "Price not available", durationSeconds = response.durationSeconds)
     }
-    log.info("Market price for {}: {} (attempt {}, duration {}s)", regNr, response.marketPrice, response.attempts, response.durationSeconds)
+    log.info("Market price for $regNr: ${response.marketPrice} (attempt ${response.attempts}, duration ${response.durationSeconds}s)")
     return CarPriceResult(price = response.marketPrice, durationSeconds = response.durationSeconds)
   }
 
@@ -39,15 +39,15 @@ class Auto24Service(
   ): CarPriceResult =
     when {
       error.contains("Vehicle not found") -> {
-        log.info("Vehicle not found for registration number: {}", regNr)
+        log.info("Vehicle not found for registration number: $regNr")
         CarPriceResult(price = null, error = "Vehicle not found", durationSeconds = durationSeconds)
       }
       error.contains("Price not available") -> {
-        log.info("Price not available for registration number: {}", regNr)
+        log.info("Price not available for registration number: $regNr")
         CarPriceResult(price = null, error = "Price not available", durationSeconds = durationSeconds)
       }
       else -> {
-        log.error("Failed to fetch price: {}", error)
+        log.error("Failed to fetch price: $error")
         throw CaptchaException("Failed to fetch price: $error")
       }
     }

--- a/src/main/kotlin/ee/tenman/portfolio/binance/BinanceService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/binance/BinanceService.kt
@@ -25,7 +25,7 @@ class BinanceService(
 
   @Retryable(backoff = Backoff(delay = 1000))
   fun getCurrentPrice(symbol: String): BigDecimal {
-    log.debug("Getting current price for symbol: {}", symbol)
+    log.debug("Getting current price for symbol: $symbol")
     val tickerPrice = binanceClient.getTickerPrice(symbol)
     return tickerPrice.price.toBigDecimal()
   }

--- a/src/main/kotlin/ee/tenman/portfolio/configuration/LogoUploadRunner.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/configuration/LogoUploadRunner.kt
@@ -18,32 +18,32 @@ class LogoUploadRunner(
   }
 
   private fun uploadLogoIfMissing(ticker: String) {
-    log.info("Checking logo for ticker: {}", ticker)
+    log.info("Checking logo for ticker: $ticker")
 
     if (minioService.logoExists(ticker)) {
-      log.info("Logo already exists in MinIO for ticker: {}", ticker)
+      log.info("Logo already exists in MinIO for ticker: $ticker")
       return
     }
 
     try {
       val resource = ClassPathResource("static/logos/$ticker.png")
-      log.info("Looking for logo file: static/logos/{}.png, exists: {}", ticker, resource.exists())
+      log.info("Looking for logo file: static/logos/$ticker.png, exists: ${resource.exists()}")
 
       if (!resource.exists()) {
-        log.warn("Logo file not found in static resources for ticker: {}", ticker)
+        log.warn("Logo file not found in static resources for ticker: $ticker")
         return
       }
 
       val logoData = resource.inputStream.use { it.readBytes() }
-      log.info("Read {} bytes from logo file for ticker: {}", logoData.size, ticker)
+      log.info("Read ${logoData.size} bytes from logo file for ticker: $ticker")
 
       minioService.uploadLogo(ticker, logoData)
-      log.info("Successfully uploaded logo to MinIO for ticker: {}", ticker)
+      log.info("Successfully uploaded logo to MinIO for ticker: $ticker")
 
       val exists = minioService.logoExists(ticker)
-      log.info("Verification after upload - logo exists: {} for ticker: {}", exists, ticker)
+      log.info("Verification after upload - logo exists: $exists for ticker: $ticker")
     } catch (e: Exception) {
-      log.error("Failed to upload logo to MinIO for ticker: {}", ticker, e)
+      log.error("Failed to upload logo to MinIO for ticker: $ticker", e)
     }
   }
 }

--- a/src/main/kotlin/ee/tenman/portfolio/configuration/MinioBucketInitializer.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/configuration/MinioBucketInitializer.kt
@@ -33,15 +33,14 @@ class MinioBucketInitializer(
             .bucket(minioProperties.bucketName)
             .build(),
         )
-        log.info("Created MinIO bucket: {}", minioProperties.bucketName)
+        log.info("Created MinIO bucket: ${minioProperties.bucketName}")
       } else {
-        log.info("MinIO bucket already exists: {}", minioProperties.bucketName)
+        log.info("MinIO bucket already exists: ${minioProperties.bucketName}")
       }
     } catch (e: Exception) {
       log.warn(
-        "Failed to initialize MinIO bucket '{}'. " +
-          "MinIO may not be running. Logo upload/download features will not work until MinIO is available.",
-        minioProperties.bucketName,
+        "Failed to initialize MinIO bucket '${minioProperties.bucketName}'. " +
+          "MinIO may not be running. Logo upload/download features will not work until MinIO is available",
         e,
       )
     }

--- a/src/main/kotlin/ee/tenman/portfolio/configuration/RestClientConfiguration.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/configuration/RestClientConfiguration.kt
@@ -1,0 +1,27 @@
+package ee.tenman.portfolio.configuration
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpHeaders
+import org.springframework.http.client.SimpleClientHttpRequestFactory
+import org.springframework.web.client.RestClient
+
+@Configuration
+class RestClientConfiguration {
+  @Bean
+  fun restClient(): RestClient =
+    RestClient
+      .builder()
+      .defaultHeader(HttpHeaders.USER_AGENT, USER_AGENT)
+      .requestFactory(
+        SimpleClientHttpRequestFactory().apply {
+          setConnectTimeout(TIMEOUT_MS)
+          setReadTimeout(TIMEOUT_MS)
+        },
+      ).build()
+
+  companion object {
+    private const val USER_AGENT = "Portfolio/1.0"
+    private const val TIMEOUT_MS = 5000
+  }
+}

--- a/src/main/kotlin/ee/tenman/portfolio/configuration/aspect/LoggingAspect.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/configuration/aspect/LoggingAspect.kt
@@ -23,10 +23,7 @@ class LoggingAspect {
     val method = signature.method
 
     if (method.returnType == Void.TYPE) {
-      log.warn(
-        "Loggable annotation should not be used on methods without return type: {}",
-        method.name,
-      )
+      log.warn("Loggable annotation should not be used on methods without return type: ${method.name}")
       return joinPoint.proceed()
     }
 
@@ -50,7 +47,7 @@ class LoggingAspect {
   @Throws(Throwable::class)
   private fun logEntry(joinPoint: ProceedingJoinPoint) {
     val argsJson = JsonMapperFactory.instance.writeValueAsString(joinPoint.args)
-    log.info("{} entered with arguments: {}", joinPoint.signature.toShortString(), argsJson)
+    log.info("${joinPoint.signature.toShortString()} entered with arguments: $argsJson")
   }
 
   @Throws(Throwable::class)
@@ -59,12 +56,9 @@ class LoggingAspect {
     result: Any,
     startTime: Long,
   ) {
-    log.info(
-      "{} exited with result: {} in {} seconds",
-      joinPoint.signature.toShortString(),
-      JsonMapperFactory.truncateJson(JsonMapperFactory.instance.writeValueAsString(result)),
-      TimeUtility.durationInSeconds(startTime),
-    )
+    val resultJson = JsonMapperFactory.truncateJson(JsonMapperFactory.instance.writeValueAsString(result))
+    val duration = TimeUtility.durationInSeconds(startTime)
+    log.info("${joinPoint.signature.toShortString()} exited with result: $resultJson in $duration seconds")
   }
 
   companion object {

--- a/src/main/kotlin/ee/tenman/portfolio/controller/BuildInfoController.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/controller/BuildInfoController.kt
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import java.time.Clock
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
@@ -12,15 +13,15 @@ import java.time.format.DateTimeFormatter
 class BuildInfoController(
   @Value("\${build.hash:local}") private val buildHash: String,
   @Value("\${build.time:unknown}") private val buildTime: String,
+  private val clock: Clock,
 ) {
   private val dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'")
 
   @GetMapping
   fun getBuildInfo(): Map<String, String> {
-    // If buildTime is empty, use current time
     val time =
       if ("unknown" == buildTime) {
-        LocalDateTime.now().format(dateTimeFormatter)
+        LocalDateTime.now(clock).format(dateTimeFormatter)
       } else {
         buildTime
       }

--- a/src/main/kotlin/ee/tenman/portfolio/controller/LogoController.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/controller/LogoController.kt
@@ -24,7 +24,7 @@ class LogoController(
   fun getLogo(
     @PathVariable symbol: String,
   ): ResponseEntity<ByteArray> {
-    log.debug("Fetching logo for symbol: {}", LogSanitizerUtil.sanitize(symbol))
+    log.debug("Fetching logo for symbol: ${LogSanitizerUtil.sanitize(symbol)}")
 
     val logoData = minioService.downloadLogo(symbol)
 
@@ -35,7 +35,7 @@ class LogoController(
         .cacheControl(CacheControl.maxAge(7, TimeUnit.DAYS).cachePublic())
         .body(logoData)
     } else {
-      log.debug("Logo not found for symbol: {}", LogSanitizerUtil.sanitize(symbol))
+      log.debug("Logo not found for symbol: ${LogSanitizerUtil.sanitize(symbol)}")
       ResponseEntity.status(HttpStatus.NOT_FOUND).build()
     }
   }

--- a/src/main/kotlin/ee/tenman/portfolio/googlevision/FileToBase64.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/googlevision/FileToBase64.kt
@@ -14,7 +14,7 @@ object FileToBase64 {
     try {
       encodeToBase64(Files.readAllBytes(Paths.get(filePath)))
     } catch (e: Exception) {
-      log.error("Error reading file: {}", filePath, e)
+      log.error("Error reading file: $filePath", e)
       ""
     }
 

--- a/src/main/kotlin/ee/tenman/portfolio/googlevision/GoogleVisionService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/googlevision/GoogleVisionService.kt
@@ -46,7 +46,7 @@ class GoogleVisionService(
       return VISION_DISABLED_RESPONSE
     }
     MDC.put("uuid", uuid.toString())
-    log.debug("Starting plate number detection from image. Image size: {} bytes", base64EncodedImage.toByteArray().size)
+    log.debug("Starting plate number detection from image. Image size: ${base64EncodedImage.toByteArray().size} bytes")
     return try {
       val textRequest =
         GoogleVisionApiRequest(
@@ -61,13 +61,13 @@ class GoogleVisionService(
           ?.split("\n")
           ?.toTypedArray()
           ?: emptyArray()
-      log.info("Received text detection response with {} text blocks", strings.size)
+      log.info("Received text detection response with ${strings.size} text blocks")
       val response = mutableMapOf<String, String>()
       for (description in strings) {
-        log.debug("Processing text annotation: {}", description)
+        log.debug("Processing text annotation: $description")
         CAR_PLATE_NUMBER_PATTERN.find(description)?.let { matchResult ->
           val plateNr = matchResult.value.replace(" ", "").uppercase()
-          log.info("Plate number found: {}", plateNr)
+          log.info("Plate number found: $plateNr")
           response["plateNumber"] = plateNr
           response["hasCar"] = "true"
           return response

--- a/src/main/kotlin/ee/tenman/portfolio/job/BinanceDataRetrievalJob.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/job/BinanceDataRetrievalJob.kt
@@ -54,7 +54,7 @@ class BinanceDataRetrievalJob(
       return
     }
     instruments.forEach { instrument -> processInstrument(instrument) }
-    log.info("Completed Binance data retrieval job. Processed {} instruments", instruments.size)
+    log.info("Completed Binance data retrieval job. Processed ${instruments.size} instruments")
   }
 
   private fun processInstrument(instrument: Instrument) {
@@ -64,23 +64,23 @@ class BinanceDataRetrievalJob(
       } else {
         fetchFullHistory(instrument)
       }
-    }.onFailure { e -> log.error("Error retrieving data for instrument {}", instrument.symbol, e) }
+    }.onFailure { e -> log.error("Error retrieving data for instrument ${instrument.symbol}", e) }
   }
 
   private fun refreshCurrentPrice(instrument: Instrument) {
-    log.debug("Refreshing current price for instrument: {}", instrument.symbol)
+    log.debug("Refreshing current price for instrument: ${instrument.symbol}")
     val currentPrice = binanceService.getCurrentPrice(instrument.symbol)
     val today = LocalDate.now(clock)
     dailyPriceService.saveCurrentPrice(instrument, currentPrice, today, ProviderName.BINANCE)
     instrumentService.updateCurrentPrice(instrument.id, currentPrice)
-    log.debug("Updated current price for {}: {}", instrument.symbol, currentPrice)
+    log.debug("Updated current price for ${instrument.symbol}: $currentPrice")
   }
 
   private fun fetchFullHistory(instrument: Instrument) {
-    log.info("Fetching full history for instrument: {} (no historical data found)", instrument.symbol)
+    log.info("Fetching full history for instrument: ${instrument.symbol} (no historical data found)")
     val dailyData = binanceService.getDailyPricesAsync(instrument.symbol)
     if (dailyData.isEmpty()) {
-      log.warn("No daily data found for instrument: {}", instrument.symbol)
+      log.warn("No daily data found for instrument: ${instrument.symbol}")
       return
     }
     dataProcessingUtil.processDailyData(

--- a/src/main/kotlin/ee/tenman/portfolio/job/InstrumentPriceGapFillingJob.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/job/InstrumentPriceGapFillingJob.kt
@@ -63,13 +63,13 @@ class InstrumentPriceGapFillingJob(
         log.info("No LIGHTYEAR instruments found to fill gaps")
         return
       }
-      log.info("Found {} LIGHTYEAR instruments to process for gap filling", instruments.size)
+      log.info("Found ${instruments.size} LIGHTYEAR instruments to process for gap filling")
       var totalSaved = 0
       instruments.forEach { instrument ->
         val saved = fillGapsForInstrument(instrument)
         totalSaved += saved
       }
-      log.info("Instrument price gap filling completed: {} prices saved", totalSaved)
+      log.info("Instrument price gap filling completed: $totalSaved prices saved")
     } finally {
       isExecuting.set(false)
     }
@@ -77,11 +77,11 @@ class InstrumentPriceGapFillingJob(
 
   private fun fillGapsForInstrument(instrument: Instrument): Int {
     try {
-      log.debug("Filling price gaps for instrument: {}", instrument.symbol)
+      log.debug("Filling price gaps for instrument: ${instrument.symbol}")
       val existingDates = dailyPriceService.findAllExistingDates(instrument)
       val ftData = ftHistoricalPricesService.fetchPrices(instrument.symbol)
       if (ftData.isEmpty()) {
-        log.warn("No FT data found for instrument: {}", instrument.symbol)
+        log.warn("No FT data found for instrument: ${instrument.symbol}")
         return 0
       }
       var savedCount = 0
@@ -103,11 +103,11 @@ class InstrumentPriceGapFillingJob(
         }
       }
       if (savedCount > 0) {
-        log.debug("Saved {} new FT prices for instrument {}", savedCount, instrument.symbol)
+        log.debug("Saved $savedCount new FT prices for instrument ${instrument.symbol}")
       }
       return savedCount
     } catch (e: Exception) {
-      log.error("Error filling gaps for instrument {}: {}", instrument.symbol, e.message)
+      log.error("Error filling gaps for instrument ${instrument.symbol}: ${e.message}")
       return 0
     }
   }

--- a/src/main/kotlin/ee/tenman/portfolio/job/InstrumentXirrJob.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/job/InstrumentXirrJob.kt
@@ -57,7 +57,7 @@ class InstrumentXirrJob(
     }
     val successCount = results.count { it.second }
     val failureCount = results.count { !it.second }
-    log.info("Instrument XIRR calculation completed: {} succeeded, {} failed", successCount, failureCount)
+    log.info("Instrument XIRR calculation completed: $successCount succeeded, $failureCount failed")
   }
 
   private fun calculateInstrumentXirr(
@@ -67,14 +67,14 @@ class InstrumentXirrJob(
     runCatching {
     val dailyPrices = dailyPriceService.findAllByInstrument(instrument)
     if (dailyPrices.isEmpty()) {
-      log.debug("No price history for {}", instrument.symbol)
+      log.debug("No price history for ${instrument.symbol}")
       return instrument.symbol to true
     }
     val sortedPrices = dailyPrices.sortedBy { it.entryDate }
     val firstPriceDate = sortedPrices.first().entryDate
     val cashFlows = generateMonthlyCashFlows(firstPriceDate, calculationDate, sortedPrices, instrument)
     if (cashFlows.size < 2) {
-      log.debug("Insufficient data for XIRR calculation for {}", instrument.symbol)
+      log.debug("Insufficient data for XIRR calculation for ${instrument.symbol}")
       instrumentService.updateXirrAnnualReturn(instrument.id, null)
       return instrument.symbol to true
     }
@@ -83,7 +83,7 @@ class InstrumentXirrJob(
     instrumentService.updateXirrAnnualReturn(instrument.id, xirrValue)
     instrument.symbol to true
   }.getOrElse { e ->
-    log.warn("Failed to calculate XIRR for {}: {}", instrument.symbol, e.message)
+    log.warn("Failed to calculate XIRR for ${instrument.symbol}: ${e.message}")
     instrument.symbol to false
   }
 

--- a/src/main/kotlin/ee/tenman/portfolio/job/LightyearDataFetchJob.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/job/LightyearDataFetchJob.kt
@@ -7,6 +7,7 @@ import ee.tenman.portfolio.service.etf.EtfHoldingsService
 import ee.tenman.portfolio.service.infrastructure.JobTransactionService
 import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Scheduled
+import java.time.Clock
 import java.time.Instant
 import java.time.LocalDate
 
@@ -17,6 +18,7 @@ class LightyearDataFetchJob(
   private val lightyearPriceService: LightyearPriceService,
   private val etfHoldingsService: EtfHoldingsService,
   private val etfBreakdownService: ee.tenman.portfolio.service.etf.EtfBreakdownService,
+  private val clock: Clock,
 ) : Job {
   private val log = LoggerFactory.getLogger(javaClass)
 
@@ -24,7 +26,7 @@ class LightyearDataFetchJob(
   @Scheduled(cron = "0 50 23 * * ?")
   fun runJob() {
     log.info("Running Lightyear data fetch job for ${properties.etfs.size} ETFs")
-    val startTime = Instant.now()
+    val startTime = Instant.now(clock)
     var status = JobStatus.SUCCESS
     var message: String? = null
 
@@ -37,7 +39,7 @@ class LightyearDataFetchJob(
       message = "Failed to fetch data: ${e.message}"
       log.error("Lightyear data fetch job failed", e)
     } finally {
-      val endTime = Instant.now()
+      val endTime = Instant.now(clock)
       jobTransactionService.saveJobExecution(
         job = this,
         startTime = startTime,
@@ -53,7 +55,7 @@ class LightyearDataFetchJob(
   }
 
   private fun fetchAllEtfs(): String {
-    val today = LocalDate.now()
+    val today = LocalDate.now(clock)
     val results = mutableListOf<String>()
 
     properties.etfs.forEach { etfConfig ->

--- a/src/main/kotlin/ee/tenman/portfolio/job/LightyearPriceRetrievalJob.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/job/LightyearPriceRetrievalJob.kt
@@ -51,10 +51,7 @@ class LightyearPriceRetrievalJob(
       .toMinutes()
 
     if (minutesSinceStartup < 4) {
-      log.debug(
-        "Skipping job execution. Only {} minutes since startup. Waiting for 4 minutes.",
-        minutesSinceStartup,
-      )
+      log.debug("Skipping job execution. Only $minutesSinceStartup minutes since startup. Waiting for 4 minutes.")
       return false
     }
 

--- a/src/main/kotlin/ee/tenman/portfolio/job/WisdomTreeDataUpdateJob.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/job/WisdomTreeDataUpdateJob.kt
@@ -5,12 +5,14 @@ import ee.tenman.portfolio.service.infrastructure.JobTransactionService
 import ee.tenman.portfolio.service.integration.WisdomTreeUpdateService
 import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Scheduled
+import java.time.Clock
 import java.time.Instant
 
 @ScheduledJob
 class WisdomTreeDataUpdateJob(
   private val jobTransactionService: JobTransactionService,
   private val wisdomTreeUpdateService: WisdomTreeUpdateService,
+  private val clock: Clock,
 ) : Job {
   private val log = LoggerFactory.getLogger(javaClass)
 
@@ -22,7 +24,7 @@ class WisdomTreeDataUpdateJob(
 
   override fun execute() {
     log.info("Executing WisdomTree data update job for WTAI")
-    val startTime = Instant.now()
+    val startTime = Instant.now(clock)
     var status = JobStatus.SUCCESS
     var message: String? = null
 
@@ -37,7 +39,7 @@ class WisdomTreeDataUpdateJob(
       message = "Failed to update WTAI holdings: ${e.message}"
       log.error("WisdomTree data update job failed", e)
     } finally {
-      val endTime = Instant.now()
+      val endTime = Instant.now(clock)
       jobTransactionService.saveJobExecution(
         job = this,
         startTime = startTime,

--- a/src/main/kotlin/ee/tenman/portfolio/lightyear/LightyearHistoricalPricesService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/lightyear/LightyearHistoricalPricesService.kt
@@ -22,7 +22,7 @@ class LightyearHistoricalPricesService(
   @Retryable(backoff = Backoff(delay = 1000, multiplier = 2.0, maxDelay = 5000))
   fun fetchHistoricalPrices(uuid: String): Map<LocalDate, DailyPriceData> =
     runBlocking {
-      log.info("Fetching historical prices for Lightyear instrument: {}", uuid)
+      log.info("Fetching historical prices for Lightyear instrument: $uuid")
 
       val (fiveYearData, maxData) =
         listOf(
@@ -35,11 +35,7 @@ class LightyearHistoricalPricesService(
       mergedData.putAll(fiveYearData)
 
       log.info(
-        "Fetched {} historical prices for instrument {} (5y: {}, max: {})",
-        mergedData.size,
-        uuid,
-        fiveYearData.size,
-        maxData.size,
+        "Fetched ${mergedData.size} historical prices for instrument $uuid (5y: ${fiveYearData.size}, max: ${maxData.size})",
       )
 
       mergedData

--- a/src/main/kotlin/ee/tenman/portfolio/lightyear/LightyearPriceService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/lightyear/LightyearPriceService.kt
@@ -23,24 +23,24 @@ class LightyearPriceService(
   @Retryable(backoff = Backoff(delay = 1000, multiplier = 2.0, maxDelay = 5000))
   fun fetchCurrentPrices(): Map<String, BigDecimal> {
     val symbols = properties.getAllSymbols()
-    log.info("Fetching prices for {} Lightyear instruments", symbols.size)
+    log.info("Fetching prices for ${symbols.size} Lightyear instruments")
     val prices = mutableMapOf<String, BigDecimal>()
     symbols.forEach { symbol ->
       val uuid = resolveUuid(symbol)
       if (uuid == null) {
-        log.warn("No UUID found for symbol: {}", symbol)
+        log.warn("No UUID found for symbol: $symbol")
         return@forEach
       }
       runCatching {
         val path = "/v1/market-data/$uuid/price"
         val response = lightyearPriceClient.getPrice(path)
         prices[symbol] = response.price
-        log.debug("Fetched price for {}: {}", symbol, response.price)
+        log.debug("Fetched price for $symbol: ${response.price}")
       }.onFailure { e ->
-        log.warn("Failed to fetch price for symbol: {}", symbol, e)
+        log.warn("Failed to fetch price for symbol: $symbol", e)
       }
     }
-    log.info("Successfully fetched prices for {}/{} instruments", prices.size, symbols.size)
+    log.info("Successfully fetched prices for ${prices.size}/${symbols.size} instruments")
     return prices
   }
 
@@ -65,14 +65,14 @@ class LightyearPriceService(
   private fun fetchInstrumentsBatch(holdings: List<LightyearHoldingResponse>): Map<String, LightyearInstrumentResponse> {
     val instrumentIds = holdings.mapNotNull { it.instrumentId }.distinct()
     if (instrumentIds.isEmpty()) return emptyMap()
-    log.info("Fetching {} instrument details in batches", instrumentIds.size)
+    log.info("Fetching ${instrumentIds.size} instrument details in batches")
     val cache = mutableMapOf<String, LightyearInstrumentResponse>()
     val batchSize = 100
     val totalBatches = (instrumentIds.size + batchSize - 1) / batchSize
     instrumentIds.chunked(batchSize).forEachIndexed { batchIndex, batch ->
       fetchInstrumentBatchWithRetry(batch, batchIndex + 1, totalBatches)?.forEach { cache[it.id] = it }
     }
-    log.info("Successfully fetched {} of {} instrument details", cache.size, instrumentIds.size)
+    log.info("Successfully fetched ${cache.size} of ${instrumentIds.size} instrument details")
     return cache
   }
 
@@ -85,15 +85,15 @@ class LightyearPriceService(
     repeat(maxRetries) { attempt ->
       runCatching {
         val instruments = lightyearPriceClient.getInstrumentBatch(batch)
-        log.info("Fetched batch {}/{} ({} instruments)", batchNumber, totalBatches, instruments.size)
+        log.info("Fetched batch $batchNumber/$totalBatches (${instruments.size} instruments)")
         return instruments
       }.onFailure { e ->
         val retriesLeft = maxRetries - attempt - 1
         if (retriesLeft > 0) {
-          log.warn("Batch {}/{} failed (attempt {}), retrying: {}", batchNumber, totalBatches, attempt + 1, e.message)
+          log.warn("Batch $batchNumber/$totalBatches failed (attempt ${attempt + 1}), retrying: ${e.message}")
           Thread.sleep((attempt + 1) * 1000L)
         } else {
-          log.warn("Batch {}/{} failed after {} attempts: {}", batchNumber, totalBatches, maxRetries, e.message)
+          log.warn("Batch $batchNumber/$totalBatches failed after $maxRetries attempts: ${e.message}")
         }
       }
     }
@@ -104,13 +104,13 @@ class LightyearPriceService(
   fun fetchHoldingsRaw(symbol: String): List<LightyearHoldingResponse> {
     val uuid = resolveUuid(symbol)
     if (uuid == null) {
-      log.warn("No UUID mapping found for symbol: {}", symbol)
+      log.warn("No UUID mapping found for symbol: $symbol")
       return emptyList()
     }
-    log.info("Fetching holdings for {} ({})", symbol, uuid)
+    log.info("Fetching holdings for $symbol ($uuid)")
     val path = "/v1/market-data/$uuid/fund-info/holdings"
     val holdings = lightyearPriceClient.getHoldings(path)
-    log.info("Fetched {} holdings for {}", holdings.size, symbol)
+    log.info("Fetched ${holdings.size} holdings for $symbol")
     return holdings
   }
 
@@ -118,16 +118,16 @@ class LightyearPriceService(
   fun fetchFundInfo(symbol: String): BigDecimal? {
     val uuid = resolveUuid(symbol)
     if (uuid == null) {
-      log.warn("No UUID found for symbol: {}", symbol)
+      log.warn("No UUID found for symbol: $symbol")
       return null
     }
     return runCatching {
       val path = "/v1/market-data/$uuid/fund-info"
       val response = lightyearPriceClient.getFundInfo(path)
-      log.debug("Fetched TER for {}: {}", symbol, response.ter)
+      log.debug("Fetched TER for $symbol: ${response.ter}")
       response.ter
     }.onFailure { e ->
-      log.warn("Failed to fetch fund info for symbol: {}", symbol, e)
+      log.warn("Failed to fetch fund info for symbol: $symbol", e)
     }.getOrNull()
   }
 
@@ -141,15 +141,15 @@ class LightyearPriceService(
 
   fun lookupUuidFromWeb(symbol: String): String? {
     val lookupSymbol = convertToLightyearSymbol(symbol)
-    log.info("Looking up UUID from web for symbol: {} (lookup: {})", symbol, lookupSymbol)
+    log.info("Looking up UUID from web for symbol: $symbol (lookup: $lookupSymbol)")
     return runCatching {
       val response = lightyearPriceClient.lookupUuid(lookupSymbol)
       uuidCacheService.cacheUuid(symbol, response.uuid)
       saveUuidToDatabase(symbol, response.uuid)
-      log.info("Found UUID {} for symbol {} from web lookup", response.uuid, symbol)
+      log.info("Found UUID ${response.uuid} for symbol $symbol from web lookup")
       response.uuid
     }.onFailure { e ->
-      log.warn("Failed to lookup UUID for symbol {}: {}", symbol, e.message)
+      log.warn("Failed to lookup UUID for symbol $symbol: ${e.message}")
     }.getOrNull()
   }
 
@@ -159,9 +159,9 @@ class LightyearPriceService(
   ) {
     runCatching {
       instrumentService.updateProviderExternalId(symbol, uuid)
-      log.info("Saved UUID {} for symbol {} to database", uuid, symbol)
+      log.info("Saved UUID $uuid for symbol $symbol to database")
     }.onFailure { e ->
-      log.warn("Failed to save UUID for symbol {}: {}", symbol, e.message)
+      log.warn("Failed to save UUID for symbol $symbol: ${e.message}")
     }
   }
 

--- a/src/main/kotlin/ee/tenman/portfolio/openrouter/OpenRouterCircuitBreaker.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/openrouter/OpenRouterCircuitBreaker.kt
@@ -44,9 +44,7 @@ class OpenRouterCircuitBreaker(
     circuitBreaker.eventPublisher
       .onStateTransition { event ->
         log.info(
-          "Circuit breaker state transition: {} -> {}",
-          event.stateTransition.fromState,
-          event.stateTransition.toState,
+          "Circuit breaker state transition: ${event.stateTransition.fromState} -> ${event.stateTransition.toState}",
         )
       }
     AiModel.entries.forEach { model ->
@@ -117,7 +115,7 @@ class OpenRouterCircuitBreaker(
       val now = clock.millis()
       val lastRequest = lastRequestTime.get()
       if ((now - lastRequest) < rateLimitMs) {
-        log.debug("{} rate limit active, {} ms until next request allowed", modelType, rateLimitMs - (now - lastRequest))
+        log.debug("$modelType rate limit active, ${rateLimitMs - (now - lastRequest)} ms until next request allowed")
         return false
       }
       if (lastRequestTime.compareAndSet(lastRequest, now)) {
@@ -128,12 +126,12 @@ class OpenRouterCircuitBreaker(
 
   fun recordSuccess() {
     circuitBreaker.onSuccess(0, TimeUnit.MILLISECONDS)
-    log.debug("Recorded success, circuit breaker state: {}", circuitBreaker.state)
+    log.debug("Recorded success, circuit breaker state: ${circuitBreaker.state}")
   }
 
   fun recordFailure(throwable: Throwable) {
     circuitBreaker.onError(0, TimeUnit.MILLISECONDS, throwable)
-    log.warn("Recorded failure, circuit breaker state: {}", circuitBreaker.state)
+    log.warn("Recorded failure, circuit breaker state: ${circuitBreaker.state}")
   }
 
   private fun canUseModel(model: AiModel): Boolean {

--- a/src/main/kotlin/ee/tenman/portfolio/openrouter/OpenRouterVisionService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/openrouter/OpenRouterVisionService.kt
@@ -16,13 +16,13 @@ class OpenRouterVisionService(
       return null
     }
     return runCatching {
-      log.info("Calling OpenRouter Vision API with model: {}", request.model)
+      log.info("Calling OpenRouter Vision API with model: ${request.model}")
       val response = openRouterVisionClient.chatCompletion("Bearer ${openRouterProperties.apiKey}", request)
       val content = response.extractContent()
-      log.info("OpenRouter Vision response: '{}'", content)
+      log.info("OpenRouter Vision response: '$content'")
       content
     }.onFailure { throwable ->
-      log.error("Error calling OpenRouter Vision API: {}", throwable.message, throwable)
+      log.error("Error calling OpenRouter Vision API: ${throwable.message}", throwable)
     }.getOrNull()
   }
 }

--- a/src/main/kotlin/ee/tenman/portfolio/service/LicensePlateDetectionService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/service/LicensePlateDetectionService.kt
@@ -79,7 +79,7 @@ class LicensePlateDetectionService(
       remainingJobs.remove(completedDeferred)
       if (result != null) {
         if (result.plateNumber != null) {
-          log.info("Plate detected by {}, cancelling remaining jobs", result.provider)
+          log.info("Plate detected by ${result.provider}, cancelling remaining jobs")
           remainingJobs.forEach { it.cancel() }
           return result
         }
@@ -102,13 +102,13 @@ class LicensePlateDetectionService(
       val hasCar = result["hasCar"]?.toBoolean() ?: false
       val plateNumber = result["plateNumber"]
       if (plateNumber != null) {
-        log.info("Google Vision detected plate: {} in {}ms", plateNumber, elapsedMs)
+        log.info("Google Vision detected plate: $plateNumber in ${elapsedMs}ms")
         return DetectionResult(plateNumber = plateNumber, hasCar = hasCar, provider = DetectionProvider.GOOGLE_VISION)
       }
-      log.info("Google Vision: no plate found in {}ms, hasCar={}", elapsedMs, hasCar)
+      log.info("Google Vision: no plate found in ${elapsedMs}ms, hasCar=$hasCar")
       DetectionResult(plateNumber = null, hasCar = hasCar, provider = DetectionProvider.GOOGLE_VISION)
     }.getOrElse { e ->
-      log.error("Google Vision failed: {}", e.message)
+      log.error("Google Vision failed: ${e.message}")
       null
     }
 
@@ -117,24 +117,24 @@ class LicensePlateDetectionService(
     base64Image: String,
   ): DetectionResult? =
     runCatching {
-      log.info("Attempting detection with {}", model.modelId)
+      log.info("Attempting detection with ${model.modelId}")
       val startTime = System.currentTimeMillis()
       val request = OpenRouterVisionRequest.forLicensePlateExtraction(model.modelId, base64Image)
       val response = openRouterVisionService.extractText(request)
       val elapsedMs = System.currentTimeMillis() - startTime
       if (response.isNullOrBlank()) {
-        log.info("{}: empty response in {}ms", model.modelId, elapsedMs)
+        log.info("${model.modelId}: empty response in ${elapsedMs}ms")
         return DetectionResult(plateNumber = null, hasCar = false, provider = DetectionProvider.fromVisionModel(model))
       }
       val plateNumber = extractPlateNumber(response)
       if (plateNumber != null) {
-        log.info("{} detected plate: {} in {}ms", model.modelId, plateNumber, elapsedMs)
+        log.info("${model.modelId} detected plate: $plateNumber in ${elapsedMs}ms")
         return DetectionResult(plateNumber = plateNumber, hasCar = true, provider = DetectionProvider.fromVisionModel(model))
       }
-      log.info("{}: response '{}' did not match pattern in {}ms", model.modelId, response, elapsedMs)
+      log.info("${model.modelId}: response '$response' did not match pattern in ${elapsedMs}ms")
       DetectionResult(plateNumber = null, hasCar = false, provider = DetectionProvider.fromVisionModel(model))
     }.getOrElse { e ->
-      log.error("{} failed: {}", model.modelId, e.message)
+      log.error("${model.modelId} failed: ${e.message}")
       null
     }
 

--- a/src/main/kotlin/ee/tenman/portfolio/service/VehicleInfoService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/service/VehicleInfoService.kt
@@ -21,11 +21,11 @@ class VehicleInfoService(
   private val log = LoggerFactory.getLogger(javaClass)
 
   fun getVehicleInfo(plateNumber: String): VehicleInfoResponse {
-    log.info("Fetching vehicle info for plate: {}", plateNumber)
+    log.info("Fetching vehicle info for plate: $plateNumber")
     val startTime = System.nanoTime()
     val (auto24Result, veegoResult) = fetchInParallel(plateNumber)
     val totalDuration = TimeUtility.durationInSeconds(startTime).toDouble()
-    log.info("Vehicle info fetched for {} in {}s", plateNumber, totalDuration)
+    log.info("Vehicle info fetched for $plateNumber in ${totalDuration}s")
     return buildResponse(plateNumber, auto24Result, veegoResult, totalDuration)
   }
 
@@ -39,7 +39,7 @@ class VehicleInfoService(
   private fun fetchAuto24Safely(plateNumber: String): CarPriceResult =
     runCatching { auto24Service.findCarPrice(plateNumber) }
       .getOrElse { exception ->
-        log.error("Failed to fetch Auto24 price for {}: {}", plateNumber, exception.message)
+        log.error("Failed to fetch Auto24 price for $plateNumber: ${exception.message}")
         CarPriceResult(price = null, error = exception.message ?: "Unknown error")
       }
 

--- a/src/main/kotlin/ee/tenman/portfolio/service/calculation/XirrCalculationService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/service/calculation/XirrCalculationService.kt
@@ -7,18 +7,21 @@ import ee.tenman.portfolio.service.calculation.xirr.Xirr
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.math.BigDecimal
+import java.time.Clock
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
 import kotlin.math.min
 
 @Service
-class XirrCalculationService {
+class XirrCalculationService(
+  private val clock: Clock,
+) {
   private val log = LoggerFactory.getLogger(javaClass)
 
   fun buildCashFlows(
     transactions: List<PortfolioTransaction>,
     currentValue: BigDecimal,
-    calculationDate: LocalDate = LocalDate.now(),
+    calculationDate: LocalDate = LocalDate.now(clock),
   ): List<CashFlow> {
     val cashFlows = transactions.map(::convertToCashFlow)
     val finalValue =
@@ -31,7 +34,7 @@ class XirrCalculationService {
 
   fun calculateAdjustedXirr(
     cashFlows: List<CashFlow>,
-    calculationDate: LocalDate = LocalDate.now(),
+    calculationDate: LocalDate = LocalDate.now(clock),
   ): Double {
     if (cashFlows.size < 2) return 0.0
     return runCatching {

--- a/src/main/kotlin/ee/tenman/portfolio/service/infrastructure/CacheInvalidationService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/service/infrastructure/CacheInvalidationService.kt
@@ -25,7 +25,7 @@ class CacheInvalidationService(
     instrumentId?.let { cache.evict(it) }
     symbol?.let { cache.evict(it) }
     cache.evict(ALL_INSTRUMENTS_KEY)
-    log.debug("Evicted instrument cache for id={}, symbol={}", instrumentId, symbol)
+    log.debug("Evicted instrument cache for id=$instrumentId, symbol=$symbol")
   }
 
   fun evictTransactionCaches() {
@@ -62,7 +62,7 @@ class CacheInvalidationService(
     val keys = redisTemplate.keys("$cacheName::*")
     if (keys.isNotEmpty()) {
       redisTemplate.delete(keys)
-      log.debug("Evicted {} keys from cache {}", keys.size, cacheName)
+      log.debug("Evicted ${keys.size} keys from cache $cacheName")
     }
   }
 

--- a/src/main/kotlin/ee/tenman/portfolio/service/infrastructure/ImageDownloadService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/service/infrastructure/ImageDownloadService.kt
@@ -1,0 +1,17 @@
+package ee.tenman.portfolio.service.infrastructure
+
+import org.springframework.stereotype.Service
+import org.springframework.web.client.RestClient
+
+@Service
+class ImageDownloadService(
+  private val restClient: RestClient,
+) {
+  fun download(url: String): ByteArray =
+    restClient
+      .get()
+      .uri(url)
+      .retrieve()
+      .body(ByteArray::class.java)
+      ?: error("Empty response from $url")
+}

--- a/src/main/kotlin/ee/tenman/portfolio/service/infrastructure/MinioService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/service/infrastructure/MinioService.kt
@@ -31,7 +31,7 @@ class MinioService(
         )
       true
     } catch (e: Exception) {
-      log.trace("Logo not found for {}: {}", symbol, e.message)
+      log.trace("Logo not found for $symbol: ${e.message}")
       false
     }
 
@@ -50,7 +50,7 @@ class MinioService(
         .contentType(contentType)
         .build(),
     )
-    log.debug("Uploaded logo for symbol: {}", symbol)
+    log.debug("Uploaded logo for symbol: $symbol")
   }
 
   @Cacheable(value = ["etfLogos"], key = "#symbol")
@@ -68,7 +68,7 @@ class MinioService(
           stream.readBytes()
         }
     } catch (e: Exception) {
-      log.warn("Failed to download logo for symbol: {}", LogSanitizerUtil.sanitize(symbol), e)
+      log.warn("Failed to download logo for symbol: ${LogSanitizerUtil.sanitize(symbol)}", e)
       null
     }
 }

--- a/src/main/kotlin/ee/tenman/portfolio/service/instrument/InstrumentSnapshotService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/service/instrument/InstrumentSnapshotService.kt
@@ -103,7 +103,7 @@ class InstrumentSnapshotService(
     platforms
       ?.mapNotNull { platformStr ->
         runCatching { Platform.valueOf(platformStr.uppercase()) }
-          .onFailure { log.debug("Invalid platform filter: {}", platformStr, it) }
+          .onFailure { log.debug("Invalid platform filter: $platformStr", it) }
           .getOrNull()
       }?.toSet()
 

--- a/src/main/kotlin/ee/tenman/portfolio/service/integration/CountryClassificationService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/service/integration/CountryClassificationService.kt
@@ -25,7 +25,7 @@ class CountryClassificationService(
     etfNames: List<String> = emptyList(),
   ): CountryClassificationResult? {
     val sanitizedName = LogSanitizerUtil.sanitize(companyName)
-    log.info("Classifying country for company: {} (ticker: {})", sanitizedName, ticker)
+    log.info("Classifying country for company: $sanitizedName (ticker: $ticker)")
     if (companyName.isBlank()) {
       log.warn("Blank company name")
       return null
@@ -40,7 +40,7 @@ class CountryClassificationService(
     sanitizedName: String,
   ): CountryClassificationResult? {
     if (!properties.enabled) {
-      log.warn("LLM classification disabled, skipping: {}", sanitizedName)
+      log.warn("LLM classification disabled, skipping: $sanitizedName")
       return null
     }
     val prompt = buildPrompt(companyName, ticker, etfNames)
@@ -53,7 +53,7 @@ class CountryClassificationService(
   ): CountryClassificationResult? {
     val anySp500 = etfNames.any { it.contains("S&P 500", ignoreCase = true) }
     if (anySp500) {
-      log.info("Auto-assigning US for {} (in S&P 500 ETF)", sanitizedName)
+      log.info("Auto-assigning US for $sanitizedName (in S&P 500 ETF)")
       return CountryClassificationResult(countryCode = "US", countryName = "United States", model = null)
     }
     return null
@@ -67,7 +67,7 @@ class CountryClassificationService(
   ): CountryClassificationResult? {
     val response = openRouterClient.classifyWithCountryFallback(prompt)
     if (response == null) {
-      log.warn("All country classification models failed for: {}", sanitizedName)
+      log.warn("All country classification models failed for: $sanitizedName")
       return null
     }
     return parseResponse(response, sanitizedName, logUnknownCountry = true)
@@ -81,11 +81,11 @@ class CountryClassificationService(
     val content = response.content ?: return null
     val countryCode = parseCountryCode(content)
     if (countryCode == null) {
-      if (logUnknownCountry) log.warn("Unknown country from model response: {}", content)
+      if (logUnknownCountry) log.warn("Unknown country from model response: $content")
       return null
     }
     val countryName = getCountryName(countryCode)
-    log.info("Classified {} as {} ({}) using model {}", sanitizedName, countryName, countryCode, response.model)
+    log.info("Classified $sanitizedName as $countryName ($countryCode) using model ${response.model}")
     return CountryClassificationResult(countryCode = countryCode, countryName = countryName, model = response.model)
   }
 

--- a/src/main/kotlin/ee/tenman/portfolio/service/pricing/DailyPriceService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/service/pricing/DailyPriceService.kt
@@ -10,11 +10,13 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
 import java.math.RoundingMode
+import java.time.Clock
 import java.time.LocalDate
 
 @Service
 class DailyPriceService(
   private val dailyPriceRepository: DailyPriceRepository,
+  private val clock: Clock,
 ) {
   @Transactional(readOnly = true)
   fun getPrice(
@@ -96,7 +98,7 @@ class DailyPriceService(
     instrument: Instrument,
     period: PriceChangePeriod = PriceChangePeriod.P24H,
   ): PriceChange? {
-    val currentDate = LocalDate.now()
+    val currentDate = LocalDate.now(clock)
     val targetDate = currentDate.minusDays(period.days.toLong())
 
     val currentPrice = findLastDailyPrice(instrument, currentDate)?.closePrice ?: return null
@@ -120,7 +122,7 @@ class DailyPriceService(
     instrument: Instrument,
     startDate: LocalDate,
   ): PriceChange? {
-    val currentDate = LocalDate.now()
+    val currentDate = LocalDate.now(clock)
 
     val currentPrice = findLastDailyPrice(instrument, currentDate)?.closePrice ?: return null
 

--- a/src/main/kotlin/ee/tenman/portfolio/service/pricing/LightyearPriceUpdateService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/service/pricing/LightyearPriceUpdateService.kt
@@ -33,7 +33,7 @@ class LightyearPriceUpdateService(
       saveDailyPrice(instrument, price, today, symbol)
       ProcessResult.SUCCESS_WITH_DAILY_PRICE
     }.getOrElse {
-      log.warn("Failed to update price for symbol {}: {}", symbol, it.message)
+      log.warn("Failed to update price for symbol $symbol: ${it.message}")
       ProcessResult.FAILED
     }
 
@@ -43,7 +43,7 @@ class LightyearPriceUpdateService(
     symbol: String,
   ) {
     instrumentService.updateCurrentPrice(instrument.id, price)
-    log.debug("Updated current price for {}: {}", symbol, price)
+    log.debug("Updated current price for $symbol: $price")
   }
 
   private fun saveDailyPrice(
@@ -64,6 +64,6 @@ class LightyearPriceUpdateService(
         volume = null,
       )
     dailyPriceService.saveDailyPrice(dailyPrice)
-    log.debug("Saved Lightyear daily price for {}: {}", symbol, price)
+    log.debug("Saved Lightyear daily price for $symbol: $price")
   }
 }

--- a/src/main/kotlin/ee/tenman/portfolio/service/pricing/Trading212PriceUpdateService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/service/pricing/Trading212PriceUpdateService.kt
@@ -28,7 +28,7 @@ class Trading212PriceUpdateService(
     runCatching {
       val instrument = instrumentService.findBySymbol(symbol)
       instrumentService.updateCurrentPrice(instrument.id, price)
-      log.debug("Updated current price for {}: {}", symbol, price)
+      log.debug("Updated current price for $symbol: $price")
       if (isWeekend) return@runCatching ProcessResult.SUCCESS_WITHOUT_DAILY_PRICE
       val dailyPrice =
         DailyPrice(
@@ -42,10 +42,10 @@ class Trading212PriceUpdateService(
           volume = null,
         )
       dailyPriceService.saveDailyPrice(dailyPrice)
-      log.debug("Saved Trading212 daily price for {}: {}", symbol, price)
+      log.debug("Saved Trading212 daily price for $symbol: $price")
       ProcessResult.SUCCESS_WITH_DAILY_PRICE
     }.getOrElse {
-      log.warn("Failed to update price for symbol {}: {}", symbol, it.message)
+      log.warn("Failed to update price for symbol $symbol: ${it.message}")
       ProcessResult.FAILED
     }
 }

--- a/src/main/kotlin/ee/tenman/portfolio/service/transaction/TransactionService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/service/transaction/TransactionService.kt
@@ -16,12 +16,14 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Isolation
 import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
+import java.time.Clock
 
 @Service
 class TransactionService(
   private val portfolioTransactionRepository: PortfolioTransactionRepository,
   private val profitCalculationEngine: ProfitCalculationEngine,
   private val transactionCacheService: TransactionCacheService,
+  private val clock: Clock,
 ) {
   private val log = LoggerFactory.getLogger(javaClass)
 
@@ -121,7 +123,7 @@ class TransactionService(
     val effectiveFromDate = fromDate ?: java.time.LocalDate.of(2000, 1, 1)
     val effectiveUntilDate =
       untilDate ?: java.time.LocalDate
-        .now()
+        .now(clock)
         .plusYears(100)
     return when {
       !platformEnums.isNullOrEmpty() && hasDates ->
@@ -173,6 +175,6 @@ class TransactionService(
 
   private fun String.toPlatformOrNull(): Platform? =
     runCatching { Platform.valueOf(this) }
-      .onFailure { log.warn("Invalid platform name: {}", this) }
+      .onFailure { log.warn("Invalid platform name: $this") }
       .getOrNull()
 }

--- a/src/main/kotlin/ee/tenman/portfolio/telegram/CarTelegramBot.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/telegram/CarTelegramBot.kt
@@ -105,7 +105,7 @@ class CarTelegramBot(
     startTime: Long,
   ) = try {
     val detectionResult = licensePlateDetectionService.detectPlateNumber(imageFile)
-    log.debug("Detection result: {}", objectMapper.writeValueAsString(detectionResult))
+    log.debug("Detection result: ${objectMapper.writeValueAsString(detectionResult)}")
     when {
       !detectionResult.hasCar -> sendMessage(chatId, "No car detected.", replyToMessageId)
       detectionResult.plateNumber == null ->
@@ -175,6 +175,6 @@ class CarTelegramBot(
       },
     )
   } catch (e: TelegramApiException) {
-    log.error("Failed to send message: {}", text, e)
+    log.error("Failed to send message: $text", e)
   }
 }

--- a/src/main/kotlin/ee/tenman/portfolio/trading212/Trading212Service.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/trading212/Trading212Service.kt
@@ -38,7 +38,7 @@ class Trading212Service(
         val priceData = response.data[ticker]
         if (priceData != null) {
           prices[symbol] = priceData.bid
-          log.debug("Fetched price for {}: {}", symbol, priceData.bid)
+          log.debug("Fetched price for $symbol: ${priceData.bid}")
         } else {
           log.warn("No price data found for ticker: $ticker (symbol: $symbol)")
         }

--- a/src/main/kotlin/ee/tenman/portfolio/veego/VeegoService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/veego/VeegoService.kt
@@ -14,16 +14,16 @@ class VeegoService(
 
   @Retryable(backoff = Backoff(delay = 1000))
   fun getTaxInfo(plateNumber: String): VeegoResult {
-    log.info("Fetching tax info for plate: {}", plateNumber)
+    log.info("Fetching tax info for plate: $plateNumber")
     val startTime = System.nanoTime()
     return runCatching {
       val response = veegoClient.getTaxInfo(plateNumber, VeegoTaxRequest(plateNumber))
       val duration = TimeUtility.durationInSeconds(startTime).toDouble()
-      log.info("Tax info retrieved for {}: {} EUR annual, {} EUR registration", plateNumber, response.annualTax, response.registrationTax)
+      log.info("Tax info retrieved for $plateNumber: ${response.annualTax} EUR annual, ${response.registrationTax} EUR registration")
       VeegoResult.fromResponse(response, duration)
     }.getOrElse { exception ->
       val duration = TimeUtility.durationInSeconds(startTime).toDouble()
-      log.error("Failed to fetch tax info for {}: {}", plateNumber, exception.message)
+      log.error("Failed to fetch tax info for $plateNumber: ${exception.message}")
       VeegoResult.error(exception.message ?: "Unknown error", duration)
     }
   }

--- a/src/main/kotlin/ee/tenman/portfolio/wisdomtree/WisdomTreeHoldingsService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/wisdomtree/WisdomTreeHoldingsService.kt
@@ -20,13 +20,13 @@ class WisdomTreeHoldingsService(
 
   @Retryable(backoff = Backoff(delay = 1000, multiplier = 2.0, maxDelay = 5000))
   fun fetchHoldings(etfId: String = WTAI_ETF_ID): List<WisdomTreeHolding> {
-    log.info("Fetching holdings for ETF: {}", LogSanitizerUtil.sanitize(etfId))
+    log.info("Fetching holdings for ETF: ${LogSanitizerUtil.sanitize(etfId)}")
 
     return try {
       val htmlContent = wisdomTreeHoldingsClient.getHoldings(etfId)
       parseHoldings(htmlContent)
     } catch (e: Exception) {
-      log.error("Failed to fetch holdings for ETF: {}", LogSanitizerUtil.sanitize(etfId), e)
+      log.error("Failed to fetch holdings for ETF: ${LogSanitizerUtil.sanitize(etfId)}", e)
       throw e
     }
   }

--- a/src/main/resources/db/migration/V202512291200__lightyear_rebalancing_transactions.sql
+++ b/src/main/resources/db/migration/V202512291200__lightyear_rebalancing_transactions.sql
@@ -1,0 +1,20 @@
+INSERT INTO portfolio_transaction (instrument_id, transaction_type, quantity, price, transaction_date, platform)
+VALUES ((SELECT id FROM instrument WHERE symbol = 'VNRA:GER:EUR'), 'SELL', 0.111578661, 147.3399706458, '2025-12-29', 'LIGHTYEAR');
+
+INSERT INTO portfolio_transaction (instrument_id, transaction_type, quantity, price, transaction_date, platform)
+VALUES ((SELECT id FROM instrument WHERE symbol = 'WTAI:MIL:EUR'), 'SELL', 0.280349583, 73.2299813455, '2025-12-29', 'LIGHTYEAR');
+
+INSERT INTO portfolio_transaction (instrument_id, transaction_type, quantity, price, transaction_date, platform)
+VALUES ((SELECT id FROM instrument WHERE symbol = 'XAIX:GER:EUR'), 'SELL', 0.30108429, 154.9398773034, '2025-12-29', 'LIGHTYEAR');
+
+INSERT INTO portfolio_transaction (instrument_id, transaction_type, quantity, price, transaction_date, platform)
+VALUES ((SELECT id FROM instrument WHERE symbol = 'QDVE:GER:EUR'), 'BUY', 0.067763524, 35.8600014764, '2025-12-29', 'LIGHTYEAR');
+
+INSERT INTO portfolio_transaction (instrument_id, transaction_type, quantity, price, transaction_date, platform)
+VALUES ((SELECT id FROM instrument WHERE symbol = 'CSX5:AEX:EUR'), 'BUY', 0.07768897, 218.9500455426, '2025-12-29', 'LIGHTYEAR');
+
+INSERT INTO portfolio_transaction (instrument_id, transaction_type, quantity, price, transaction_date, platform)
+VALUES ((SELECT id FROM instrument WHERE symbol = 'XNAS:GER:EUR'), 'BUY', 0.456898267, 50.2299867689, '2025-12-29', 'LIGHTYEAR');
+
+INSERT INTO portfolio_transaction (instrument_id, transaction_type, quantity, price, transaction_date, platform)
+VALUES ((SELECT id FROM instrument WHERE symbol = 'EXUS:GER:EUR'), 'BUY', 1.177663524, 35.0099836424, '2025-12-29', 'LIGHTYEAR');

--- a/src/test/kotlin/ee/tenman/portfolio/controller/PortfolioTransactionControllerIT.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/controller/PortfolioTransactionControllerIT.kt
@@ -41,6 +41,7 @@ private val DEFAULT_COOKIE = Cookie("AUTHSESSION", "NzEyYmI5ZTMtOTNkNy00MjQyLTgx
 @ExtendWith(OutputCaptureExtension::class)
 @IntegrationTest
 class PortfolioTransactionControllerIT {
+  private val testDate = LocalDate.of(2024, 1, 15)
   private val faker = Faker()
 
   @Resource
@@ -89,7 +90,7 @@ class PortfolioTransactionControllerIT {
         transactionType = TransactionType.BUY,
         quantity = BigDecimal("10"),
         price = BigDecimal("100"),
-        transactionDate = LocalDate.now(),
+        transactionDate = testDate,
         platform = Platform.TRADING212,
       )
 
@@ -105,7 +106,7 @@ class PortfolioTransactionControllerIT {
       .andExpect(jsonPath("$.transactionType").value("BUY"))
       .andExpect(jsonPath("$.quantity").value(10))
       .andExpect(jsonPath("$.price").value(100))
-      .andExpect(jsonPath("$.transactionDate").value(LocalDate.now().toString()))
+      .andExpect(jsonPath("$.transactionDate").value(testDate.toString()))
       .andExpect(jsonPath("$.platform").value("TRADING212"))
 
     val savedTransaction = portfolioTransactionRepository.findAll().first()
@@ -272,7 +273,7 @@ class PortfolioTransactionControllerIT {
           transactionType = TransactionType.BUY,
           quantity = BigDecimal("10"),
           price = BigDecimal("100"),
-          transactionDate = LocalDate.now(),
+          transactionDate = testDate,
           platform = Platform.BINANCE,
         ),
         PortfolioTransaction(
@@ -280,7 +281,7 @@ class PortfolioTransactionControllerIT {
           transactionType = TransactionType.BUY,
           quantity = BigDecimal("20"),
           price = BigDecimal("200"),
-          transactionDate = LocalDate.now(),
+          transactionDate = testDate,
           platform = Platform.TRADING212,
         ),
         PortfolioTransaction(
@@ -288,7 +289,7 @@ class PortfolioTransactionControllerIT {
           transactionType = TransactionType.SELL,
           quantity = BigDecimal("5"),
           price = BigDecimal("150"),
-          transactionDate = LocalDate.now(),
+          transactionDate = testDate,
           platform = Platform.BINANCE,
         ),
       ),
@@ -318,7 +319,7 @@ class PortfolioTransactionControllerIT {
           transactionType = TransactionType.BUY,
           quantity = BigDecimal("10"),
           price = BigDecimal("100"),
-          transactionDate = LocalDate.now(),
+          transactionDate = testDate,
           platform = Platform.BINANCE,
         ),
         PortfolioTransaction(
@@ -326,7 +327,7 @@ class PortfolioTransactionControllerIT {
           transactionType = TransactionType.BUY,
           quantity = BigDecimal("20"),
           price = BigDecimal("200"),
-          transactionDate = LocalDate.now(),
+          transactionDate = testDate,
           platform = Platform.TRADING212,
         ),
         PortfolioTransaction(
@@ -334,7 +335,7 @@ class PortfolioTransactionControllerIT {
           transactionType = TransactionType.SELL,
           quantity = BigDecimal("30"),
           price = BigDecimal("300"),
-          transactionDate = LocalDate.now(),
+          transactionDate = testDate,
           platform = Platform.LIGHTYEAR,
         ),
         PortfolioTransaction(
@@ -342,7 +343,7 @@ class PortfolioTransactionControllerIT {
           transactionType = TransactionType.BUY,
           quantity = BigDecimal("40"),
           price = BigDecimal("400"),
-          transactionDate = LocalDate.now(),
+          transactionDate = testDate,
           platform = Platform.SWEDBANK,
         ),
       ),
@@ -373,7 +374,7 @@ class PortfolioTransactionControllerIT {
         transactionType = TransactionType.BUY,
         quantity = BigDecimal("10"),
         price = BigDecimal("100"),
-        transactionDate = LocalDate.now(),
+        transactionDate = testDate,
         platform = Platform.BINANCE,
       ),
     )
@@ -401,7 +402,7 @@ class PortfolioTransactionControllerIT {
           transactionType = TransactionType.BUY,
           quantity = BigDecimal("10"),
           price = BigDecimal("100"),
-          transactionDate = LocalDate.now(),
+          transactionDate = testDate,
           platform = Platform.BINANCE,
         ),
         PortfolioTransaction(
@@ -409,7 +410,7 @@ class PortfolioTransactionControllerIT {
           transactionType = TransactionType.BUY,
           quantity = BigDecimal("20"),
           price = BigDecimal("200"),
-          transactionDate = LocalDate.now(),
+          transactionDate = testDate,
           platform = Platform.TRADING212,
         ),
         PortfolioTransaction(
@@ -417,7 +418,7 @@ class PortfolioTransactionControllerIT {
           transactionType = TransactionType.SELL,
           quantity = BigDecimal("30"),
           price = BigDecimal("300"),
-          transactionDate = LocalDate.now(),
+          transactionDate = testDate,
           platform = Platform.LIGHTYEAR,
         ),
       ),

--- a/src/test/kotlin/ee/tenman/portfolio/job/InstrumentXirrJobTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/job/InstrumentXirrJobTest.kt
@@ -25,12 +25,12 @@ import java.time.LocalDate
 import java.time.ZoneId
 
 class InstrumentXirrJobTest {
-  private val instrumentService: InstrumentService = mockk(relaxed = true)
-  private val dailyPriceService: DailyPriceService = mockk()
-  private val xirrCalculationService: XirrCalculationService = XirrCalculationService()
-  private val jobExecutionService: JobExecutionService = mockk(relaxed = true)
   private val fixedInstant: Instant = Instant.parse("2025-06-15T10:00:00Z")
   private val clock: Clock = Clock.fixed(fixedInstant, ZoneId.of("UTC"))
+  private val instrumentService: InstrumentService = mockk(relaxed = true)
+  private val dailyPriceService: DailyPriceService = mockk()
+  private val xirrCalculationService: XirrCalculationService = XirrCalculationService(clock)
+  private val jobExecutionService: JobExecutionService = mockk(relaxed = true)
 
   private val job =
     InstrumentXirrJob(

--- a/src/test/kotlin/ee/tenman/portfolio/job/TerUpdateJobTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/job/TerUpdateJobTest.kt
@@ -19,18 +19,22 @@ import io.mockk.verify
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.math.BigDecimal
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
 
 class TerUpdateJobTest {
   private val jobTransactionService = mockk<JobTransactionService>()
   private val instrumentRepository = mockk<InstrumentRepository>()
   private val lightyearPriceService = mockk<LightyearPriceService>()
   private val instrumentService = mockk<InstrumentService>()
+  private val clock = Clock.fixed(Instant.parse("2024-01-15T10:00:00Z"), ZoneId.of("UTC"))
   private lateinit var job: TerUpdateJob
 
   @BeforeEach
   fun setUp() {
     every { jobTransactionService.saveJobExecution(any(), any(), any(), any(), any()) } returns mockk()
-    job = TerUpdateJob(jobTransactionService, instrumentRepository, lightyearPriceService, instrumentService)
+    job = TerUpdateJob(jobTransactionService, instrumentRepository, lightyearPriceService, instrumentService, clock)
   }
 
   @Test

--- a/src/test/kotlin/ee/tenman/portfolio/job/WisdomTreeDataUpdateJobTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/job/WisdomTreeDataUpdateJobTest.kt
@@ -8,12 +8,16 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
 
 class WisdomTreeDataUpdateJobTest {
   private val jobTransactionService: JobTransactionService = mockk(relaxed = true)
   private val wisdomTreeUpdateService: WisdomTreeUpdateService = mockk()
+  private val clock = Clock.fixed(Instant.parse("2024-01-15T10:00:00Z"), ZoneId.of("UTC"))
 
-  private val job = WisdomTreeDataUpdateJob(jobTransactionService, wisdomTreeUpdateService)
+  private val job = WisdomTreeDataUpdateJob(jobTransactionService, wisdomTreeUpdateService, clock)
 
   @Test
   fun `should execute WisdomTree update successfully`() {

--- a/src/test/kotlin/ee/tenman/portfolio/openrouter/OpenRouterCircuitBreakerTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/openrouter/OpenRouterCircuitBreakerTest.kt
@@ -22,6 +22,7 @@ class OpenRouterCircuitBreakerTest {
       (MILLISECONDS_PER_MINUTE / AiModel.GEMINI_3_FLASH_PREVIEW.rateLimitPerMinute) + RATE_LIMIT_BUFFER_MS
     private val FALLBACK_RATE_LIMIT_INTERVAL_MS =
       (MILLISECONDS_PER_MINUTE / AiModel.CLAUDE_OPUS_4_5.rateLimitPerMinute) + RATE_LIMIT_BUFFER_MS
+    private val TEST_INSTANT = Instant.parse("2024-01-15T10:00:00Z")
   }
 
   @BeforeEach
@@ -35,7 +36,7 @@ class OpenRouterCircuitBreakerTest {
             recoveryTimeoutSeconds = 60,
           ),
       )
-    clock = MutableClock(Instant.now())
+    clock = MutableClock(TEST_INSTANT)
     circuitBreaker = OpenRouterCircuitBreaker(properties, clock)
   }
 

--- a/src/test/kotlin/ee/tenman/portfolio/repository/PortfolioTransactionRepositoryTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/repository/PortfolioTransactionRepositoryTest.kt
@@ -26,6 +26,7 @@ class PortfolioTransactionRepositoryTest {
   private lateinit var instrumentRepository: InstrumentRepository
 
   private lateinit var testInstrument: Instrument
+  private val testDate = LocalDate.of(2024, 1, 15)
 
   @BeforeEach
   fun setup() {
@@ -46,11 +47,11 @@ class PortfolioTransactionRepositoryTest {
   @Test
   fun `should find transactions by single platform`() {
     val binanceTransaction1 =
-      createAndSaveCashFlow(Platform.BINANCE, BigDecimal("100"), LocalDate.now().minusDays(1))
+      createAndSaveCashFlow(Platform.BINANCE, BigDecimal("100"), testDate.minusDays(1))
     val binanceTransaction2 =
-      createAndSaveCashFlow(Platform.BINANCE, BigDecimal("200"), LocalDate.now())
-    createAndSaveCashFlow(Platform.TRADING212, BigDecimal("300"), LocalDate.now())
-    createAndSaveCashFlow(Platform.LIGHTYEAR, BigDecimal("400"), LocalDate.now())
+      createAndSaveCashFlow(Platform.BINANCE, BigDecimal("200"), testDate)
+    createAndSaveCashFlow(Platform.TRADING212, BigDecimal("300"), testDate)
+    createAndSaveCashFlow(Platform.LIGHTYEAR, BigDecimal("400"), testDate)
 
     val result = portfolioTransactionRepository.findAllByPlatformsWithInstruments(listOf(Platform.BINANCE))
 
@@ -63,11 +64,11 @@ class PortfolioTransactionRepositoryTest {
   @Test
   fun `should find transactions by multiple platforms`() {
     val binanceTransaction =
-      createAndSaveCashFlow(Platform.BINANCE, BigDecimal("100"), LocalDate.now())
+      createAndSaveCashFlow(Platform.BINANCE, BigDecimal("100"), testDate)
     val trading212Transaction =
-      createAndSaveCashFlow(Platform.TRADING212, BigDecimal("200"), LocalDate.now())
-    createAndSaveCashFlow(Platform.LIGHTYEAR, BigDecimal("300"), LocalDate.now())
-    createAndSaveCashFlow(Platform.SWEDBANK, BigDecimal("400"), LocalDate.now())
+      createAndSaveCashFlow(Platform.TRADING212, BigDecimal("200"), testDate)
+    createAndSaveCashFlow(Platform.LIGHTYEAR, BigDecimal("300"), testDate)
+    createAndSaveCashFlow(Platform.SWEDBANK, BigDecimal("400"), testDate)
 
     val result =
       portfolioTransactionRepository.findAllByPlatformsWithInstruments(
@@ -84,8 +85,8 @@ class PortfolioTransactionRepositoryTest {
 
   @Test
   fun `should return empty list when no transactions match platforms`() {
-    createAndSaveCashFlow(Platform.BINANCE, BigDecimal("100"), LocalDate.now())
-    createAndSaveCashFlow(Platform.TRADING212, BigDecimal("200"), LocalDate.now())
+    createAndSaveCashFlow(Platform.BINANCE, BigDecimal("100"), testDate)
+    createAndSaveCashFlow(Platform.TRADING212, BigDecimal("200"), testDate)
 
     val result =
       portfolioTransactionRepository.findAllByPlatformsWithInstruments(
@@ -97,21 +98,20 @@ class PortfolioTransactionRepositoryTest {
 
   @Test
   fun `should return transactions ordered by date and id descending`() {
-    val today = LocalDate.now()
-    createAndSaveCashFlow(Platform.BINANCE, BigDecimal("100"), today.minusDays(2))
+    createAndSaveCashFlow(Platform.BINANCE, BigDecimal("100"), testDate.minusDays(2))
     val transaction2 =
-      createAndSaveCashFlow(Platform.BINANCE, BigDecimal("200"), today)
-    createAndSaveCashFlow(Platform.BINANCE, BigDecimal("300"), today.minusDays(1))
+      createAndSaveCashFlow(Platform.BINANCE, BigDecimal("200"), testDate)
+    createAndSaveCashFlow(Platform.BINANCE, BigDecimal("300"), testDate.minusDays(1))
     val transaction4 =
-      createAndSaveCashFlow(Platform.BINANCE, BigDecimal("400"), today)
+      createAndSaveCashFlow(Platform.BINANCE, BigDecimal("400"), testDate)
 
     val result = portfolioTransactionRepository.findAllByPlatformsWithInstruments(listOf(Platform.BINANCE))
 
     expect(result).toHaveSize(4)
-    expect(result[0].transactionDate).toEqual(today)
-    expect(result[1].transactionDate).toEqual(today)
-    expect(result[2].transactionDate).toEqual(today.minusDays(1))
-    expect(result[3].transactionDate).toEqual(today.minusDays(2))
+    expect(result[0].transactionDate).toEqual(testDate)
+    expect(result[1].transactionDate).toEqual(testDate)
+    expect(result[2].transactionDate).toEqual(testDate.minusDays(1))
+    expect(result[3].transactionDate).toEqual(testDate.minusDays(2))
 
     val todayTransactions = result.take(2)
     expect(todayTransactions[0].id > todayTransactions[1].id).toEqual(true)
@@ -121,7 +121,7 @@ class PortfolioTransactionRepositoryTest {
 
   @Test
   fun `should fetch instruments eagerly with transactions`() {
-    createAndSaveCashFlow(Platform.BINANCE, BigDecimal("100"), LocalDate.now())
+    createAndSaveCashFlow(Platform.BINANCE, BigDecimal("100"), testDate)
 
     val result = portfolioTransactionRepository.findAllByPlatformsWithInstruments(listOf(Platform.BINANCE))
 
@@ -133,7 +133,7 @@ class PortfolioTransactionRepositoryTest {
 
   @Test
   fun `should handle empty platforms list`() {
-    createAndSaveCashFlow(Platform.BINANCE, BigDecimal("100"), LocalDate.now())
+    createAndSaveCashFlow(Platform.BINANCE, BigDecimal("100"), testDate)
 
     val result = portfolioTransactionRepository.findAllByPlatformsWithInstruments(emptyList())
 

--- a/src/test/kotlin/ee/tenman/portfolio/service/calculation/InvestmentMetricsServiceTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/service/calculation/InvestmentMetricsServiceTest.kt
@@ -31,13 +31,16 @@ import org.junit.jupiter.params.provider.MethodSource
 import java.math.BigDecimal
 import java.math.RoundingMode
 import java.time.Clock
+import java.time.Instant
 import java.time.LocalDate
+import java.time.ZoneId
 import java.util.stream.Stream
 
 class InvestmentMetricsServiceTest {
+  private val clock = Clock.fixed(Instant.parse("2024-01-15T10:00:00Z"), ZoneId.of("UTC"))
   private val dailyPriceService = mockk<DailyPriceService>()
   private val transactionService = mockk<TransactionService>()
-  private val xirrCalculationService = XirrCalculationService()
+  private val xirrCalculationService = XirrCalculationService(clock)
   private val holdingsCalculationService = HoldingsCalculationService()
   private lateinit var investmentMetricsService: InvestmentMetricsService
 

--- a/src/test/kotlin/ee/tenman/portfolio/service/transaction/TransactionServiceTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/service/transaction/TransactionServiceTest.kt
@@ -23,7 +23,10 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 import java.math.RoundingMode
+import java.time.Clock
+import java.time.Instant
 import java.time.LocalDate
+import java.time.ZoneId
 import java.util.*
 
 class TransactionServiceTest {
@@ -33,13 +36,14 @@ class TransactionServiceTest {
   private lateinit var transactionService: TransactionService
   private lateinit var testInstrument: Instrument
   private val testDate = LocalDate.of(2024, 1, 15)
+  private val clock = Clock.fixed(Instant.parse("2024-01-15T10:00:00Z"), ZoneId.of("UTC"))
 
   @BeforeEach
   fun setUp() {
     portfolioTransactionRepository = mockk()
     profitCalculationEngine = ProfitCalculationEngine()
     transactionCacheService = mockk()
-    transactionService = TransactionService(portfolioTransactionRepository, profitCalculationEngine, transactionCacheService)
+    transactionService = TransactionService(portfolioTransactionRepository, profitCalculationEngine, transactionCacheService, clock)
 
     testInstrument =
       Instrument(


### PR DESCRIPTION
## Summary
- Extract image downloading logic to separate `ImageDownloadService` for better separation of concerns
- Fix incorrect ticker-based name updates in ETF holdings
  - Same ticker can represent different companies on different exchanges (e.g., MRK = Merck & Co. in US, MRK = Merck KGaA in Germany)
  - Now only match holdings by exact (name, ticker) combination
  - If no exact match found, create new holding instead of updating existing one
- Refactor `EtfHoldingsService` and `WisdomTreeUpdateService` to idiomatic Kotlin
  - Use expression bodies
  - Use `orElseGet()`, `map()`, `?.let {}`
  - Use `runCatching` with `onSuccess`/`onFailure`

## Test plan
- [x] Unit tests updated for new holding matching behavior
- [ ] Verify `EtfHoldingsServiceIT` tests pass
- [ ] Verify build completes successfully