### PR TITLE
Display instrument prices with 5 significant digits

### DIFF
--- a/ui/components/instruments/instrument-table.test.ts
+++ b/ui/components/instruments/instrument-table.test.ts
@@ -144,7 +144,7 @@ describe('InstrumentTable', () => {
       const rows = wrapper.findAll('tbody tr')
 
       expect(rows[0].text()).toContain('$150.50')
-      expect(rows[1].text()).toContain('€45,000.00')
+      expect(rows[1].text()).toContain('€45,000')
     })
 
     it('should format total investment with currency', () => {

--- a/ui/components/instruments/instrument-table.vue
+++ b/ui/components/instruments/instrument-table.vue
@@ -79,7 +79,7 @@
           </div>
           <div class="metric-group">
             <span class="metric-value">
-              {{ formatCurrencyWithSign(item.currentPrice, item.baseCurrency) }}
+              {{ formatPrice(item.currentPrice, item.baseCurrency) }}
             </span>
             <span class="metric-label">Price</span>
           </div>
@@ -219,7 +219,7 @@
 
     <template #cell-currentPrice="{ item }">
       <span :class="getChangeClass(item.id, 'currentPrice')">
-        {{ formatCurrencyWithSign(item.currentPrice, item.baseCurrency) }}
+        {{ formatPrice(item.currentPrice, item.baseCurrency) }}
       </span>
     </template>
 
@@ -296,6 +296,7 @@ import { instrumentColumns } from '../../config'
 import {
   getProfitClass,
   formatCurrencyWithSign,
+  formatPrice,
   formatQuantity,
   formatPercentageFromDecimal,
   formatPriceChange,

--- a/ui/models/generated/domain-models.ts
+++ b/ui/models/generated/domain-models.ts
@@ -1,5 +1,5 @@
 /* tslint:disable */
-/* eslint-disable */
+ 
 // Generated using typescript-generator (timestamp removed to prevent git churn)
 
 /**

--- a/ui/utils/formatters.test.ts
+++ b/ui/utils/formatters.test.ts
@@ -3,6 +3,7 @@ import {
   formatCurrencyWithSymbol,
   formatCurrency,
   formatCurrencyWithSign,
+  formatPrice,
   getCurrencySymbol,
   formatNumber,
   formatPercentageFromDecimal,
@@ -119,6 +120,57 @@ describe('formatCurrencyWithSign', () => {
   it('should default to EUR for unknown currencies', () => {
     expect(formatCurrencyWithSign(100, 'JPY')).toBe('€100.00')
     expect(formatCurrencyWithSign(100, 'UNKNOWN')).toBe('€100.00')
+  })
+})
+
+describe('formatPrice', () => {
+  it('should format large prices with no decimals', () => {
+    expect(formatPrice(12345.67, 'EUR')).toBe('€12,346')
+    expect(formatPrice(99999.99, 'USD')).toBe('$100,000')
+    expect(formatPrice(10000, 'GBP')).toBe('£10,000')
+  })
+
+  it('should format medium prices with 1 decimal', () => {
+    expect(formatPrice(1234.56, 'EUR')).toBe('€1,234.6')
+    expect(formatPrice(9999.99, 'USD')).toBe('$10,000.0')
+    expect(formatPrice(1000, 'GBP')).toBe('£1,000.0')
+  })
+
+  it('should format small prices with 2 decimals', () => {
+    expect(formatPrice(123.45, 'EUR')).toBe('€123.45')
+    expect(formatPrice(12.34, 'USD')).toBe('$12.34')
+    expect(formatPrice(1.23, 'GBP')).toBe('£1.23')
+    expect(formatPrice(0.12, 'EUR')).toBe('€0.12')
+  })
+
+  it('should handle null and undefined values', () => {
+    expect(formatPrice(null)).toBe('0.00')
+    expect(formatPrice(undefined)).toBe('0.00')
+    expect(formatPrice(null, 'USD')).toBe('0.00')
+  })
+
+  it('should handle zero value', () => {
+    expect(formatPrice(0, 'EUR')).toBe('€0.00')
+    expect(formatPrice(0, 'USD')).toBe('$0.00')
+  })
+
+  it('should format negative numbers as absolute values', () => {
+    expect(formatPrice(-12345.67, 'EUR')).toBe('€12,346')
+    expect(formatPrice(-1234.56, 'USD')).toBe('$1,234.6')
+    expect(formatPrice(-123.45, 'GBP')).toBe('£123.45')
+  })
+
+  it('should default to EUR for undefined currency', () => {
+    expect(formatPrice(100)).toBe('€100.00')
+    expect(formatPrice(1234.56)).toBe('€1,234.6')
+    expect(formatPrice(12345.67)).toBe('€12,346')
+  })
+
+  it('should handle edge cases at thresholds', () => {
+    expect(formatPrice(999.99, 'EUR')).toBe('€999.99')
+    expect(formatPrice(1000, 'EUR')).toBe('€1,000.0')
+    expect(formatPrice(9999.9, 'EUR')).toBe('€9,999.9')
+    expect(formatPrice(10000, 'EUR')).toBe('€10,000')
   })
 })
 

--- a/ui/utils/formatters.ts
+++ b/ui/utils/formatters.ts
@@ -91,6 +91,32 @@ export const formatCurrencyWithSign = (
   return `${currencySymbol}${absValue}`
 }
 
+const PRICE_THRESHOLD_NO_DECIMALS = 10000
+const PRICE_THRESHOLD_ONE_DECIMAL = 1000
+
+export const formatPrice = (value: number | undefined | null, currency?: string): string => {
+  if (value === null || value === undefined) return '0.00'
+
+  const absValue = Math.abs(value)
+  const currencySymbol = getCurrencySymbol(currency)
+
+  let fractionDigits: number
+  if (absValue >= PRICE_THRESHOLD_NO_DECIMALS) {
+    fractionDigits = 0
+  } else if (absValue >= PRICE_THRESHOLD_ONE_DECIMAL) {
+    fractionDigits = 1
+  } else {
+    fractionDigits = 2
+  }
+
+  const formatted = absValue.toLocaleString('en-US', {
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits,
+  })
+
+  return `${currencySymbol}${formatted}`
+}
+
 export const getCurrencySymbol = (currency?: string): string => {
   switch (currency?.toUpperCase()) {
     case 'EUR':


### PR DESCRIPTION
## Summary
- Add `formatPrice()` function to format instrument prices with 5 significant digits
- Large prices (>=10,000) display without decimals: €12,346
- Medium prices (>=1,000) display with 1 decimal: €1,234.6
- Smaller prices display with 2 decimals: €123.45
- Apply only to Price column, other currency values unchanged

## Test plan
- [x] Unit tests for formatPrice() added (8 test cases)
- [x] All 670 frontend tests pass
- [x] Lint and format checks pass
- [ ] Visual verification on instruments page

Closes #1193