### PR TITLE
Fix white page on initial load

### DIFF
--- a/ui/app.vue
+++ b/ui/app.vue
@@ -1,5 +1,10 @@
 <template>
-  <div class="d-flex flex-column min-vh-100">
+  <div v-if="isAuthChecking" class="auth-loading">
+    <div class="spinner-border text-primary" role="status">
+      <span class="visually-hidden">Loading...</span>
+    </div>
+  </div>
+  <div v-else class="d-flex flex-column min-vh-100">
     <NavBar />
     <main class="flex-grow-1">
       <div class="container-fluid py-2">
@@ -27,10 +32,27 @@
 </template>
 
 <script lang="ts" setup>
+import { onMounted } from 'vue'
 import NavBar from './components/nav-bar.vue'
 import ConfirmDialog from './components/shared/confirm-dialog.vue'
 import { provideConfirm } from './composables/use-confirm'
+import { useAuthState } from './composables/use-auth-state'
 
 const currentYear = new Date().getFullYear()
 const confirmState = provideConfirm()
+const { isAuthChecking, checkAuth } = useAuthState()
+
+onMounted(() => {
+  checkAuth()
+})
 </script>
+
+<style scoped>
+.auth-loading {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  background-color: #f8f9fa;
+}
+</style>

--- a/ui/components/instruments/instruments-view.test.ts
+++ b/ui/components/instruments/instruments-view.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { ref, h } from 'vue'
 import { mount, flushPromises } from '@vue/test-utils'
 import { QueryClient, VueQueryPlugin } from '@tanstack/vue-query'
 import InstrumentsView from './instruments-view.vue'
 import { instrumentsService } from '../../services/instruments-service'
 import type { InstrumentsResponse, Platform } from '../../models/generated/domain-models'
 import { ProviderName } from '../../models/generated/domain-models'
-import { h } from 'vue'
 import { createInstrumentDto } from '../../tests/fixtures'
 
 const mockShow = vi.fn()
@@ -14,6 +14,13 @@ const mockToastSuccess = vi.fn()
 const mockToastError = vi.fn()
 
 vi.mock('../../services/instruments-service')
