### PR TITLE
Add iShares Global Aerospace & Defence (DFND) instrument

### DIFF
--- a/src/main/kotlin/ee/tenman/portfolio/ft/HistoricalPricesService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/ft/HistoricalPricesService.kt
@@ -38,6 +38,7 @@ private val TICKERS: Map<String, String> =
     "EXUS:GER:EUR" to "871264993",
     "DFEN:GER:EUR" to "794499387",
     "WBIT:GER:EUR" to "653421505",
+    "DFND:PAR:EUR" to "913527044",
   )
 
 private val REQUEST_DATE_FORMATTER: DateTimeFormatter =

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -193,6 +193,8 @@ scraping:
         uuid: "1ef669d5-871f-60c2-9d43-eb48e3c470cb"
       - symbol: "DFEN:GER:EUR"
         uuid: "1ef669ad-df78-6d52-af15-0ffcdec674e6"
+      - symbol: "DFND:PAR:EUR"
+        uuid: "1efc26c6-bdb9-61c9-a75b-85fa9e28d0c0"
     additional-instruments:
       - symbol: "WTAI:MIL:EUR"
         uuid: "1f02fdcc-38f9-67b8-ad1b-a71ae2564bd4"

--- a/src/main/resources/db/migration/V202512301300__add_dfnd_instrument.sql
+++ b/src/main/resources/db/migration/V202512301300__add_dfnd_instrument.sql
@@ -1,0 +1,23 @@
+INSERT INTO instrument (
+    symbol,
+    name,
+    instrument_category,
+    base_currency,
+    provider_name,
+    provider_external_id,
+    current_price,
+    created_at,
+    updated_at,
+    version
+) VALUES (
+    'DFND:PAR:EUR',
+    'iShares Global Aerospace & Defence',
+    'ETF',
+    'EUR',
+    'LIGHTYEAR',
+    '1efc26c6-bdb9-61c9-a75b-85fa9e28d0c0',
+    0,
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP,
+    0
+);


### PR DESCRIPTION
## Summary

- Add new ETF instrument: iShares Global Aerospace & Defence (DFND)
- Symbol: `DFND:PAR:EUR` (Paris Exchange)
- Create database migration for instrument record
- Add FT.com ticker mapping for price retrieval
- Add Lightyear UUID mapping for platform sync

Closes #1165

## Test plan

- [x] Backend tests pass
- [x] Frontend tests pass
- [ ] Verify instrument appears in database after migration
- [ ] Verify FT price retrieval works for DFND:PAR:EUR
- [ ] Verify Lightyear sync picks up the instrument