### PR TITLE
Change XIRR minimum threshold from 90 to 30 days

### DIFF
--- a/src/main/kotlin/ee/tenman/portfolio/service/calculation/XirrCalculationService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/service/calculation/XirrCalculationService.kt
@@ -19,7 +19,7 @@ class XirrCalculationService(
   private val log = LoggerFactory.getLogger(javaClass)
 
   companion object {
-    private const val MIN_DAYS_FOR_XIRR = 90.0
+    private const val MIN_DAYS_FOR_XIRR = 30.0
     private const val FULL_DAMPING_DAYS = 120.0
   }
 

--- a/src/test/kotlin/ee/tenman/portfolio/service/calculation/FinancialCalculationEdgeCaseTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/service/calculation/FinancialCalculationEdgeCaseTest.kt
@@ -51,7 +51,7 @@ class FinancialCalculationEdgeCaseTest {
     }
 
     @Test
-    fun `should return null for very recent transaction below 90 days`() {
+    fun `should return null for very recent transaction below 30 days`() {
       val transactions =
         listOf(
         CashFlow(-1000.0, LocalDate.now(clock).minusDays(1)),

--- a/src/test/kotlin/ee/tenman/portfolio/service/calculation/InvestmentMetricsServiceTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/service/calculation/InvestmentMetricsServiceTest.kt
@@ -594,10 +594,10 @@ class InvestmentMetricsServiceTest {
   }
 
   @Test
-  fun `should calculateAdjustedXirr with exactly 90 days investment period`() {
+  fun `should calculateAdjustedXirr with exactly 30 days investment period`() {
     val transactions =
       listOf(
-        CashFlow(-1000.0, testDate.minusDays(90)),
+        CashFlow(-1000.0, testDate.minusDays(30)),
         CashFlow(1200.0, testDate),
       )
 


### PR DESCRIPTION
## Summary
- Reduce XIRR minimum investment period threshold from 90 days to 30 days
- Allows XIRR calculation for newer investments

## Test plan
- [ ] Verify XIRR calculates for investments held 30+ days
- [ ] Verify XIRR returns null for investments held less than 30 days