### PR TITLE
Add iShares AI Infrastructure ETF (AIFS) instrument

### DIFF
--- a/src/main/kotlin/ee/tenman/portfolio/ft/HistoricalPricesService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/ft/HistoricalPricesService.kt
@@ -40,6 +40,7 @@ private val TICKERS: Map<String, String> =
     "WBIT:GER:EUR" to "653421505",
     "DFND:PAR:EUR" to "913527044",
     "IS3S:GER:EUR" to "79062420",
+    "AIFS:GER:EUR" to "950573165",
   )
 
 private val REQUEST_DATE_FORMATTER: DateTimeFormatter =

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -201,6 +201,8 @@ scraping:
         uuid: "1f02fdcc-38f9-67b8-ad1b-a71ae2564bd4"
       - symbol: "WBIT:GER:EUR"
         uuid: "1ef3aa4c-5f26-6cf0-8eba-bb4404220dad"
+      - symbol: "AIFS:GER:EUR"
+        uuid: "1efb76c2-b6a1-6638-914d-2d7971d10ab6"
 
 cloudflare-bypass-proxy:
   url: ${CLOUDFLARE_BYPASS_PROXY_URL:${TRADING212_PROXY_URL:http://localhost:3000}}

--- a/src/main/resources/db/migration/V202601061738__add_aifs_instrument.sql
+++ b/src/main/resources/db/migration/V202601061738__add_aifs_instrument.sql
@@ -1,0 +1,23 @@
+INSERT INTO instrument (
+    symbol,
+    name,
+    instrument_category,
+    base_currency,
+    provider_name,
+    provider_external_id,
+    current_price,
+    created_at,
+    updated_at,
+    version
+) VALUES (
+    'AIFS:GER:EUR',
+    'iShares AI Infrastructure',
+    'ETF',
+    'EUR',
+    'LIGHTYEAR',
+    '1efb76c2-b6a1-6638-914d-2d7971d10ab6',
+    0,
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP,
+    0
+);


### PR DESCRIPTION
## Summary

- Add database migration for AIFS:GER:EUR instrument with Lightyear provider
- Configure Lightyear UUID (`1efb76c2-b6a1-6638-914d-2d7971d10ab6`) for price fetching
- Add FT.com ID (`950573165`) mapping for historical prices

## Test plan

- [ ] Migration runs successfully on deployment
- [ ] Instrument appears in instruments list
- [ ] Lightyear price fetching works for AIFS
- [ ] FT.com historical prices are retrieved

Closes #1204