+vi.mock('../../composables/use-auth-state', () => ({
+  useAuthState: () => ({
+    isAuthenticated: ref(true),
+    isAuthChecking: ref(false),
+    checkAuth: vi.fn().mockResolvedValue(true),
+  }),
+}))
 vi.mock('../../composables/use-toast', () => ({
   useToast: () => ({
     success: mockToastSuccess,

--- a/ui/components/instruments/instruments-view.vue
+++ b/ui/components/instruments/instruments-view.vue
@@ -65,6 +65,7 @@ import { useLocalStorage } from '@vueuse/core'
 import { useBootstrapModal } from '../../composables/use-bootstrap-modal'
 import { usePriceChangePeriod } from '../../composables/use-price-change-period'
 import { useSortableTable } from '../../composables/use-sortable-table'
+import { useAuthState } from '../../composables/use-auth-state'
 import CrudLayout from '../shared/crud-layout.vue'
 import InstrumentTable from './instrument-table.vue'
 import InstrumentModal from './instrument-modal.vue'
@@ -79,10 +80,12 @@ const { show: showModal, hide: hideModal } = useBootstrapModal('instrumentModal'
 const { selectedPeriod, periods } = usePriceChangePeriod()
 const queryClient = useQueryClient()
 const toast = useToast()
+const { isAuthenticated } = useAuthState()
 
 const { data: allInstruments } = useQuery({
   queryKey: ['instruments-all'],
   queryFn: () => instrumentsService.getAll(),
+  enabled: isAuthenticated,
 })
 
 const availablePlatforms = computed(() => {
@@ -139,6 +142,7 @@ const {
     return instrumentsService.getAll(selectedPlatforms.value, selectedPeriod.value)
   },
   refetchInterval: REFETCH_INTERVALS.INSTRUMENTS,
+  enabled: isAuthenticated,
 })
 
 const filteredItems = computed(() => {

--- a/ui/components/transactions/transactions-view.vue
+++ b/ui/components/transactions/transactions-view.vue
@@ -123,8 +123,10 @@ import {
   QUICK_DATE_OPTIONS,
   type QuickDatePreset,
 } from '../../composables/use-quick-dates'
+import { useAuthState } from '../../composables/use-auth-state'
 
 const selectedPlatforms = useLocalStorage<string[]>(STORAGE_KEYS.SELECTED_TRANSACTION_PLATFORMS, [])
+const { isAuthenticated } = useAuthState()
 const quickDateDropdown = ref<HTMLElement | null>(null)
 
 const closeDropdown = () => {
@@ -144,6 +146,7 @@ const { fromDate, untilDate, selectedQuickDate, setQuickDate, clearDates } = use
 const { data: allTransactionsResponse } = useQuery({
   queryKey: ['transactions'],
   queryFn: () => transactionsService.getAll(),
+  enabled: isAuthenticated,
 })
 
 const { data: transactionsResponse, isLoading } = useQuery({
@@ -154,6 +157,7 @@ const { data: transactionsResponse, isLoading } = useQuery({
       fromDate.value || undefined,
       untilDate.value || undefined
     ),
+  enabled: isAuthenticated,
 })
 
 const transactions = computed(() => transactionsResponse.value?.transactions)

--- a/ui/composables/use-auth-state.ts
+++ b/ui/composables/use-auth-state.ts
@@ -1,0 +1,36 @@
+import { ref, readonly } from 'vue'
+import { httpClient } from '../utils/http-client'
+import { API_ENDPOINTS } from '../constants'
+
+const isAuthenticated = ref(false)
+const isAuthChecking = ref(true)
+const authCheckPromise = ref<Promise<boolean> | null>(null)
+
+async function checkAuth(): Promise<boolean> {
+  if (authCheckPromise.value) {
+    return authCheckPromise.value
+  }
+
+  authCheckPromise.value = (async () => {
+    try {
+      await httpClient.get(API_ENDPOINTS.BUILD_INFO)
+      isAuthenticated.value = true
+      return true
+    } catch {
+      isAuthenticated.value = false
+      return false
+    } finally {
+      isAuthChecking.value = false
+    }
+  })()
+
+  return authCheckPromise.value
+}
+
+export function useAuthState() {
+  return {
+    isAuthenticated: readonly(isAuthenticated),
+    isAuthChecking: readonly(isAuthChecking),
+    checkAuth,
+  }
+}

--- a/ui/composables/use-portfolio-summary-query.test.ts
+++ b/ui/composables/use-portfolio-summary-query.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ref } from 'vue'
 import { flushPromises } from '@vue/test-utils'
 import { usePortfolioSummaryQuery } from './use-portfolio-summary-query'
 import { portfolioSummaryService } from '../services/portfolio-summary-service'
@@ -8,6 +9,13 @@ import type { Page } from '../models/page'
 import { createPortfolioSummaryDto } from '../tests/fixtures'
 
 vi.mock('../services/portfolio-summary-service')
+vi.mock('./use-auth-state', () => ({
+  useAuthState: () => ({
+    isAuthenticated: ref(true),
+    isAuthChecking: ref(false),
+    checkAuth: vi.fn().mockResolvedValue(true),
+  }),
+}))
 
 const mockCurrentSummary: PortfolioSummaryDto = createPortfolioSummaryDto({
   date: '2023-12-31',

--- a/ui/composables/use-portfolio-summary-query.ts
+++ b/ui/composables/use-portfolio-summary-query.ts
@@ -6,11 +6,13 @@ import {
   sortSummariesByDateAsc,
   flattenPages,
 } from '../services/summary-aggregator'
+import { useAuthState } from './use-auth-state'
 
 export function usePortfolioSummaryQuery() {
   const queryClient = useQueryClient()
   const recalculationMessage = ref('')
   const pageSize = 186
+  const { isAuthenticated } = useAuthState()
 
   const {
     data: historicalData,
@@ -29,11 +31,13 @@ export function usePortfolioSummaryQuery() {
       return undefined
     },
     initialPageParam: 0,
+    enabled: isAuthenticated,
   })
 
   const { data: currentSummary, isLoading: isLoadingCurrent } = useQuery({
     queryKey: ['portfolio-summary', 'current'],
     queryFn: portfolioSummaryService.getCurrent,
+    enabled: isAuthenticated,
   })
 
   const recalculateMutation = useMutation({

--- a/ui/index.html
+++ b/ui/index.html
@@ -14,9 +14,36 @@
 
   <!-- Preconnect to external domains used in the app -->
   <link href="https://cdn.jsdelivr.net" rel="preconnect"> <!-- For Bootstrap -->
+
+  <!-- Initial loading styles -->
+  <style>
+    .initial-loader {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      height: 100vh;
+      background-color: #f8f9fa;
+    }
+    .initial-spinner {
+      width: 3rem;
+      height: 3rem;
+      border: 0.25rem solid #e9ecef;
+      border-top-color: #0d6efd;
+      border-radius: 50%;
+      animation: spin 1s linear infinite;
+    }
+    @keyframes spin {
+      to { transform: rotate(360deg); }
+    }
+  </style>
 </head>
 <body>
-<div id="app"></div>
+<div id="app">
+  <div class="initial-loader">
+    <div class="initial-spinner"></div>
+  </div>
+</div>
 <script src="./main.ts" type="module"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add `use-auth-state` composable for centralized authentication state management
- Add `enabled: isAuthenticated` guards to all TanStack Query hooks to prevent race conditions
- Add loading spinner in `index.html` and `app.vue` for visual feedback during auth check
- Fix intermittent white page issue on first load at fov.ee

## Root Cause
TanStack Query was firing API requests before the authentication state was ready, causing queries to fail silently and resulting in a white page.

## Test plan
- [ ] Verify lint and format pass (`npm run lint-format`)
- [ ] Verify all 670 frontend tests pass (`npm test`)
- [ ] Test initial page load on fov.ee - should show loading spinner then content
- [ ] Test refresh - should work correctly
- [ ] Test different pages (Instruments, Transactions, Portfolio Summary)