### PR TITLE
Increase AI rate limits and add parallel country classification

### DIFF
--- a/src/main/kotlin/ee/tenman/portfolio/domain/AiModel.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/domain/AiModel.kt
@@ -6,11 +6,11 @@ enum class AiModel(
   val sectorFallbackTier: Int = -1,
   val countryFallbackTier: Int = -1,
 ) {
-  GEMINI_3_FLASH_PREVIEW("google/gemini-3-flash-preview", 100, sectorFallbackTier = 0),
-  CLAUDE_OPUS_4_5("anthropic/claude-opus-4.5", 60, sectorFallbackTier = 1, countryFallbackTier = 0),
-  CLAUDE_SONNET_4_5("anthropic/claude-sonnet-4.5", 60, sectorFallbackTier = 2, countryFallbackTier = 1),
-  GEMINI_2_5_FLASH("google/gemini-2.5-flash", 100, sectorFallbackTier = 3),
-  DEEPSEEK_V3_2("deepseek/deepseek-v3.2", 60, sectorFallbackTier = 4, countryFallbackTier = 2),
+  GEMINI_3_FLASH_PREVIEW("google/gemini-3-flash-preview", 400, sectorFallbackTier = 0),
+  CLAUDE_OPUS_4_5("anthropic/claude-opus-4.5", 240, sectorFallbackTier = 1, countryFallbackTier = 0),
+  CLAUDE_SONNET_4_5("anthropic/claude-sonnet-4.5", 240, sectorFallbackTier = 2, countryFallbackTier = 1),
+  GEMINI_2_5_FLASH("google/gemini-2.5-flash", 400, sectorFallbackTier = 3),
+  DEEPSEEK_V3_2("deepseek/deepseek-v3.2", 240, sectorFallbackTier = 4, countryFallbackTier = 2),
   ;
 
   fun nextSectorFallbackModel(): AiModel? = entries.find { it.sectorFallbackTier == this.sectorFallbackTier + 1 }

--- a/src/test/kotlin/ee/tenman/portfolio/openrouter/AiModelTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/openrouter/AiModelTest.kt
@@ -57,27 +57,27 @@ class AiModelTest {
 
   @Test
   fun `should have correct rate limits for GEMINI_3_FLASH_PREVIEW`() {
-    expect(AiModel.GEMINI_3_FLASH_PREVIEW.rateLimitPerMinute).toEqual(100)
+    expect(AiModel.GEMINI_3_FLASH_PREVIEW.rateLimitPerMinute).toEqual(400)
   }
 
   @Test
   fun `should have correct rate limits for GEMINI_2_5_FLASH`() {
-    expect(AiModel.GEMINI_2_5_FLASH.rateLimitPerMinute).toEqual(100)
+    expect(AiModel.GEMINI_2_5_FLASH.rateLimitPerMinute).toEqual(400)
   }
 
   @Test
   fun `should have correct rate limits for CLAUDE_SONNET_4_5`() {
-    expect(AiModel.CLAUDE_SONNET_4_5.rateLimitPerMinute).toEqual(60)
+    expect(AiModel.CLAUDE_SONNET_4_5.rateLimitPerMinute).toEqual(240)
   }
 
   @Test
   fun `should have correct rate limits for CLAUDE_OPUS_4_5`() {
-    expect(AiModel.CLAUDE_OPUS_4_5.rateLimitPerMinute).toEqual(60)
+    expect(AiModel.CLAUDE_OPUS_4_5.rateLimitPerMinute).toEqual(240)
   }
 
   @Test
   fun `should have correct rate limits for DEEPSEEK_V3_2`() {
-    expect(AiModel.DEEPSEEK_V3_2.rateLimitPerMinute).toEqual(60)
+    expect(AiModel.DEEPSEEK_V3_2.rateLimitPerMinute).toEqual(240)
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Increase AI model rate limits from 60 to 240 requests/min for Claude and DeepSeek models
- Increase Gemini model rate limits from 100 to 400 requests/min
- Add 5-thread parallel processing to country classification job using Kotlin coroutines
- Add 3-thread parallel processing to sector classification job using Kotlin coroutines
- Use `fold` instead of `reduce` to safely handle empty result lists

## Test plan
- [x] Verify rate limit tests pass with new values
- [x] Verify classification jobs compile correctly
- [x] Lint checks pass (ktlint, detekt)
- [ ] Run classification jobs to confirm parallel processing works