### PR TITLE
Sell QDVE positions and add CASH synthetic fund

### DIFF
--- a/src/main/resources/db/migration/V202601131530__sell_qdve_buy_eur.sql
+++ b/src/main/resources/db/migration/V202601131530__sell_qdve_buy_eur.sql
@@ -1,0 +1,11 @@
+INSERT INTO portfolio_transaction (instrument_id, transaction_type, quantity, price, transaction_date, platform, commission)
+VALUES ((SELECT id FROM instrument WHERE symbol = 'QDVE:GER:EUR'), 'SELL', 35, 36.00, '2026-01-13', 'LHV', 0);
+
+INSERT INTO portfolio_transaction (instrument_id, transaction_type, quantity, price, transaction_date, platform, commission)
+VALUES ((SELECT id FROM instrument WHERE symbol = 'QDVE:GER:EUR'), 'SELL', 78, 36.00, '2026-01-13', 'SWEDBANK', 3.93);
+
+INSERT INTO portfolio_transaction (instrument_id, transaction_type, quantity, price, transaction_date, platform, commission)
+VALUES ((SELECT id FROM instrument WHERE symbol = 'EUR'), 'BUY', 1260, 1.0, '2026-01-13', 'LHV', 0);
+
+INSERT INTO portfolio_transaction (instrument_id, transaction_type, quantity, price, transaction_date, platform, commission)
+VALUES ((SELECT id FROM instrument WHERE symbol = 'EUR'), 'BUY', 2804.07, 1.0, '2026-01-13', 'SWEDBANK', 0);

--- a/src/main/resources/db/migration/V202601131600__add_cash_synthetic_fund.sql
+++ b/src/main/resources/db/migration/V202601131600__add_cash_synthetic_fund.sql
@@ -1,0 +1,22 @@
+INSERT INTO instrument (symbol, name, instrument_category, base_currency, provider_name, created_at, updated_at, version)
+VALUES ('CASH', 'Cash Holdings', 'ETF', 'EUR', 'SYNTHETIC', NOW(), NOW(), 0)
+ON CONFLICT DO NOTHING;
+
+INSERT INTO etf_holding (name, ticker, sector, uuid, created_at, updated_at, version)
+VALUES ('Euro Cash', 'EUR', 'Cash', gen_random_uuid(), NOW(), NOW(), 0)
+ON CONFLICT DO NOTHING;
+
+INSERT INTO etf_position (etf_instrument_id, holding_id, snapshot_date, weight_percentage, created_at, updated_at, version)
+SELECT
+  (SELECT id FROM instrument WHERE symbol = 'CASH'),
+  h.id,
+  CURRENT_DATE,
+  0,
+  NOW(), NOW(), 0
+FROM etf_holding h
+WHERE h.ticker = 'EUR' AND h.name = 'Euro Cash'
+  AND NOT EXISTS (
+    SELECT 1 FROM etf_position p
+    WHERE p.etf_instrument_id = (SELECT id FROM instrument WHERE symbol = 'CASH')
+      AND p.holding_id = h.id
+  );


### PR DESCRIPTION
## Summary
- Sell all LHV QDVE positions (35 shares at 36 EUR)
- Sell Swedbank QDVE positions (78 shares at 36 EUR, commission 3.93 EUR)
- Add EUR cash purchases from sale proceeds (4,064.07 EUR total)
- Add CASH synthetic ETF to track cash holdings in ETF Breakdown view

## Test plan
- [ ] Verify migrations apply successfully on backend restart
- [ ] Confirm QDVE positions reduced correctly
- [ ] Confirm EUR cash balances increased
- [ ] Verify CASH tag appears in ETF Breakdown page