### PR TITLE
Add infinite scroll pagination to ETF breakdown page

### DIFF
--- a/src/test/kotlin/ee/tenman/portfolio/service/etf/SyntheticEtfCalculationServiceTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/service/etf/SyntheticEtfCalculationServiceTest.kt
@@ -220,7 +220,7 @@ class SyntheticEtfCalculationServiceTest {
       val instrument1 = createInstrument("AAPL", BigDecimal("100.00"))
       val instrument2 = createInstrument("MSFT", BigDecimal("200.00"))
       val etf = createEtfInstrument("SYNTH-ETF")
-      every { etfPositionRepository.findLatestPositionsByEtfId(etf.id) } returns listOf(position1, position2)
+      every { etfPositionRepository.findLatestPositionsByEtfIds(listOf(etf.id)) } returns listOf(position1, position2)
       every { instrumentRepository.findBySymbolIn(listOf("AAPL", "MSFT")) } returns listOf(instrument1, instrument2)
       every { transactionCalculationService.batchCalculateAll(listOf(instrument1.id, instrument2.id)) } returns
         mapOf(

--- a/ui/components/etf/etf-breakdown-chart.vue
+++ b/ui/components/etf/etf-breakdown-chart.vue
@@ -86,6 +86,17 @@ const renderChart = () => {
   })
 }
 
+const updateChartData = () => {
+  if (!chart?.data?.datasets?.[0] || props.chartData.length === 0) {
+    renderChart()
+    return
+  }
+  chart.data.labels = props.chartData.map(item => item.label)
+  chart.data.datasets[0].data = props.chartData.map(item => item.value)
+  chart.data.datasets[0].backgroundColor = props.chartData.map(item => item.color)
+  chart.update('none')
+}
+
 onMounted(() => {
   renderChart()
 })
@@ -93,7 +104,7 @@ onMounted(() => {
 watch(
   () => props.chartData,
   () => {
-    renderChart()
+    updateChartData()
   },
   { deep: true }
 )

--- a/ui/components/etf/etf-breakdown.vue
+++ b/ui/components/etf/etf-breakdown.vue
@@ -102,10 +102,15 @@ const errorMessage = ref('')
 const selectedEtfs = useLocalStorage<string[]>('portfolio_selected_etfs', [])
 const selectedPlatforms = useLocalStorage<string[]>('portfolio_etf_breakdown_platforms', [])
 
-const availablePlatforms = computed(() => {
-  if (masterHoldings.value.length === 0) return []
+const etfPlatformMetadata = computed(() => {
+  if (masterHoldings.value.length === 0) return { etfs: [], platforms: [] }
+  const etfSet = new Set<string>()
   const platformSet = new Set<string>()
   masterHoldings.value.forEach(holding => {
+    holding.inEtfs.split(',').forEach(etf => {
+      const trimmed = etf.trim()
+      if (trimmed) etfSet.add(trimmed)
+    })
     if (holding.platforms) {
       holding.platforms.split(',').forEach(p => {
         const trimmed = p.trim()
@@ -113,24 +118,12 @@ const availablePlatforms = computed(() => {
       })
     }
   })
-  return Array.from(platformSet).sort()
+  return { etfs: Array.from(etfSet).sort(), platforms: Array.from(platformSet).sort() }
 })
 
-const availableEtfs = computed(() => {
-  if (masterHoldings.value.length === 0) return []
+const availablePlatforms = computed(() => etfPlatformMetadata.value.platforms)
 
-  const etfSet = new Set<string>()
-  masterHoldings.value.forEach(holding => {
-    holding.inEtfs.split(',').forEach(etf => {
-      const trimmedEtf = etf.trim()
-      if (trimmedEtf) {
-        etfSet.add(trimmedEtf)
-      }
-    })
-  })
-
-  return Array.from(etfSet).sort()
-})
+const availableEtfs = computed(() => etfPlatformMetadata.value.etfs)
 
 watch(
   availableEtfs,


### PR DESCRIPTION
## Summary
- Load 200 holdings initially with infinite scroll for more on scroll
- Add lazy image loading for logos and flags using native `loading="lazy"`
- Update charts in place instead of destroying and recreating on data change
- Memoize ETF/platform computed derivations into single iteration
- Fix N+1 query in `SyntheticEtfCalculationService.calculateTotalValue()` using batch query

## Test plan
- [x] Verify infinite scroll loads next 200 items when scrolling to bottom
- [x] Verify filter changes reset to first 200 items
- [x] Verify charts update smoothly without flicker
- [x] Verify images load only when visible
- [x] All 670 frontend tests pass
- [x] All backend tests pass

Closes #1208