### PR TITLE
Add VanEck Defense (DFEN) instrument

### DIFF
--- a/src/main/kotlin/ee/tenman/portfolio/ft/HistoricalPricesService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/ft/HistoricalPricesService.kt
@@ -36,6 +36,7 @@ private val TICKERS: Map<String, String> =
     "VNRA:GER:EUR" to "544523562",
     "XNAS:GER:EUR" to "640687109",
     "EXUS:GER:EUR" to "871264993",
+    "DFEN:GER:EUR" to "794499387",
   )
 
 private val REQUEST_DATE_FORMATTER: DateTimeFormatter =

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -191,6 +191,8 @@ scraping:
         uuid: "1f098996-8150-6170-8254-e77b526cb347"
       - symbol: "EXUS:GER:EUR"
         uuid: "1ef669d5-871f-60c2-9d43-eb48e3c470cb"
+      - symbol: "DFEN:GER:EUR"
+        uuid: "1ef669ad-df78-6d52-af15-0ffcdec674e6"
     additional-instruments:
       - symbol: "WTAI:MIL:EUR"
         uuid: "1f02fdcc-38f9-67b8-ad1b-a71ae2564bd4"

--- a/src/main/resources/db/migration/V202512301200__add_dfen_instrument.sql
+++ b/src/main/resources/db/migration/V202512301200__add_dfen_instrument.sql
@@ -1,0 +1,23 @@
+INSERT INTO instrument (
+    symbol,
+    name,
+    instrument_category,
+    base_currency,
+    provider_name,
+    provider_external_id,
+    current_price,
+    created_at,
+    updated_at,
+    version
+) VALUES (
+    'DFEN:GER:EUR',
+    'VanEck Defense',
+    'ETF',
+    'EUR',
+    'LIGHTYEAR',
+    '1ef669ad-df78-6d52-af15-0ffcdec674e6',
+    0,
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP,
+    0
+);


### PR DESCRIPTION
## Summary
- Add VanEck Defense ETF (DFEN) instrument
- Lightyear URL: https://lightyear.com/en/etf/DFEN:XETRA
- FT.com ID: 794499387
- Created Flyway migration V202512301200
- Updated application.yml with Lightyear UUID

## Test plan
- [x] Run lint and format checks
- [x] Run frontend tests (661 passed)
- [x] Run backend tests (all passed)

Closes #1162