### PR TITLE
Add diversification calculator feature

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -196,6 +196,8 @@ tasks.named<cz.habarta.typescript.generator.gradle.GenerateTask>("generateTypeSc
       "ee.tenman.portfolio.dto.EtfHoldingBreakdownDto",
       "ee.tenman.portfolio.dto.EtfDiagnosticDto",
       "ee.tenman.portfolio.dto.CalculationResult",
+      "ee.tenman.portfolio.dto.DiversificationCalculatorRequestDto",
+      "ee.tenman.portfolio.dto.DiversificationCalculatorResponseDto",
       "ee.tenman.portfolio.domain.Platform",
       "ee.tenman.portfolio.domain.ProviderName",
       "ee.tenman.portfolio.domain.TransactionType",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,13 @@
       "name": "ui",
       "version": "0.0.1",
       "dependencies": {
+        "@guolao/vue-monaco-editor": "^1.6.0",
         "@tanstack/vue-query": "^5.92.5",
         "@vueuse/core": "^14.1.0",
         "axios": "^1.13.2",
         "bootstrap": "^5.3.8",
         "chart.js": "^4.5.1",
+        "monaco-editor": "^0.55.1",
         "vue": "^3.5.26",
         "vue-chartjs": "^5.3.3",
         "vue-router": "^4.6.4",
@@ -791,6 +793,52 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@guolao/vue-monaco-editor": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@guolao/vue-monaco-editor/-/vue-monaco-editor-1.6.0.tgz",
+      "integrity": "sha512-w2IiJ6eJGGeuIgCK6EKZOAfhHTTUB5aZwslzwGbZ5e89Hb4avx6++GkLTW8p84Sng/arFMjLPPxSBI56cFudyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@monaco-editor/loader": "^1.6.1",
+        "vue-demi": "latest"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.7.2",
+        "monaco-editor": ">=0.43.0",
+        "vue": "^2.6.14 || >=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@guolao/vue-monaco-editor/node_modules/vue-demi": {
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -907,6 +955,15 @@
       "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
       "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
       "license": "MIT"
+    },
+    "node_modules/@monaco-editor/loader": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.7.0.tgz",
+      "integrity": "sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==",
+      "license": "MIT",
+      "dependencies": {
+        "state-local": "^1.0.6"
+      }
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.0",
@@ -1784,6 +1841,13 @@
       "dependencies": {
         "undici-types": "~7.16.0"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/web-bluetooth": {
       "version": "0.0.21",
@@ -3146,6 +3210,15 @@
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -4887,6 +4960,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/marked": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
+      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -4975,6 +5060,16 @@
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/monaco-editor": {
+      "version": "0.55.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
+      "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
+      "license": "MIT",
+      "dependencies": {
+        "dompurify": "3.2.7",
+        "marked": "14.0.0"
       }
     },
     "node_modules/mrmime": {
@@ -5881,6 +5976,12 @@
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/state-local": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
       "license": "MIT"
     },
     "node_modules/std-env": {

--- a/package.json
+++ b/package.json
@@ -36,11 +36,13 @@
     "docker:down": "docker compose -f compose.yaml down"
   },
   "dependencies": {
+    "@guolao/vue-monaco-editor": "^1.6.0",
     "@tanstack/vue-query": "^5.92.5",
     "@vueuse/core": "^14.1.0",
     "axios": "^1.13.2",
     "bootstrap": "^5.3.8",
     "chart.js": "^4.5.1",
+    "monaco-editor": "^0.55.1",
     "vue": "^3.5.26",
     "vue-chartjs": "^5.3.3",
     "vue-router": "^4.6.4",

--- a/src/main/kotlin/ee/tenman/portfolio/configuration/RedisConfiguration.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/configuration/RedisConfiguration.kt
@@ -25,6 +25,7 @@ class RedisConfiguration {
     cacheConfigurations[LIGHTYEAR_UUID_CACHE] = RedisCacheConfiguration.defaultCacheConfig().entryTtl(Duration.ofDays(1))
     cacheConfigurations[LOGO_CANDIDATES_CACHE] = RedisCacheConfiguration.defaultCacheConfig().entryTtl(Duration.ofDays(365))
     cacheConfigurations[LOGO_NAME_SEARCH_CACHE] = RedisCacheConfiguration.defaultCacheConfig().entryTtl(Duration.ofDays(1))
+    cacheConfigurations[DIVERSIFICATION_ETFS_CACHE] = RedisCacheConfiguration.defaultCacheConfig().entryTtl(Duration.ofHours(1))
     val defaultConfig = RedisCacheConfiguration.defaultCacheConfig().entryTtl(DEFAULT_TTL)
     return RedisCacheManager
       .builder(connectionFactory)
@@ -44,6 +45,7 @@ class RedisConfiguration {
     const val LIGHTYEAR_UUID_CACHE: String = "lightyear-uuid"
     const val LOGO_CANDIDATES_CACHE: String = "logo-candidates"
     const val LOGO_NAME_SEARCH_CACHE: String = "logo-name-search"
+    const val DIVERSIFICATION_ETFS_CACHE: String = "diversification-etfs"
     private val DEFAULT_TTL: Duration = Duration.ofMinutes(5)
   }
 }

--- a/src/main/kotlin/ee/tenman/portfolio/controller/DiversificationCalculatorController.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/controller/DiversificationCalculatorController.kt
@@ -1,0 +1,26 @@
+package ee.tenman.portfolio.controller
+
+import ee.tenman.portfolio.dto.DiversificationCalculatorRequestDto
+import ee.tenman.portfolio.dto.DiversificationCalculatorResponseDto
+import ee.tenman.portfolio.dto.EtfDetailDto
+import ee.tenman.portfolio.service.diversification.DiversificationCalculatorService
+import jakarta.validation.Valid
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/diversification")
+class DiversificationCalculatorController(
+  private val diversificationCalculatorService: DiversificationCalculatorService,
+) {
+  @PostMapping("/calculate")
+  fun calculate(
+    @Valid @RequestBody request: DiversificationCalculatorRequestDto,
+  ): DiversificationCalculatorResponseDto = diversificationCalculatorService.calculate(request)
+
+  @GetMapping("/available-etfs")
+  fun getAvailableEtfs(): List<EtfDetailDto> = diversificationCalculatorService.getAvailableEtfs()
+}

--- a/src/main/kotlin/ee/tenman/portfolio/dto/AllocationDto.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/dto/AllocationDto.kt
@@ -1,0 +1,12 @@
+package ee.tenman.portfolio.dto
+
+import jakarta.validation.constraints.DecimalMin
+import jakarta.validation.constraints.Positive
+import java.math.BigDecimal
+
+data class AllocationDto(
+  @field:Positive(message = "Instrument ID must be positive")
+  val instrumentId: Long,
+  @field:DecimalMin(value = "0", message = "Percentage must be non-negative")
+  val percentage: BigDecimal,
+)

--- a/src/main/kotlin/ee/tenman/portfolio/dto/ConcentrationDto.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/dto/ConcentrationDto.kt
@@ -1,0 +1,13 @@
+package ee.tenman.portfolio.dto
+
+import java.io.Serializable
+import java.math.BigDecimal
+
+data class ConcentrationDto(
+  val top10Percentage: BigDecimal,
+  val largestPosition: LargestPositionDto?,
+) : Serializable {
+  companion object {
+    private const val serialVersionUID = 1L
+  }
+}

--- a/src/main/kotlin/ee/tenman/portfolio/dto/DiversificationCalculatorRequestDto.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/dto/DiversificationCalculatorRequestDto.kt
@@ -1,0 +1,8 @@
+package ee.tenman.portfolio.dto
+
+import jakarta.validation.Valid
+
+data class DiversificationCalculatorRequestDto(
+  @field:Valid
+  val allocations: List<AllocationDto>,
+)

--- a/src/main/kotlin/ee/tenman/portfolio/dto/DiversificationCalculatorResponseDto.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/dto/DiversificationCalculatorResponseDto.kt
@@ -1,0 +1,19 @@
+package ee.tenman.portfolio.dto
+
+import java.io.Serializable
+import java.math.BigDecimal
+
+data class DiversificationCalculatorResponseDto(
+  val weightedTer: BigDecimal,
+  val weightedAnnualReturn: BigDecimal,
+  val totalUniqueHoldings: Int,
+  val etfDetails: List<EtfDetailDto>,
+  val holdings: List<DiversificationHoldingDto>,
+  val sectors: List<DiversificationSectorDto>,
+  val countries: List<DiversificationCountryDto>,
+  val concentration: ConcentrationDto,
+) : Serializable {
+  companion object {
+    private const val serialVersionUID = 1L
+  }
+}

--- a/src/main/kotlin/ee/tenman/portfolio/dto/DiversificationCountryDto.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/dto/DiversificationCountryDto.kt
@@ -1,0 +1,14 @@
+package ee.tenman.portfolio.dto
+
+import java.io.Serializable
+import java.math.BigDecimal
+
+data class DiversificationCountryDto(
+  val countryCode: String?,
+  val countryName: String,
+  val percentage: BigDecimal,
+) : Serializable {
+  companion object {
+    private const val serialVersionUID = 1L
+  }
+}

--- a/src/main/kotlin/ee/tenman/portfolio/dto/DiversificationHoldingDto.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/dto/DiversificationHoldingDto.kt
@@ -1,0 +1,15 @@
+package ee.tenman.portfolio.dto
+
+import java.io.Serializable
+import java.math.BigDecimal
+
+data class DiversificationHoldingDto(
+  val name: String,
+  val ticker: String?,
+  val percentage: BigDecimal,
+  val inEtfs: String,
+) : Serializable {
+  companion object {
+    private const val serialVersionUID = 1L
+  }
+}

--- a/src/main/kotlin/ee/tenman/portfolio/dto/DiversificationSectorDto.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/dto/DiversificationSectorDto.kt
@@ -1,0 +1,13 @@
+package ee.tenman.portfolio.dto
+
+import java.io.Serializable
+import java.math.BigDecimal
+
+data class DiversificationSectorDto(
+  val sector: String,
+  val percentage: BigDecimal,
+) : Serializable {
+  companion object {
+    private const val serialVersionUID = 1L
+  }
+}

--- a/src/main/kotlin/ee/tenman/portfolio/dto/EtfDetailDto.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/dto/EtfDetailDto.kt
@@ -1,0 +1,18 @@
+package ee.tenman.portfolio.dto
+
+import java.io.Serializable
+import java.math.BigDecimal
+
+data class EtfDetailDto(
+  val instrumentId: Long,
+  val symbol: String,
+  val name: String,
+  val allocation: BigDecimal,
+  val ter: BigDecimal?,
+  val annualReturn: BigDecimal?,
+  val currentPrice: BigDecimal?,
+) : Serializable {
+  companion object {
+    private const val serialVersionUID = 1L
+  }
+}

--- a/src/main/kotlin/ee/tenman/portfolio/dto/LargestPositionDto.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/dto/LargestPositionDto.kt
@@ -1,0 +1,13 @@
+package ee.tenman.portfolio.dto
+
+import java.io.Serializable
+import java.math.BigDecimal
+
+data class LargestPositionDto(
+  val name: String,
+  val percentage: BigDecimal,
+) : Serializable {
+  companion object {
+    private const val serialVersionUID = 1L
+  }
+}

--- a/src/main/kotlin/ee/tenman/portfolio/model/diversification/AggregatedHolding.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/model/diversification/AggregatedHolding.kt
@@ -1,0 +1,13 @@
+package ee.tenman.portfolio.model.diversification
+
+import java.math.BigDecimal
+
+data class AggregatedHolding(
+  val name: String,
+  val ticker: String?,
+  val sector: String?,
+  val countryCode: String?,
+  val countryName: String?,
+  val percentage: BigDecimal,
+  val etfSymbols: Set<String>,
+)

--- a/src/main/kotlin/ee/tenman/portfolio/repository/EtfPositionRepository.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/repository/EtfPositionRepository.kt
@@ -89,4 +89,7 @@ interface EtfPositionRepository : JpaRepository<EtfPosition, Long> {
     @Param("etfInstrumentId") etfInstrumentId: Long,
     @Param("snapshotDate") snapshotDate: LocalDate,
   ): List<EtfPosition>
+
+  @Query("SELECT DISTINCT ep.etfInstrument.id FROM EtfPosition ep")
+  fun findDistinctEtfInstrumentIds(): List<Long>
 }

--- a/src/main/kotlin/ee/tenman/portfolio/service/diversification/DiversificationCalculatorService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/service/diversification/DiversificationCalculatorService.kt
@@ -1,0 +1,221 @@
+package ee.tenman.portfolio.service.diversification
+
+import ee.tenman.portfolio.configuration.RedisConfiguration.Companion.DIVERSIFICATION_ETFS_CACHE
+import ee.tenman.portfolio.dto.AllocationDto
+import ee.tenman.portfolio.dto.ConcentrationDto
+import ee.tenman.portfolio.dto.DiversificationCalculatorRequestDto
+import ee.tenman.portfolio.dto.DiversificationCalculatorResponseDto
+import ee.tenman.portfolio.dto.DiversificationCountryDto
+import ee.tenman.portfolio.dto.DiversificationHoldingDto
+import ee.tenman.portfolio.dto.DiversificationSectorDto
+import ee.tenman.portfolio.dto.EtfDetailDto
+import ee.tenman.portfolio.dto.LargestPositionDto
+import ee.tenman.portfolio.model.diversification.AggregatedHolding
+import ee.tenman.portfolio.repository.EtfPositionRepository
+import ee.tenman.portfolio.repository.InstrumentRepository
+import org.springframework.cache.annotation.Cacheable
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+import java.math.RoundingMode
+
+@Service
+class DiversificationCalculatorService(
+  private val instrumentRepository: InstrumentRepository,
+  private val etfPositionRepository: EtfPositionRepository,
+) {
+  @Transactional(readOnly = true)
+  fun calculate(request: DiversificationCalculatorRequestDto): DiversificationCalculatorResponseDto {
+    validateRequest(request)
+    val allocations = normalizeAllocations(request.allocations)
+    val instrumentIds = allocations.map { it.instrumentId }
+    val instruments = instrumentRepository.findAllById(instrumentIds).associateBy { it.id }
+    val positions = etfPositionRepository.findLatestPositionsByEtfIds(instrumentIds)
+    val positionsByEtfId = positions.groupBy { it.etfInstrument.id }
+    val etfDetails = buildEtfDetails(allocations, instruments)
+    val weightedTer = calculateWeightedTer(etfDetails)
+    val weightedAnnualReturn = calculateWeightedAnnualReturn(etfDetails)
+    val holdingsData = aggregateHoldings(allocations, positionsByEtfId, instruments)
+    val holdings = buildHoldingDtos(holdingsData)
+    val sectors = aggregateSectors(holdingsData)
+    val countries = aggregateCountries(holdingsData)
+    val concentration = buildConcentration(holdings)
+    return DiversificationCalculatorResponseDto(
+      weightedTer = weightedTer,
+      weightedAnnualReturn = weightedAnnualReturn,
+      totalUniqueHoldings = holdings.size,
+      etfDetails = etfDetails,
+      holdings = holdings,
+      sectors = sectors,
+      countries = countries,
+      concentration = concentration,
+    )
+  }
+
+  @Transactional(readOnly = true)
+  @Cacheable(value = [DIVERSIFICATION_ETFS_CACHE], key = "'available-etfs'", unless = "#result.isEmpty()")
+  fun getAvailableEtfs(): List<EtfDetailDto> {
+    val etfIds = etfPositionRepository.findDistinctEtfInstrumentIds()
+    val instruments = instrumentRepository.findAllById(etfIds)
+    return instruments
+      .map { instrument ->
+        EtfDetailDto(
+          instrumentId = instrument.id,
+          symbol = instrument.symbol,
+          name = instrument.name,
+          allocation = BigDecimal.ZERO,
+          ter = instrument.ter,
+          annualReturn = instrument.xirrAnnualReturn,
+          currentPrice = instrument.currentPrice,
+        )
+      }.sortedBy { it.symbol }
+  }
+
+  private fun validateRequest(request: DiversificationCalculatorRequestDto) {
+    val validAllocations = request.allocations.filter { it.instrumentId > 0 }
+    require(validAllocations.isNotEmpty()) { "At least one valid ETF allocation is required" }
+    validAllocations.forEach { allocation ->
+      require(allocation.percentage >= BigDecimal.ZERO) { "Allocation percentage cannot be negative" }
+    }
+    val totalPercentage = validAllocations.sumOf { it.percentage }
+    require(totalPercentage > BigDecimal.ZERO) { "Total allocation percentage must be greater than zero" }
+  }
+
+  private fun normalizeAllocations(allocations: List<AllocationDto>): List<AllocationDto> {
+    val validAllocations = allocations.filter { it.instrumentId > 0 && it.percentage > BigDecimal.ZERO }
+    val total = validAllocations.sumOf { it.percentage }
+    if (total.signum() == 0) return validAllocations
+    return validAllocations.map { a ->
+      AllocationDto(
+        instrumentId = a.instrumentId,
+        percentage = a.percentage.multiply(HUNDRED).divide(total, CALCULATION_SCALE, RoundingMode.HALF_UP),
+      )
+    }
+  }
+
+  private fun buildEtfDetails(
+    allocations: List<AllocationDto>,
+    instruments: Map<Long, ee.tenman.portfolio.domain.Instrument>,
+  ): List<EtfDetailDto> =
+    allocations.mapNotNull { allocation ->
+      val instrument = instruments[allocation.instrumentId] ?: return@mapNotNull null
+      EtfDetailDto(
+        instrumentId = instrument.id,
+        symbol = instrument.symbol,
+        name = instrument.name,
+        allocation = allocation.percentage,
+        ter = instrument.ter,
+        annualReturn = instrument.xirrAnnualReturn,
+        currentPrice = instrument.currentPrice,
+      )
+    }
+
+  private fun calculateWeightedTer(etfDetails: List<EtfDetailDto>): BigDecimal = calculateWeightedValue(etfDetails) { it.ter }
+
+  private fun calculateWeightedAnnualReturn(etfDetails: List<EtfDetailDto>): BigDecimal =
+    calculateWeightedValue(etfDetails) { it.annualReturn }
+
+  private fun calculateWeightedValue(
+    etfDetails: List<EtfDetailDto>,
+    valueSelector: (EtfDetailDto) -> BigDecimal?,
+  ): BigDecimal {
+    val withValue = etfDetails.mapNotNull { etf -> valueSelector(etf)?.let { etf to it } }
+    if (withValue.isEmpty()) return BigDecimal.ZERO
+    val weightedSum =
+      withValue.sumOf { (etf, value) ->
+      etf.allocation.multiply(value).divide(HUNDRED, CALCULATION_SCALE, RoundingMode.HALF_UP)
+    }
+    val totalAllocation = withValue.sumOf { (etf, _) -> etf.allocation }
+    if (totalAllocation.signum() == 0) return BigDecimal.ZERO
+    return weightedSum.multiply(HUNDRED).divide(totalAllocation, RESULT_SCALE, RoundingMode.HALF_UP)
+  }
+
+  private fun aggregateHoldings(
+    allocations: List<AllocationDto>,
+    positionsByEtfId: Map<Long, List<ee.tenman.portfolio.domain.EtfPosition>>,
+    instruments: Map<Long, ee.tenman.portfolio.domain.Instrument>,
+  ): Map<String, AggregatedHolding> =
+    allocations.fold(emptyMap()) { acc, allocation ->
+      val positions = positionsByEtfId[allocation.instrumentId] ?: return@fold acc
+      val instrument = instruments[allocation.instrumentId] ?: return@fold acc
+      positions.fold(acc) { innerAcc, position ->
+        val key = normalizeHoldingName(position.holding.name)
+        val weightedPercentage =
+          position.weightPercentage
+            .multiply(allocation.percentage)
+            .divide(HUNDRED, CALCULATION_SCALE, RoundingMode.HALF_UP)
+        val existing = innerAcc[key]
+        val updated =
+          if (existing != null) {
+            existing.copy(
+              percentage = existing.percentage.add(weightedPercentage),
+              etfSymbols = existing.etfSymbols + instrument.symbol,
+            )
+          } else {
+            AggregatedHolding(
+              name = position.holding.name,
+              ticker = position.holding.ticker,
+              sector = position.holding.sector,
+              countryCode = position.holding.countryCode,
+              countryName = position.holding.countryName,
+              percentage = weightedPercentage,
+              etfSymbols = setOf(instrument.symbol),
+            )
+          }
+        innerAcc + (key to updated)
+      }
+    }
+
+  private fun normalizeHoldingName(name: String): String = name.lowercase().replace(Regex("\\s+"), " ").trim()
+
+  private fun buildHoldingDtos(holdingsData: Map<String, AggregatedHolding>): List<DiversificationHoldingDto> =
+    holdingsData.values
+      .filter { it.percentage.signum() > 0 }
+      .map { holding ->
+        DiversificationHoldingDto(
+          name = holding.name,
+          ticker = holding.ticker,
+          percentage = holding.percentage.setScale(RESULT_SCALE, RoundingMode.HALF_UP),
+          inEtfs = holding.etfSymbols.sorted().joinToString(", "),
+        )
+      }.sortedByDescending { it.percentage }
+
+  private fun aggregateSectors(holdingsData: Map<String, AggregatedHolding>): List<DiversificationSectorDto> =
+    holdingsData.values
+      .groupBy { it.sector ?: UNKNOWN }
+      .map { (sector, holdings) ->
+        DiversificationSectorDto(
+          sector = sector,
+          percentage = holdings.sumOf { it.percentage }.setScale(RESULT_SCALE, RoundingMode.HALF_UP),
+        )
+      }.filter { it.percentage.signum() > 0 }
+      .sortedByDescending { it.percentage }
+
+  private fun aggregateCountries(holdingsData: Map<String, AggregatedHolding>): List<DiversificationCountryDto> =
+    holdingsData.values
+      .groupBy { it.countryName ?: UNKNOWN }
+      .map { (countryName, holdings) ->
+        DiversificationCountryDto(
+          countryCode = holdings.firstNotNullOfOrNull { it.countryCode },
+          countryName = countryName,
+          percentage = holdings.sumOf { it.percentage }.setScale(RESULT_SCALE, RoundingMode.HALF_UP),
+        )
+      }.filter { it.percentage.signum() > 0 }
+      .sortedByDescending { it.percentage }
+
+  private fun buildConcentration(holdings: List<DiversificationHoldingDto>): ConcentrationDto {
+    val top10Percentage = holdings.take(TOP_HOLDINGS_COUNT).sumOf { it.percentage }
+    return ConcentrationDto(
+      top10Percentage = top10Percentage.setScale(RESULT_SCALE, RoundingMode.HALF_UP),
+      largestPosition = holdings.firstOrNull()?.let { LargestPositionDto(it.name, it.percentage) },
+    )
+  }
+
+  companion object {
+    private const val CALCULATION_SCALE = 10
+    private const val RESULT_SCALE = 4
+    private const val TOP_HOLDINGS_COUNT = 10
+    private const val UNKNOWN = "Unknown"
+    private val HUNDRED = BigDecimal(100)
+  }
+}

--- a/src/test/kotlin/ee/tenman/portfolio/controller/DiversificationCalculatorControllerIT.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/controller/DiversificationCalculatorControllerIT.kt
@@ -1,0 +1,379 @@
+package ee.tenman.portfolio.controller
+
+import ch.tutteli.atrium.api.fluent.en_GB.notToBeEmpty
+import ch.tutteli.atrium.api.verbs.expect
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.equalTo
+import com.github.tomakehurst.wiremock.client.WireMock.stubFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
+import ee.tenman.portfolio.configuration.IntegrationTest
+import ee.tenman.portfolio.domain.EtfHolding
+import ee.tenman.portfolio.domain.EtfPosition
+import ee.tenman.portfolio.domain.Instrument
+import ee.tenman.portfolio.domain.ProviderName
+import ee.tenman.portfolio.repository.EtfHoldingRepository
+import ee.tenman.portfolio.repository.EtfPositionRepository
+import ee.tenman.portfolio.repository.InstrumentRepository
+import jakarta.annotation.Resource
+import jakarta.servlet.http.Cookie
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.cache.CacheManager
+import org.springframework.http.HttpHeaders.CONTENT_TYPE
+import org.springframework.http.MediaType.APPLICATION_JSON
+import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.math.BigDecimal
+import java.time.LocalDate
+
+private val DEFAULT_COOKIE = Cookie("AUTHSESSION", "NzEyYmI5ZTMtOTNkNy00MjQyLTgxYmItZWE4ZDA3OWI0N2Uz")
+
+@IntegrationTest
+class DiversificationCalculatorControllerIT {
+  @Resource
+  private lateinit var mockMvc: MockMvc
+
+  @Resource
+  private lateinit var cacheManager: CacheManager
+
+  @Resource
+  private lateinit var instrumentRepository: InstrumentRepository
+
+  @Resource
+  private lateinit var etfHoldingRepository: EtfHoldingRepository
+
+  @Resource
+  private lateinit var etfPositionRepository: EtfPositionRepository
+
+  @BeforeEach
+  fun setup() {
+    stubFor(
+      WireMock
+        .get(urlPathEqualTo("/user-by-session"))
+        .withQueryParam("sessionId", equalTo("NzEyYmI5ZTMtOTNkNy00MjQyLTgxYmItZWE4ZDA3OWI0N2Uz"))
+        .willReturn(
+          aResponse()
+            .withHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
+            .withBodyFile("user-details-response.json"),
+        ),
+    )
+    cacheManager.cacheNames.forEach { cacheName -> cacheManager.getCache(cacheName)?.clear() }
+  }
+
+  @Test
+  fun `should return available etfs sorted by symbol`() {
+    val etf1 = createAndSaveInstrument("VUAA", "Vanguard S&P 500")
+    val etf2 = createAndSaveInstrument("VWCE", "Vanguard FTSE All-World")
+    val etf3 = createAndSaveInstrument("CSPX", "iShares Core S&P 500")
+    createEtfPositions(etf1)
+    createEtfPositions(etf2)
+    createEtfPositions(etf3)
+
+    mockMvc
+      .perform(get("/api/diversification/available-etfs").cookie(DEFAULT_COOKIE))
+      .andExpect(status().isOk)
+      .andExpect(jsonPath("$").isArray)
+      .andExpect(jsonPath("$.length()").value(3))
+      .andExpect(jsonPath("$[0].symbol").value("CSPX"))
+      .andExpect(jsonPath("$[1].symbol").value("VUAA"))
+      .andExpect(jsonPath("$[2].symbol").value("VWCE"))
+
+    val cached =
+      mockMvc
+        .perform(get("/api/diversification/available-etfs").cookie(DEFAULT_COOKIE))
+        .andExpect(status().isOk)
+        .andReturn()
+    expect(cached.response.contentAsString).notToBeEmpty()
+  }
+
+  @Test
+  fun `should return empty list when no etfs have positions`() {
+    createAndSaveInstrument("VUAA", "Vanguard S&P 500")
+
+    mockMvc
+      .perform(get("/api/diversification/available-etfs").cookie(DEFAULT_COOKIE))
+      .andExpect(status().isOk)
+      .andExpect(jsonPath("$").isArray)
+      .andExpect(jsonPath("$.length()").value(0))
+  }
+
+  @Test
+  fun `should calculate diversification for single etf`() {
+    val etf = createAndSaveInstrument("VWCE", "Vanguard FTSE All-World", BigDecimal("0.22"))
+    createEtfPositions(etf)
+
+    mockMvc
+      .perform(
+        post("/api/diversification/calculate")
+          .contentType(APPLICATION_JSON)
+          .cookie(DEFAULT_COOKIE)
+          .content(
+            """
+            {
+              "allocations": [
+                {"instrumentId": ${etf.id}, "percentage": 100}
+              ]
+            }
+            """.trimIndent(),
+          ),
+      ).andExpect(status().isOk)
+      .andExpect(jsonPath("$.weightedTer").value(0.22))
+      .andExpect(jsonPath("$.holdings").isArray)
+      .andExpect(jsonPath("$.sectors").isArray)
+      .andExpect(jsonPath("$.countries").isArray)
+      .andExpect(jsonPath("$.concentration.top10Percentage").exists())
+  }
+
+  @Test
+  fun `should calculate weighted ter for multiple etfs`() {
+    val etf1 = createAndSaveInstrument("VWCE", "Vanguard FTSE All-World", BigDecimal("0.22"))
+    val etf2 = createAndSaveInstrument("VUAA", "Vanguard S&P 500", BigDecimal("0.07"))
+    createEtfPositions(etf1)
+    createEtfPositions(etf2)
+
+    mockMvc
+      .perform(
+        post("/api/diversification/calculate")
+          .contentType(APPLICATION_JSON)
+          .cookie(DEFAULT_COOKIE)
+          .content(
+            """
+            {
+              "allocations": [
+                {"instrumentId": ${etf1.id}, "percentage": 50},
+                {"instrumentId": ${etf2.id}, "percentage": 50}
+              ]
+            }
+            """.trimIndent(),
+          ),
+      ).andExpect(status().isOk)
+      .andExpect(jsonPath("$.weightedTer").value(0.145))
+      .andExpect(jsonPath("$.etfDetails").isArray)
+      .andExpect(jsonPath("$.etfDetails.length()").value(2))
+  }
+
+  @Test
+  fun `should return empty results for empty allocations`() {
+    mockMvc
+      .perform(
+        post("/api/diversification/calculate")
+          .contentType(APPLICATION_JSON)
+          .cookie(DEFAULT_COOKIE)
+          .content("""{"allocations": []}"""),
+      ).andExpect(status().isOk)
+      .andExpect(jsonPath("$.holdings").isEmpty)
+      .andExpect(jsonPath("$.sectors").isEmpty)
+      .andExpect(jsonPath("$.countries").isEmpty)
+      .andExpect(jsonPath("$.totalUniqueHoldings").value(0))
+  }
+
+  @Test
+  fun `should reject negative instrument id`() {
+    mockMvc
+      .perform(
+        post("/api/diversification/calculate")
+          .contentType(APPLICATION_JSON)
+          .cookie(DEFAULT_COOKIE)
+          .content(
+            """
+            {
+              "allocations": [
+                {"instrumentId": -1, "percentage": 100}
+              ]
+            }
+            """.trimIndent(),
+          ),
+      ).andExpect(status().isBadRequest)
+  }
+
+  @Test
+  fun `should reject negative percentage`() {
+    val etf = createAndSaveInstrument("VWCE", "Vanguard FTSE All-World")
+    createEtfPositions(etf)
+
+    mockMvc
+      .perform(
+        post("/api/diversification/calculate")
+          .contentType(APPLICATION_JSON)
+          .cookie(DEFAULT_COOKIE)
+          .content(
+            """
+            {
+              "allocations": [
+                {"instrumentId": ${etf.id}, "percentage": -10}
+              ]
+            }
+            """.trimIndent(),
+          ),
+      ).andExpect(status().isBadRequest)
+  }
+
+  @Test
+  fun `should aggregate holdings from multiple etfs with same holding`() {
+    val etf1 = createAndSaveInstrument("VWCE", "Vanguard FTSE All-World")
+    val etf2 = createAndSaveInstrument("VUAA", "Vanguard S&P 500")
+    val appleHolding = createAndSaveHolding("AAPL", "Apple Inc", "Technology", "US", "United States")
+    createPosition(etf1, appleHolding, BigDecimal("5.0"))
+    createPosition(etf2, appleHolding, BigDecimal("10.0"))
+
+    mockMvc
+      .perform(
+        post("/api/diversification/calculate")
+          .contentType(APPLICATION_JSON)
+          .cookie(DEFAULT_COOKIE)
+          .content(
+            """
+            {
+              "allocations": [
+                {"instrumentId": ${etf1.id}, "percentage": 50},
+                {"instrumentId": ${etf2.id}, "percentage": 50}
+              ]
+            }
+            """.trimIndent(),
+          ),
+      ).andExpect(status().isOk)
+      .andExpect(jsonPath("$.holdings.length()").value(1))
+      .andExpect(jsonPath("$.holdings[0].name").value("Apple Inc"))
+      .andExpect(jsonPath("$.holdings[0].percentage").value(7.5))
+  }
+
+  @Test
+  fun `should aggregate sectors correctly`() {
+    val etf = createAndSaveInstrument("VWCE", "Vanguard FTSE All-World")
+    val holding1 = createAndSaveHolding("AAPL", "Apple Inc", "Technology", "US", "United States")
+    val holding2 = createAndSaveHolding("MSFT", "Microsoft", "Technology", "US", "United States")
+    val holding3 = createAndSaveHolding("JPM", "JPMorgan", "Financials", "US", "United States")
+    createPosition(etf, holding1, BigDecimal("30.0"))
+    createPosition(etf, holding2, BigDecimal("20.0"))
+    createPosition(etf, holding3, BigDecimal("10.0"))
+
+    mockMvc
+      .perform(
+        post("/api/diversification/calculate")
+          .contentType(APPLICATION_JSON)
+          .cookie(DEFAULT_COOKIE)
+          .content(
+            """
+            {
+              "allocations": [
+                {"instrumentId": ${etf.id}, "percentage": 100}
+              ]
+            }
+            """.trimIndent(),
+          ),
+      ).andExpect(status().isOk)
+      .andExpect(jsonPath("$.sectors.length()").value(2))
+      .andExpect(jsonPath("$.sectors[0].sector").value("Technology"))
+      .andExpect(jsonPath("$.sectors[0].percentage").value(50.0))
+  }
+
+  @Test
+  fun `should include etf details in response`() {
+    val etf =
+      createAndSaveInstrument(
+        symbol = "VWCE",
+        name = "Vanguard FTSE All-World",
+        ter = BigDecimal("0.22"),
+        annualReturn = BigDecimal("0.12"),
+        currentPrice = BigDecimal("120.50"),
+      )
+    createEtfPositions(etf)
+
+    mockMvc
+      .perform(
+        post("/api/diversification/calculate")
+          .contentType(APPLICATION_JSON)
+          .cookie(DEFAULT_COOKIE)
+          .content(
+            """
+            {
+              "allocations": [
+                {"instrumentId": ${etf.id}, "percentage": 100}
+              ]
+            }
+            """.trimIndent(),
+          ),
+      ).andExpect(status().isOk)
+      .andExpect(jsonPath("$.etfDetails[0].symbol").value("VWCE"))
+      .andExpect(jsonPath("$.etfDetails[0].name").value("Vanguard FTSE All-World"))
+      .andExpect(jsonPath("$.etfDetails[0].ter").value(0.22))
+      .andExpect(jsonPath("$.etfDetails[0].annualReturn").value(0.12))
+      .andExpect(jsonPath("$.etfDetails[0].currentPrice").value(120.50))
+  }
+
+  private fun createAndSaveInstrument(
+    symbol: String,
+    name: String,
+    ter: BigDecimal? = BigDecimal("0.20"),
+    annualReturn: BigDecimal? = BigDecimal("0.10"),
+    currentPrice: BigDecimal? = BigDecimal("100.00"),
+  ): Instrument {
+    val instrument =
+      Instrument(
+        symbol = symbol,
+        name = name,
+        category = "ETF",
+        baseCurrency = "EUR",
+        providerName = ProviderName.LIGHTYEAR,
+      ).apply {
+        this.ter = ter
+        this.xirrAnnualReturn = annualReturn
+        this.currentPrice = currentPrice
+      }
+    return instrumentRepository.save(instrument)
+  }
+
+  private fun createAndSaveHolding(
+    ticker: String?,
+    name: String,
+    sector: String?,
+    countryCode: String?,
+    countryName: String?,
+  ): EtfHolding {
+    val holding =
+      EtfHolding(
+        ticker = ticker,
+        name = name,
+        sector = sector,
+        countryCode = countryCode,
+        countryName = countryName,
+      )
+    return etfHoldingRepository.save(holding)
+  }
+
+  private fun createPosition(
+    etf: Instrument,
+    holding: EtfHolding,
+    weight: BigDecimal,
+  ): EtfPosition {
+    val position =
+      EtfPosition(
+        etfInstrument = etf,
+        holding = holding,
+        weightPercentage = weight,
+        snapshotDate = SNAPSHOT_DATE,
+      )
+    return etfPositionRepository.save(position)
+  }
+
+  private fun createEtfPositions(etf: Instrument) {
+    val holding =
+      createAndSaveHolding(
+        "${etf.symbol}-HOLD",
+        "${etf.name} Holding",
+        "Technology",
+        "US",
+        "United States",
+      )
+    createPosition(etf, holding, BigDecimal("10.0"))
+  }
+
+  companion object {
+    private val SNAPSHOT_DATE = LocalDate.of(2024, 1, 15)
+  }
+}

--- a/src/test/kotlin/ee/tenman/portfolio/dto/AllocationDtoValidationTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/dto/AllocationDtoValidationTest.kt
@@ -1,0 +1,80 @@
+package ee.tenman.portfolio.dto
+
+import ch.tutteli.atrium.api.fluent.en_GB.toBeEmpty
+import ch.tutteli.atrium.api.fluent.en_GB.toContain
+import ch.tutteli.atrium.api.fluent.en_GB.toHaveSize
+import ch.tutteli.atrium.api.verbs.expect
+import jakarta.validation.Validation
+import jakarta.validation.Validator
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+class AllocationDtoValidationTest {
+  private val validator: Validator = Validation.buildDefaultValidatorFactory().validator
+
+  @Test
+  fun `should pass validation for valid allocation`() {
+    val allocation = AllocationDto(instrumentId = 1L, percentage = BigDecimal("50.0"))
+
+    val violations = validator.validate(allocation)
+
+    expect(violations).toBeEmpty()
+  }
+
+  @Test
+  fun `should pass validation for zero percentage`() {
+    val allocation = AllocationDto(instrumentId = 1L, percentage = BigDecimal.ZERO)
+
+    val violations = validator.validate(allocation)
+
+    expect(violations).toBeEmpty()
+  }
+
+  @Test
+  fun `should pass validation for 100 percent allocation`() {
+    val allocation = AllocationDto(instrumentId = 1L, percentage = BigDecimal("100"))
+
+    val violations = validator.validate(allocation)
+
+    expect(violations).toBeEmpty()
+  }
+
+  @Test
+  fun `should fail validation for zero instrument id`() {
+    val allocation = AllocationDto(instrumentId = 0L, percentage = BigDecimal("50.0"))
+
+    val violations = validator.validate(allocation)
+
+    expect(violations).toHaveSize(1)
+    expect(violations.first().message).toContain("must be positive")
+  }
+
+  @Test
+  fun `should fail validation for negative instrument id`() {
+    val allocation = AllocationDto(instrumentId = -1L, percentage = BigDecimal("50.0"))
+
+    val violations = validator.validate(allocation)
+
+    expect(violations).toHaveSize(1)
+    expect(violations.first().message).toContain("must be positive")
+  }
+
+  @Test
+  fun `should fail validation for negative percentage`() {
+    val allocation = AllocationDto(instrumentId = 1L, percentage = BigDecimal("-10.0"))
+
+    val violations = validator.validate(allocation)
+
+    expect(violations).toHaveSize(1)
+    expect(violations.first().message).toContain("non-negative")
+  }
+
+  @Test
+  fun `should fail validation for both invalid instrument id and percentage`() {
+    val allocation = AllocationDto(instrumentId = -1L, percentage = BigDecimal("-10.0"))
+
+    val violations = validator.validate(allocation)
+
+    expect(violations).toHaveSize(2)
+  }
+}

--- a/src/test/kotlin/ee/tenman/portfolio/dto/DiversificationCalculatorRequestDtoValidationTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/dto/DiversificationCalculatorRequestDtoValidationTest.kt
@@ -1,0 +1,107 @@
+package ee.tenman.portfolio.dto
+
+import ch.tutteli.atrium.api.fluent.en_GB.toBeEmpty
+import ch.tutteli.atrium.api.fluent.en_GB.toHaveSize
+import ch.tutteli.atrium.api.verbs.expect
+import jakarta.validation.Validation
+import jakarta.validation.Validator
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+class DiversificationCalculatorRequestDtoValidationTest {
+  private val validator: Validator = Validation.buildDefaultValidatorFactory().validator
+
+  @Test
+  fun `should pass validation for valid request with single allocation`() {
+    val request =
+      DiversificationCalculatorRequestDto(
+        allocations = listOf(AllocationDto(instrumentId = 1L, percentage = BigDecimal("100"))),
+      )
+
+    val violations = validator.validate(request)
+
+    expect(violations).toBeEmpty()
+  }
+
+  @Test
+  fun `should pass validation for valid request with multiple allocations`() {
+    val request =
+      DiversificationCalculatorRequestDto(
+        allocations =
+          listOf(
+            AllocationDto(instrumentId = 1L, percentage = BigDecimal("50")),
+            AllocationDto(instrumentId = 2L, percentage = BigDecimal("30")),
+            AllocationDto(instrumentId = 3L, percentage = BigDecimal("20")),
+          ),
+      )
+
+    val violations = validator.validate(request)
+
+    expect(violations).toBeEmpty()
+  }
+
+  @Test
+  fun `should pass validation for empty allocations list`() {
+    val request = DiversificationCalculatorRequestDto(allocations = emptyList())
+
+    val violations = validator.validate(request)
+
+    expect(violations).toBeEmpty()
+  }
+
+  @Test
+  fun `should fail validation when allocation has invalid instrument id`() {
+    val request =
+      DiversificationCalculatorRequestDto(
+        allocations = listOf(AllocationDto(instrumentId = -1L, percentage = BigDecimal("100"))),
+      )
+
+    val violations = validator.validate(request)
+
+    expect(violations).toHaveSize(1)
+  }
+
+  @Test
+  fun `should fail validation when allocation has negative percentage`() {
+    val request =
+      DiversificationCalculatorRequestDto(
+        allocations = listOf(AllocationDto(instrumentId = 1L, percentage = BigDecimal("-10"))),
+      )
+
+    val violations = validator.validate(request)
+
+    expect(violations).toHaveSize(1)
+  }
+
+  @Test
+  fun `should fail validation for multiple invalid allocations`() {
+    val request =
+      DiversificationCalculatorRequestDto(
+        allocations =
+          listOf(
+            AllocationDto(instrumentId = -1L, percentage = BigDecimal("50")),
+            AllocationDto(instrumentId = 2L, percentage = BigDecimal("-10")),
+          ),
+      )
+
+    val violations = validator.validate(request)
+
+    expect(violations).toHaveSize(2)
+  }
+
+  @Test
+  fun `should validate nested allocations with cascading validation`() {
+    val request =
+      DiversificationCalculatorRequestDto(
+        allocations =
+          listOf(
+            AllocationDto(instrumentId = 1L, percentage = BigDecimal("50")),
+            AllocationDto(instrumentId = 0L, percentage = BigDecimal("-5")),
+          ),
+      )
+
+    val violations = validator.validate(request)
+
+    expect(violations).toHaveSize(2)
+  }
+}

--- a/src/test/kotlin/ee/tenman/portfolio/service/diversification/DiversificationCalculatorServiceTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/service/diversification/DiversificationCalculatorServiceTest.kt
@@ -1,0 +1,377 @@
+package ee.tenman.portfolio.service.diversification
+
+import ch.tutteli.atrium.api.fluent.en_GB.messageToContain
+import ch.tutteli.atrium.api.fluent.en_GB.notToEqualNull
+import ch.tutteli.atrium.api.fluent.en_GB.toContain
+import ch.tutteli.atrium.api.fluent.en_GB.toEqual
+import ch.tutteli.atrium.api.fluent.en_GB.toEqualNumerically
+import ch.tutteli.atrium.api.fluent.en_GB.toHaveSize
+import ch.tutteli.atrium.api.fluent.en_GB.toThrow
+import ch.tutteli.atrium.api.verbs.expect
+import ee.tenman.portfolio.domain.EtfHolding
+import ee.tenman.portfolio.domain.EtfPosition
+import ee.tenman.portfolio.domain.Instrument
+import ee.tenman.portfolio.domain.ProviderName
+import ee.tenman.portfolio.dto.AllocationDto
+import ee.tenman.portfolio.dto.DiversificationCalculatorRequestDto
+import ee.tenman.portfolio.repository.EtfPositionRepository
+import ee.tenman.portfolio.repository.InstrumentRepository
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+
+class DiversificationCalculatorServiceTest {
+  private val instrumentRepository = mockk<InstrumentRepository>()
+  private val etfPositionRepository = mockk<EtfPositionRepository>()
+  private lateinit var service: DiversificationCalculatorService
+
+  @BeforeEach
+  fun setup() {
+    service = DiversificationCalculatorService(instrumentRepository, etfPositionRepository)
+  }
+
+  @Test
+  fun `should calculate weighted ter for single etf`() {
+    val etf = createInstrument(1L, "VWCE", ter = BigDecimal("0.22"))
+    val holding = createHolding(1L, "AAPL", "Apple Inc", "Technology", "US", "United States")
+    val position = createPosition(etf, holding, BigDecimal("10.0000"))
+    setupMocks(listOf(etf), listOf(position))
+    val request = createRequest(AllocationDto(1L, BigDecimal("100")))
+
+    val result = service.calculate(request)
+
+    expect(result.weightedTer).toEqualNumerically(BigDecimal("0.2200"))
+  }
+
+  @Test
+  fun `should calculate weighted ter for multiple etfs`() {
+    val etf1 = createInstrument(1L, "VWCE", ter = BigDecimal("0.22"))
+    val etf2 = createInstrument(2L, "VUAA", ter = BigDecimal("0.07"))
+    val holding1 = createHolding(1L, "AAPL", "Apple", "Technology", "US", "United States")
+    val holding2 = createHolding(2L, "MSFT", "Microsoft", "Technology", "US", "United States")
+    val position1 = createPosition(etf1, holding1, BigDecimal("100.0000"))
+    val position2 = createPosition(etf2, holding2, BigDecimal("100.0000"))
+    setupMocks(listOf(etf1, etf2), listOf(position1, position2))
+    val request =
+      createRequest(
+      AllocationDto(1L, BigDecimal("50")),
+      AllocationDto(2L, BigDecimal("50")),
+    )
+
+    val result = service.calculate(request)
+
+    expect(result.weightedTer).toEqualNumerically(BigDecimal("0.1450"))
+  }
+
+  @Test
+  fun `should calculate weighted annual return`() {
+    val etf1 = createInstrument(1L, "VWCE", annualReturn = BigDecimal("0.12"))
+    val etf2 = createInstrument(2L, "VUAA", annualReturn = BigDecimal("0.15"))
+    val holding1 = createHolding(1L, "AAPL", "Apple", "Technology", "US", "United States")
+    val holding2 = createHolding(2L, "MSFT", "Microsoft", "Technology", "US", "United States")
+    val position1 = createPosition(etf1, holding1, BigDecimal("100.0000"))
+    val position2 = createPosition(etf2, holding2, BigDecimal("100.0000"))
+    setupMocks(listOf(etf1, etf2), listOf(position1, position2))
+    val request =
+      createRequest(
+      AllocationDto(1L, BigDecimal("60")),
+      AllocationDto(2L, BigDecimal("40")),
+    )
+
+    val result = service.calculate(request)
+
+    expect(result.weightedAnnualReturn).toEqualNumerically(BigDecimal("0.1320"))
+  }
+
+  @Test
+  fun `should aggregate holdings from multiple etfs`() {
+    val etf1 = createInstrument(1L, "VWCE")
+    val etf2 = createInstrument(2L, "VUAA")
+    val appleHolding1 = createHolding(1L, "AAPL", "Apple Inc", "Technology", "US", "United States")
+    val appleHolding2 = createHolding(2L, "AAPL", "Apple Inc", "Technology", "US", "United States")
+    val position1 = createPosition(etf1, appleHolding1, BigDecimal("5.0000"))
+    val position2 = createPosition(etf2, appleHolding2, BigDecimal("10.0000"))
+    setupMocks(listOf(etf1, etf2), listOf(position1, position2))
+    val request =
+      createRequest(
+      AllocationDto(1L, BigDecimal("50")),
+      AllocationDto(2L, BigDecimal("50")),
+    )
+
+    val result = service.calculate(request)
+
+    expect(result.holdings).toHaveSize(1)
+    expect(result.holdings[0].name).toEqual("Apple Inc")
+    expect(result.holdings[0].percentage).toEqualNumerically(BigDecimal("7.5000"))
+    expect(result.holdings[0].inEtfs).toContain("VWCE")
+    expect(result.holdings[0].inEtfs).toContain("VUAA")
+  }
+
+  @Test
+  fun `should aggregate sectors correctly`() {
+    val etf = createInstrument(1L, "VWCE")
+    val holding1 = createHolding(1L, "AAPL", "Apple", "Technology", "US", "United States")
+    val holding2 = createHolding(2L, "MSFT", "Microsoft", "Technology", "US", "United States")
+    val holding3 = createHolding(3L, "JPM", "JPMorgan", "Financials", "US", "United States")
+    val position1 = createPosition(etf, holding1, BigDecimal("30.0000"))
+    val position2 = createPosition(etf, holding2, BigDecimal("20.0000"))
+    val position3 = createPosition(etf, holding3, BigDecimal("10.0000"))
+    setupMocks(listOf(etf), listOf(position1, position2, position3))
+    val request = createRequest(AllocationDto(1L, BigDecimal("100")))
+
+    val result = service.calculate(request)
+
+    expect(result.sectors).toHaveSize(2)
+    val techSector = result.sectors.find { it.sector == "Technology" }
+    expect(techSector).notToEqualNull()
+    expect(techSector!!.percentage).toEqualNumerically(BigDecimal("50.0000"))
+  }
+
+  @Test
+  fun `should aggregate countries correctly`() {
+    val etf = createInstrument(1L, "VWCE")
+    val holding1 = createHolding(1L, "AAPL", "Apple", "Technology", "US", "United States")
+    val holding2 = createHolding(2L, "ASML", "ASML", "Technology", "NL", "Netherlands")
+    val position1 = createPosition(etf, holding1, BigDecimal("60.0000"))
+    val position2 = createPosition(etf, holding2, BigDecimal("40.0000"))
+    setupMocks(listOf(etf), listOf(position1, position2))
+    val request = createRequest(AllocationDto(1L, BigDecimal("100")))
+
+    val result = service.calculate(request)
+
+    expect(result.countries).toHaveSize(2)
+    val usCountry = result.countries.find { it.countryName == "United States" }
+    expect(usCountry).notToEqualNull()
+    expect(usCountry!!.percentage).toEqualNumerically(BigDecimal("60.0000"))
+  }
+
+  @Test
+  fun `should calculate top 10 concentration`() {
+    val etf = createInstrument(1L, "VWCE")
+    val holdings =
+      (1..15).map { i ->
+      createHolding(i.toLong(), "TICK$i", "Company $i", "Technology", "US", "United States")
+    }
+    val positions =
+      holdings.mapIndexed { index, holding ->
+      createPosition(etf, holding, BigDecimal(20 - index))
+    }
+    setupMocks(listOf(etf), positions)
+    val request = createRequest(AllocationDto(1L, BigDecimal("100")))
+
+    val result = service.calculate(request)
+
+    expect(result.concentration.top10Percentage).toEqualNumerically(BigDecimal("155.0000"))
+    expect(result.concentration.largestPosition).notToEqualNull()
+    expect(result.concentration.largestPosition!!.name).toEqual("Company 1")
+  }
+
+  @Test
+  fun `should normalize allocations to 100 percent`() {
+    val etf1 = createInstrument(1L, "VWCE", ter = BigDecimal("0.22"))
+    val etf2 = createInstrument(2L, "VUAA", ter = BigDecimal("0.07"))
+    val holding1 = createHolding(1L, "AAPL", "Apple", "Technology", "US", "United States")
+    val holding2 = createHolding(2L, "MSFT", "Microsoft", "Technology", "US", "United States")
+    val position1 = createPosition(etf1, holding1, BigDecimal("100.0000"))
+    val position2 = createPosition(etf2, holding2, BigDecimal("100.0000"))
+    setupMocks(listOf(etf1, etf2), listOf(position1, position2))
+    val request =
+      createRequest(
+      AllocationDto(1L, BigDecimal("30")),
+      AllocationDto(2L, BigDecimal("70")),
+    )
+
+    val result = service.calculate(request)
+
+    expect(result.weightedTer).toEqualNumerically(BigDecimal("0.1150"))
+  }
+
+  @Test
+  fun `should return zero weighted ter when no etfs have ter`() {
+    val etf = createInstrument(1L, "VWCE", ter = null)
+    val holding = createHolding(1L, "AAPL", "Apple", "Technology", "US", "United States")
+    val position = createPosition(etf, holding, BigDecimal("100.0000"))
+    setupMocks(listOf(etf), listOf(position))
+    val request = createRequest(AllocationDto(1L, BigDecimal("100")))
+
+    val result = service.calculate(request)
+
+    expect(result.weightedTer).toEqualNumerically(BigDecimal.ZERO)
+  }
+
+  @Test
+  fun `should return zero weighted annual return when no etfs have return`() {
+    val etf = createInstrument(1L, "VWCE", annualReturn = null)
+    val holding = createHolding(1L, "AAPL", "Apple", "Technology", "US", "United States")
+    val position = createPosition(etf, holding, BigDecimal("100.0000"))
+    setupMocks(listOf(etf), listOf(position))
+    val request = createRequest(AllocationDto(1L, BigDecimal("100")))
+
+    val result = service.calculate(request)
+
+    expect(result.weightedAnnualReturn).toEqualNumerically(BigDecimal.ZERO)
+  }
+
+  @Test
+  fun `should throw exception for empty allocations`() {
+    val request = DiversificationCalculatorRequestDto(emptyList())
+
+    expect { service.calculate(request) }
+      .toThrow<IllegalArgumentException>()
+      .messageToContain("At least one valid ETF allocation is required")
+  }
+
+  @Test
+  fun `should return available etfs sorted by symbol`() {
+    val etf1 = createInstrument(1L, "VUAA", ter = BigDecimal("0.07"))
+    val etf2 = createInstrument(2L, "VWCE", ter = BigDecimal("0.22"))
+    val etf3 = createInstrument(3L, "CSPX", ter = BigDecimal("0.07"))
+    every { etfPositionRepository.findDistinctEtfInstrumentIds() } returns listOf(1L, 2L, 3L)
+    every { instrumentRepository.findAllById(listOf(1L, 2L, 3L)) } returns listOf(etf1, etf2, etf3)
+
+    val result = service.getAvailableEtfs()
+
+    expect(result).toHaveSize(3)
+    expect(result[0].symbol).toEqual("CSPX")
+    expect(result[1].symbol).toEqual("VUAA")
+    expect(result[2].symbol).toEqual("VWCE")
+  }
+
+  @Test
+  fun `should handle holdings with unknown sector`() {
+    val etf = createInstrument(1L, "VWCE")
+    val holding = createHolding(1L, "XYZ", "Unknown Corp", null, "US", "United States")
+    val position = createPosition(etf, holding, BigDecimal("100.0000"))
+    setupMocks(listOf(etf), listOf(position))
+    val request = createRequest(AllocationDto(1L, BigDecimal("100")))
+
+    val result = service.calculate(request)
+
+    expect(result.sectors).toHaveSize(1)
+    expect(result.sectors[0].sector).toEqual("Unknown")
+  }
+
+  @Test
+  fun `should handle holdings with unknown country`() {
+    val etf = createInstrument(1L, "VWCE")
+    val holding = createHolding(1L, "XYZ", "Unknown Corp", "Technology", null, null)
+    val position = createPosition(etf, holding, BigDecimal("100.0000"))
+    setupMocks(listOf(etf), listOf(position))
+    val request = createRequest(AllocationDto(1L, BigDecimal("100")))
+
+    val result = service.calculate(request)
+
+    expect(result.countries).toHaveSize(1)
+    expect(result.countries[0].countryName).toEqual("Unknown")
+  }
+
+  @Test
+  fun `should normalize holding names for deduplication`() {
+    val etf1 = createInstrument(1L, "VWCE")
+    val etf2 = createInstrument(2L, "VUAA")
+    val holding1 = createHolding(1L, "AAPL", "Apple Inc", "Technology", "US", "United States")
+    val holding2 = createHolding(2L, "AAPL", "apple inc", "Technology", "US", "United States")
+    val position1 = createPosition(etf1, holding1, BigDecimal("50.0000"))
+    val position2 = createPosition(etf2, holding2, BigDecimal("50.0000"))
+    setupMocks(listOf(etf1, etf2), listOf(position1, position2))
+    val request =
+      createRequest(
+      AllocationDto(1L, BigDecimal("50")),
+      AllocationDto(2L, BigDecimal("50")),
+    )
+
+    val result = service.calculate(request)
+
+    expect(result.holdings).toHaveSize(1)
+  }
+
+  @Test
+  fun `should throw exception for zero total allocation`() {
+    val request = createRequest(AllocationDto(1L, BigDecimal.ZERO))
+
+    expect { service.calculate(request) }
+      .toThrow<IllegalArgumentException>()
+      .messageToContain("Total allocation percentage must be greater than zero")
+  }
+
+  @Test
+  fun `should include current price in etf details`() {
+    val etf = createInstrument(1L, "VWCE", currentPrice = BigDecimal("120.50"))
+    val holding = createHolding(1L, "AAPL", "Apple", "Technology", "US", "United States")
+    val position = createPosition(etf, holding, BigDecimal("100.0000"))
+    setupMocks(listOf(etf), listOf(position))
+    val request = createRequest(AllocationDto(1L, BigDecimal("100")))
+
+    val result = service.calculate(request)
+
+    expect(result.etfDetails).toHaveSize(1)
+    expect(result.etfDetails[0].currentPrice).notToEqualNull()
+    expect(result.etfDetails[0].currentPrice!!).toEqualNumerically(BigDecimal("120.50"))
+  }
+
+  private fun setupMocks(
+    instruments: List<Instrument>,
+    positions: List<EtfPosition>,
+  ) {
+    val ids = instruments.map { it.id }
+    every { instrumentRepository.findAllById(ids) } returns instruments
+    every { etfPositionRepository.findLatestPositionsByEtfIds(ids) } returns positions
+  }
+
+  private fun createRequest(vararg allocations: AllocationDto) = DiversificationCalculatorRequestDto(allocations.toList())
+
+  private fun createInstrument(
+    id: Long,
+    symbol: String,
+    ter: BigDecimal? = BigDecimal("0.20"),
+    annualReturn: BigDecimal? = BigDecimal("0.10"),
+    currentPrice: BigDecimal? = BigDecimal("100.00"),
+  ): Instrument =
+    Instrument(
+      symbol = symbol,
+      name = "Test $symbol",
+      category = "ETF",
+      baseCurrency = "EUR",
+      currentPrice = currentPrice,
+      providerName = ProviderName.LIGHTYEAR,
+    ).apply {
+      this.id = id
+      this.ter = ter
+      this.xirrAnnualReturn = annualReturn
+    }
+
+  private fun createHolding(
+    id: Long,
+    ticker: String?,
+    name: String,
+    sector: String?,
+    countryCode: String?,
+    countryName: String?,
+  ): EtfHolding =
+    EtfHolding(
+      ticker = ticker,
+      name = name,
+      sector = sector,
+      countryCode = countryCode,
+      countryName = countryName,
+    ).apply { this.id = id }
+
+  private fun createPosition(
+    etf: Instrument,
+    holding: EtfHolding,
+    weight: BigDecimal,
+  ): EtfPosition =
+    EtfPosition(
+      etfInstrument = etf,
+      holding = holding,
+      weightPercentage = weight,
+      snapshotDate = SNAPSHOT_DATE,
+    )
+
+  companion object {
+    private val SNAPSHOT_DATE = LocalDate.of(2024, 1, 15)
+  }
+}

--- a/ui/components/calculator.vue
+++ b/ui/components/calculator.vue
@@ -99,7 +99,7 @@ const handleReset = async () => {
     message: 'Are you sure you want to reset the calculator to default values?',
     confirmText: 'Reset',
     cancelText: 'Cancel',
-    confirmClass: 'btn-warning',
+    confirmClass: 'btn-primary',
   })
 
   if (confirmed) {

--- a/ui/components/diversification/allocation-table.test.ts
+++ b/ui/components/diversification/allocation-table.test.ts
@@ -1,0 +1,340 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import AllocationTable from './allocation-table.vue'
+
+describe('AllocationTable', () => {
+  const defaultEtfs = [
+    {
+      instrumentId: 1,
+      symbol: 'VWCE',
+      name: 'Vanguard FTSE All-World',
+      allocation: 0,
+      ter: 0.22,
+      annualReturn: 0.12,
+      currentPrice: 120.5,
+    },
+    {
+      instrumentId: 2,
+      symbol: 'VUAA',
+      name: 'Vanguard S&P 500',
+      allocation: 0,
+      ter: 0.07,
+      annualReturn: 0.15,
+      currentPrice: 95.3,
+    },
+  ]
+
+  const defaultAllocations = [{ instrumentId: 0, value: 0 }]
+
+  const defaultProps = {
+    allocations: defaultAllocations,
+    inputMode: 'percentage' as const,
+    availableEtfs: defaultEtfs,
+    isLoadingPortfolio: false,
+  }
+
+  describe('rendering', () => {
+    it('should render allocation table', () => {
+      const wrapper = mount(AllocationTable, { props: defaultProps })
+      expect(wrapper.find('.allocation-table').exists()).toBe(true)
+    })
+
+    it('should render header with correct columns', () => {
+      const wrapper = mount(AllocationTable, { props: defaultProps })
+      const headers = wrapper.findAll('th')
+      expect(headers[0].text()).toBe('ETF')
+      expect(headers[1].text()).toBe('Name')
+      expect(headers[2].text()).toBe('Price')
+      expect(headers[3].text()).toBe('TER')
+      expect(headers[4].text()).toBe('Annual Return')
+    })
+
+    it('should show Allocation % header in percentage mode', () => {
+      const wrapper = mount(AllocationTable, { props: defaultProps })
+      const headers = wrapper.findAll('th')
+      expect(headers[5].text()).toBe('Allocation %')
+    })
+
+    it('should show Amount EUR header in amount mode', () => {
+      const wrapper = mount(AllocationTable, {
+        props: { ...defaultProps, inputMode: 'amount' },
+      })
+      const headers = wrapper.findAll('th')
+      expect(headers[5].text()).toBe('Amount EUR')
+    })
+  })
+
+  describe('mode buttons', () => {
+    it('should highlight percentage button when in percentage mode', () => {
+      const wrapper = mount(AllocationTable, { props: defaultProps })
+      const buttons = wrapper.findAll('.mode-btn')
+      expect(buttons[0].classes()).toContain('active')
+      expect(buttons[1].classes()).not.toContain('active')
+    })
+
+    it('should highlight amount button when in amount mode', () => {
+      const wrapper = mount(AllocationTable, {
+        props: { ...defaultProps, inputMode: 'amount' },
+      })
+      const buttons = wrapper.findAll('.mode-btn')
+      expect(buttons[0].classes()).not.toContain('active')
+      expect(buttons[1].classes()).toContain('active')
+    })
+
+    it('should emit update:inputMode when clicking percentage button', async () => {
+      const wrapper = mount(AllocationTable, {
+        props: { ...defaultProps, inputMode: 'amount' },
+      })
+      await wrapper.findAll('.mode-btn')[0].trigger('click')
+      expect(wrapper.emitted('update:inputMode')).toEqual([['percentage']])
+    })
+
+    it('should emit update:inputMode when clicking amount button', async () => {
+      const wrapper = mount(AllocationTable, { props: defaultProps })
+      await wrapper.findAll('.mode-btn')[1].trigger('click')
+      expect(wrapper.emitted('update:inputMode')).toEqual([['amount']])
+    })
+  })
+
+  describe('allocation rows', () => {
+    it('should render one row per allocation', () => {
+      const wrapper = mount(AllocationTable, {
+        props: {
+          ...defaultProps,
+          allocations: [
+            { instrumentId: 1, value: 60 },
+            { instrumentId: 2, value: 40 },
+          ],
+        },
+      })
+      const rows = wrapper.findAll('tbody tr')
+      expect(rows).toHaveLength(2)
+    })
+
+    it('should show ETF name when selected', () => {
+      const wrapper = mount(AllocationTable, {
+        props: {
+          ...defaultProps,
+          allocations: [{ instrumentId: 1, value: 100 }],
+        },
+      })
+      expect(wrapper.text()).toContain('Vanguard FTSE All-World')
+    })
+
+    it('should format price correctly', () => {
+      const wrapper = mount(AllocationTable, {
+        props: {
+          ...defaultProps,
+          allocations: [{ instrumentId: 1, value: 100 }],
+        },
+      })
+      expect(wrapper.text()).toContain('€120.50')
+    })
+
+    it('should format TER correctly', () => {
+      const wrapper = mount(AllocationTable, {
+        props: {
+          ...defaultProps,
+          allocations: [{ instrumentId: 1, value: 100 }],
+        },
+      })
+      expect(wrapper.text()).toContain('0.22%')
+    })
+
+    it('should format annual return correctly', () => {
+      const wrapper = mount(AllocationTable, {
+        props: {
+          ...defaultProps,
+          allocations: [{ instrumentId: 1, value: 100 }],
+        },
+      })
+      expect(wrapper.text()).toContain('12.00%')
+    })
+  })
+
+  describe('action buttons', () => {
+    it('should render Add ETF button', () => {
+      const wrapper = mount(AllocationTable, { props: defaultProps })
+      expect(wrapper.text()).toContain('+ Add ETF')
+    })
+
+    it('should emit add event when Add ETF is clicked', async () => {
+      const wrapper = mount(AllocationTable, { props: defaultProps })
+      const addBtn = wrapper.findAll('.action-btn').find(b => b.text().includes('Add ETF'))
+      await addBtn?.trigger('click')
+      expect(wrapper.emitted('add')).toHaveLength(1)
+    })
+
+    it('should emit loadPortfolio event when Load from Portfolio is clicked', async () => {
+      const wrapper = mount(AllocationTable, { props: defaultProps })
+      const loadBtn = wrapper
+        .findAll('.action-btn')
+        .find(b => b.text().includes('Load from Portfolio'))
+      await loadBtn?.trigger('click')
+      expect(wrapper.emitted('loadPortfolio')).toHaveLength(1)
+    })
+
+    it('should disable Load from Portfolio button when loading', () => {
+      const wrapper = mount(AllocationTable, {
+        props: { ...defaultProps, isLoadingPortfolio: true },
+      })
+      const loadBtn = wrapper
+        .findAll('.action-btn')
+        .find(b => b.text().includes('Load from Portfolio'))
+      expect(loadBtn?.attributes('disabled')).toBeDefined()
+    })
+
+    it('should show spinner when loading portfolio', () => {
+      const wrapper = mount(AllocationTable, {
+        props: { ...defaultProps, isLoadingPortfolio: true },
+      })
+      expect(wrapper.find('.spinner-border').exists()).toBe(true)
+    })
+
+    it('should emit clear event when Clear is clicked', async () => {
+      const wrapper = mount(AllocationTable, {
+        props: {
+          ...defaultProps,
+          allocations: [{ instrumentId: 1, value: 50 }],
+        },
+      })
+      const clearBtn = wrapper.findAll('.action-btn').find(b => b.text().includes('Clear'))
+      await clearBtn?.trigger('click')
+      expect(wrapper.emitted('clear')).toHaveLength(1)
+    })
+
+    it('should disable Clear button when only empty allocation exists', () => {
+      const wrapper = mount(AllocationTable, { props: defaultProps })
+      const clearBtn = wrapper.findAll('.action-btn').find(b => b.text().includes('Clear'))
+      expect(clearBtn?.attributes('disabled')).toBeDefined()
+    })
+  })
+
+  describe('remove button', () => {
+    it('should disable remove button when only one allocation', () => {
+      const wrapper = mount(AllocationTable, { props: defaultProps })
+      const removeBtn = wrapper.find('.remove-btn')
+      expect(removeBtn.attributes('disabled')).toBeDefined()
+    })
+
+    it('should enable remove button when multiple allocations', () => {
+      const wrapper = mount(AllocationTable, {
+        props: {
+          ...defaultProps,
+          allocations: [
+            { instrumentId: 1, value: 50 },
+            { instrumentId: 2, value: 50 },
+          ],
+        },
+      })
+      const removeBtn = wrapper.find('.remove-btn')
+      expect(removeBtn.attributes('disabled')).toBeUndefined()
+    })
+
+    it('should emit remove event with index when clicked', async () => {
+      const wrapper = mount(AllocationTable, {
+        props: {
+          ...defaultProps,
+          allocations: [
+            { instrumentId: 1, value: 50 },
+            { instrumentId: 2, value: 50 },
+          ],
+        },
+      })
+      const removeBtns = wrapper.findAll('.remove-btn')
+      await removeBtns[1].trigger('click')
+      expect(wrapper.emitted('remove')).toEqual([[1]])
+    })
+  })
+
+  describe('total allocation', () => {
+    it('should show total as valid when sum is 100%', () => {
+      const wrapper = mount(AllocationTable, {
+        props: {
+          ...defaultProps,
+          allocations: [
+            { instrumentId: 1, value: 60 },
+            { instrumentId: 2, value: 40 },
+          ],
+        },
+      })
+      expect(wrapper.find('.total-value.valid').exists()).toBe(true)
+    })
+
+    it('should show total as invalid when sum is not 100%', () => {
+      const wrapper = mount(AllocationTable, {
+        props: {
+          ...defaultProps,
+          allocations: [{ instrumentId: 1, value: 50 }],
+        },
+      })
+      expect(wrapper.find('.total-value.invalid').exists()).toBe(true)
+    })
+
+    it('should show hint when total is invalid in percentage mode', () => {
+      const wrapper = mount(AllocationTable, {
+        props: {
+          ...defaultProps,
+          allocations: [{ instrumentId: 1, value: 50 }],
+        },
+      })
+      expect(wrapper.text()).toContain('(should be 100%)')
+    })
+
+    it('should show total as valid in amount mode when sum is greater than 0', () => {
+      const wrapper = mount(AllocationTable, {
+        props: {
+          ...defaultProps,
+          inputMode: 'amount',
+          allocations: [{ instrumentId: 1, value: 1000 }],
+        },
+      })
+      expect(wrapper.find('.total-value.valid').exists()).toBe(true)
+    })
+  })
+
+  describe('ETF selection filtering', () => {
+    it('should filter out already selected ETFs from dropdown', () => {
+      const wrapper = mount(AllocationTable, {
+        props: {
+          ...defaultProps,
+          allocations: [
+            { instrumentId: 1, value: 60 },
+            { instrumentId: 0, value: 0 },
+          ],
+        },
+      })
+      const selects = wrapper.findAll('select')
+      const secondSelectOptions = selects[1].findAll('option')
+      const optionValues = secondSelectOptions.map(o => o.attributes('value'))
+      expect(optionValues).not.toContain('1')
+      expect(optionValues).toContain('2')
+    })
+  })
+
+  describe('export and import buttons', () => {
+    it('should render Export button', () => {
+      const wrapper = mount(AllocationTable, { props: defaultProps })
+      expect(wrapper.text()).toContain('Export')
+    })
+
+    it('should render Import button', () => {
+      const wrapper = mount(AllocationTable, { props: defaultProps })
+      expect(wrapper.text()).toContain('Import')
+    })
+
+    it('should emit export event when Export is clicked', async () => {
+      const wrapper = mount(AllocationTable, { props: defaultProps })
+      const exportBtn = wrapper.findAll('.action-btn').find(b => b.text() === 'Export')
+      await exportBtn?.trigger('click')
+      expect(wrapper.emitted('export')).toHaveLength(1)
+    })
+
+    it('should emit import event when Import is clicked', async () => {
+      const wrapper = mount(AllocationTable, { props: defaultProps })
+      const importBtn = wrapper.findAll('.action-btn').find(b => b.text() === 'Import')
+      await importBtn?.trigger('click')
+      expect(wrapper.emitted('import')).toHaveLength(1)
+    })
+  })
+})

--- a/ui/components/diversification/allocation-table.vue
+++ b/ui/components/diversification/allocation-table.vue
@@ -1,0 +1,401 @@
+<template>
+  <div class="allocation-section">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+      <h5 class="mb-0">ETF Allocation</h5>
+      <div class="mode-buttons">
+        <button
+          type="button"
+          class="mode-btn"
+          :class="{ active: inputMode === 'percentage' }"
+          @click="$emit('update:inputMode', 'percentage')"
+        >
+          Percentage
+        </button>
+        <button
+          type="button"
+          class="mode-btn"
+          :class="{ active: inputMode === 'amount' }"
+          @click="$emit('update:inputMode', 'amount')"
+        >
+          Amount (EUR)
+        </button>
+      </div>
+    </div>
+
+    <div class="table-responsive">
+      <table class="table table-sm allocation-table">
+        <thead>
+          <tr>
+            <th>ETF</th>
+            <th>Name</th>
+            <th>Price</th>
+            <th>TER</th>
+            <th>Annual Return</th>
+            <th style="width: 150px">
+              {{ inputMode === 'percentage' ? 'Allocation %' : 'Amount EUR' }}
+            </th>
+            <th style="width: 50px"></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="(allocation, index) in allocations" :key="index">
+            <td>
+              <select
+                :value="allocation.instrumentId"
+                class="form-select form-select-sm"
+                @change="onInstrumentChange(index, $event)"
+              >
+                <option :value="0" disabled>Select ETF</option>
+                <option
+                  v-for="etf in availableEtfsForRow(index)"
+                  :key="etf.instrumentId"
+                  :value="etf.instrumentId"
+                >
+                  {{ etf.symbol }}
+                </option>
+              </select>
+            </td>
+            <td class="text-muted small">{{ getEtfName(allocation.instrumentId) }}</td>
+            <td class="text-muted small">
+              {{ formatPrice(getEtfPrice(allocation.instrumentId)) }}
+            </td>
+            <td class="text-muted small">{{ formatTer(getEtfTer(allocation.instrumentId)) }}</td>
+            <td class="text-muted small">
+              {{ formatReturn(getEtfReturn(allocation.instrumentId)) }}
+            </td>
+            <td>
+              <input
+                :value="allocation.value"
+                type="number"
+                class="form-control form-control-sm"
+                min="0"
+                :max="inputMode === 'percentage' ? 100 : undefined"
+                :step="inputMode === 'percentage' ? 1 : 100"
+                @input="onValueChange(index, $event)"
+              />
+            </td>
+            <td>
+              <button
+                type="button"
+                class="remove-btn"
+                :disabled="allocations.length <= 1"
+                @click="$emit('remove', index)"
+              >
+                &times;
+              </button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="allocation-footer">
+      <div class="action-buttons">
+        <button type="button" class="action-btn" @click="$emit('add')">+ Add ETF</button>
+        <button
+          type="button"
+          class="action-btn"
+          :disabled="isLoadingPortfolio"
+          @click="$emit('loadPortfolio')"
+        >
+          <span
+            v-if="isLoadingPortfolio"
+            class="spinner-border spinner-border-sm me-1"
+            role="status"
+          ></span>
+          Load from Portfolio
+        </button>
+        <button type="button" class="action-btn" @click="$emit('export')">Export</button>
+        <button type="button" class="action-btn" @click="$emit('import')">Import</button>
+        <button
+          type="button"
+          class="action-btn danger"
+          :disabled="allocations.length === 1 && allocations[0].instrumentId === 0"
+          @click="$emit('clear')"
+        >
+          Clear
+        </button>
+      </div>
+      <div class="total-row">
+        <span class="total-label">Total</span>
+        <span class="total-value" :class="{ invalid: !isValidTotal, valid: isValidTotal }">
+          {{
+            inputMode === 'percentage'
+              ? `${totalAllocation.toFixed(1)}%`
+              : formatCurrency(totalAllocation)
+          }}
+          <span v-if="inputMode === 'percentage' && !isValidTotal" class="total-hint">
+            (should be 100%)
+          </span>
+        </span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { computed } from 'vue'
+import { useDiversificationFormatters } from '../../composables/use-diversification-formatters'
+import type { EtfDetailDto } from '../../models/generated/domain-models'
+
+interface AllocationInput {
+  instrumentId: number
+  value: number
+}
+
+const props = defineProps<{
+  allocations: AllocationInput[]
+  inputMode: 'percentage' | 'amount'
+  availableEtfs: EtfDetailDto[]
+  isLoadingPortfolio: boolean
+}>()
+
+const emit = defineEmits<{
+  'update:inputMode': ['percentage' | 'amount']
+  'update:allocation': [index: number, allocation: AllocationInput]
+  add: []
+  remove: [index: number]
+  clear: []
+  loadPortfolio: []
+  export: []
+  import: []
+}>()
+
+const { formatPrice, formatTer, formatReturn, formatCurrency } = useDiversificationFormatters()
+
+const totalAllocation = computed(() =>
+  props.allocations.reduce((sum, a) => sum + (a.value || 0), 0)
+)
+
+const isValidTotal = computed(() => {
+  if (props.inputMode === 'percentage') {
+    return Math.abs(totalAllocation.value - 100) < 0.1
+  }
+  return totalAllocation.value > 0
+})
+
+const availableEtfsForRow = (rowIndex: number) => {
+  const selectedIds = props.allocations
+    .filter((_, i) => i !== rowIndex)
+    .map(a => a.instrumentId)
+    .filter(id => id > 0)
+  return props.availableEtfs.filter(etf => !selectedIds.includes(etf.instrumentId))
+}
+
+const getEtfName = (instrumentId: number): string =>
+  props.availableEtfs.find(e => e.instrumentId === instrumentId)?.name || ''
+
+const getEtfTer = (instrumentId: number): number | null =>
+  props.availableEtfs.find(e => e.instrumentId === instrumentId)?.ter ?? null
+
+const getEtfReturn = (instrumentId: number): number | null =>
+  props.availableEtfs.find(e => e.instrumentId === instrumentId)?.annualReturn ?? null
+
+const getEtfPrice = (instrumentId: number): number | null =>
+  props.availableEtfs.find(e => e.instrumentId === instrumentId)?.currentPrice ?? null
+
+const onInstrumentChange = (index: number, event: Event) => {
+  const target = event.target as HTMLSelectElement
+  emit('update:allocation', index, {
+    ...props.allocations[index],
+    instrumentId: Number(target.value),
+  })
+}
+
+const onValueChange = (index: number, event: Event) => {
+  const target = event.target as HTMLInputElement
+  emit('update:allocation', index, {
+    ...props.allocations[index],
+    value: Number(target.value) || 0,
+  })
+}
+</script>
+
+<style scoped>
+.allocation-section {
+  background: white;
+  border: 1px solid #e0e0e0;
+  border-radius: 0.5rem;
+  padding: 1.5rem;
+}
+
+.allocation-table {
+  margin-bottom: 1rem;
+}
+
+.allocation-table th {
+  font-weight: 500;
+  color: #6c757d;
+  font-size: 0.875rem;
+  border-bottom: 2px solid #e0e0e0;
+}
+
+.allocation-table td {
+  vertical-align: middle;
+}
+
+.allocation-table tbody tr:nth-child(odd) {
+  background-color: #f9fafb;
+}
+
+.allocation-table tbody tr:nth-child(even) {
+  background-color: white;
+}
+
+.allocation-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid #e2e8f0;
+}
+
+.total-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.total-label {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: #6b7280;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.total-value {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #1a1a1a;
+}
+
+.total-value.valid {
+  color: #059669;
+}
+
+.total-value.invalid {
+  color: #dc2626;
+}
+
+.total-hint {
+  font-size: 0.75rem;
+  font-weight: 400;
+  margin-left: 0.25rem;
+}
+
+.action-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+}
+
+.action-btn {
+  padding: 0.3125rem 0.625rem;
+  border: 1px solid #e2e8f0;
+  background: white;
+  color: #6b7280;
+  border-radius: 0.375rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.12s ease;
+  white-space: nowrap;
+}
+
+.action-btn:hover:not(:disabled) {
+  background: #f8fafc;
+  border-color: #cbd5e1;
+  color: #4b5563;
+}
+
+.action-btn:active:not(:disabled) {
+  background: #f1f5f9;
+  transform: scale(0.98);
+}
+
+.action-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.action-btn.danger:hover:not(:disabled) {
+  background: #fef2f2;
+  border-color: #fecaca;
+  color: #dc2626;
+}
+
+.mode-buttons {
+  display: flex;
+  gap: 0;
+}
+
+.mode-btn {
+  padding: 0.3125rem 0.625rem;
+  border: 1px solid #e2e8f0;
+  background: white;
+  color: #6b7280;
+  font-size: 0.75rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.12s ease;
+  white-space: nowrap;
+}
+
+.mode-btn:first-child {
+  border-radius: 0.375rem 0 0 0.375rem;
+  border-right: none;
+}
+
+.mode-btn:last-child {
+  border-radius: 0 0.375rem 0.375rem 0;
+}
+
+.mode-btn:hover:not(.active) {
+  background: #f8fafc;
+  border-color: #cbd5e1;
+  color: #4b5563;
+}
+
+.mode-btn.active {
+  background: #4b5563;
+  color: white;
+  border-color: #4b5563;
+}
+
+.remove-btn {
+  width: 1.5rem;
+  height: 1.5rem;
+  padding: 0;
+  border: 1px solid #e2e8f0;
+  background: white;
+  color: #9ca3af;
+  border-radius: 0.25rem;
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: all 0.12s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.remove-btn:hover:not(:disabled) {
+  background: #fef2f2;
+  border-color: #fecaca;
+  color: #dc2626;
+}
+
+.remove-btn:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+
+@media (max-width: 768px) {
+  .allocation-section {
+    padding: 1rem;
+  }
+}
+</style>

--- a/ui/components/diversification/breakdown-card.test.ts
+++ b/ui/components/diversification/breakdown-card.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import BreakdownCard from './breakdown-card.vue'
+
+describe('BreakdownCard', () => {
+  const defaultItems = [
+    { key: 'apple', name: 'Apple Inc', percentage: 5.5 },
+    { key: 'microsoft', name: 'Microsoft Corp', percentage: 4.8 },
+    { key: 'amazon', name: 'Amazon.com Inc', percentage: 3.2 },
+  ]
+
+  describe('rendering', () => {
+    it('should render the title', () => {
+      const wrapper = mount(BreakdownCard, {
+        props: { title: 'Top Holdings', items: defaultItems },
+      })
+      expect(wrapper.find('.breakdown-title').text()).toBe('Top Holdings')
+    })
+
+    it('should render all items', () => {
+      const wrapper = mount(BreakdownCard, {
+        props: { title: 'Holdings', items: defaultItems },
+      })
+      const items = wrapper.findAll('.breakdown-item')
+      expect(items).toHaveLength(3)
+    })
+
+    it('should display item names', () => {
+      const wrapper = mount(BreakdownCard, {
+        props: { title: 'Holdings', items: defaultItems },
+      })
+      const names = wrapper.findAll('.breakdown-name')
+      expect(names[0].text()).toBe('Apple Inc')
+      expect(names[1].text()).toBe('Microsoft Corp')
+      expect(names[2].text()).toBe('Amazon.com Inc')
+    })
+
+    it('should format percentages correctly', () => {
+      const wrapper = mount(BreakdownCard, {
+        props: { title: 'Holdings', items: defaultItems },
+      })
+      const values = wrapper.findAll('.breakdown-value')
+      expect(values[0].text()).toBe('5.50%')
+      expect(values[1].text()).toBe('4.80%')
+      expect(values[2].text()).toBe('3.20%')
+    })
+  })
+
+  describe('maxItems prop', () => {
+    it('should limit items to maxItems when specified', () => {
+      const manyItems = Array.from({ length: 20 }, (_, i) => ({
+        key: `item-${i}`,
+        name: `Item ${i}`,
+        percentage: 5 - i * 0.2,
+      }))
+      const wrapper = mount(BreakdownCard, {
+        props: { title: 'Holdings', items: manyItems, maxItems: 5 },
+      })
+      const items = wrapper.findAll('.breakdown-item')
+      expect(items).toHaveLength(5)
+    })
+
+    it('should use default maxItems of 15', () => {
+      const manyItems = Array.from({ length: 20 }, (_, i) => ({
+        key: `item-${i}`,
+        name: `Item ${i}`,
+        percentage: 5 - i * 0.2,
+      }))
+      const wrapper = mount(BreakdownCard, {
+        props: { title: 'Holdings', items: manyItems },
+      })
+      const items = wrapper.findAll('.breakdown-item')
+      expect(items).toHaveLength(15)
+    })
+
+    it('should show all items when less than maxItems', () => {
+      const wrapper = mount(BreakdownCard, {
+        props: { title: 'Holdings', items: defaultItems, maxItems: 10 },
+      })
+      const items = wrapper.findAll('.breakdown-item')
+      expect(items).toHaveLength(3)
+    })
+  })
+
+  describe('empty state', () => {
+    it('should render title with empty items', () => {
+      const wrapper = mount(BreakdownCard, {
+        props: { title: 'Empty Section', items: [] },
+      })
+      expect(wrapper.find('.breakdown-title').text()).toBe('Empty Section')
+      expect(wrapper.findAll('.breakdown-item')).toHaveLength(0)
+    })
+  })
+
+  describe('percentage formatting edge cases', () => {
+    it('should format zero percentage', () => {
+      const items = [{ key: 'zero', name: 'Zero Item', percentage: 0 }]
+      const wrapper = mount(BreakdownCard, {
+        props: { title: 'Holdings', items },
+      })
+      expect(wrapper.find('.breakdown-value').text()).toBe('0.00%')
+    })
+
+    it('should format small percentages', () => {
+      const items = [{ key: 'small', name: 'Small Item', percentage: 0.01 }]
+      const wrapper = mount(BreakdownCard, {
+        props: { title: 'Holdings', items },
+      })
+      expect(wrapper.find('.breakdown-value').text()).toBe('0.01%')
+    })
+
+    it('should format large percentages', () => {
+      const items = [{ key: 'large', name: 'Large Item', percentage: 99.99 }]
+      const wrapper = mount(BreakdownCard, {
+        props: { title: 'Holdings', items },
+      })
+      expect(wrapper.find('.breakdown-value').text()).toBe('99.99%')
+    })
+  })
+
+  describe('different titles', () => {
+    it('should render Sectors title', () => {
+      const wrapper = mount(BreakdownCard, {
+        props: {
+          title: 'Sectors',
+          items: [{ key: 'tech', name: 'Technology', percentage: 25.5 }],
+        },
+      })
+      expect(wrapper.find('.breakdown-title').text()).toBe('Sectors')
+    })
+
+    it('should render Countries title', () => {
+      const wrapper = mount(BreakdownCard, {
+        props: {
+          title: 'Countries',
+          items: [{ key: 'us', name: 'United States', percentage: 60.0 }],
+        },
+      })
+      expect(wrapper.find('.breakdown-title').text()).toBe('Countries')
+    })
+  })
+})

--- a/ui/components/diversification/breakdown-card.vue
+++ b/ui/components/diversification/breakdown-card.vue
@@ -1,0 +1,83 @@
+<template>
+  <div class="breakdown-card">
+    <h6 class="breakdown-title">{{ title }}</h6>
+    <div class="breakdown-list">
+      <div v-for="item in items.slice(0, maxItems)" :key="item.key" class="breakdown-item">
+        <span class="breakdown-name">{{ item.name }}</span>
+        <span class="breakdown-value">{{ formatPercentage(item.percentage) }}</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { useDiversificationFormatters } from '../../composables/use-diversification-formatters'
+
+interface BreakdownItem {
+  key: string
+  name: string
+  percentage: number
+}
+
+withDefaults(
+  defineProps<{
+    title: string
+    items: BreakdownItem[]
+    maxItems?: number
+  }>(),
+  {
+    maxItems: 15,
+  }
+)
+
+const { formatPercentage } = useDiversificationFormatters()
+</script>
+
+<style scoped>
+.breakdown-card {
+  background: white;
+  border: 1px solid #e0e0e0;
+  border-radius: 0.5rem;
+  padding: 1rem;
+  height: 100%;
+}
+
+.breakdown-title {
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+  color: #1a1a1a;
+}
+
+.breakdown-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.breakdown-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.25rem 0;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.breakdown-item:last-child {
+  border-bottom: none;
+}
+
+.breakdown-name {
+  font-size: 0.875rem;
+  color: #333;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 70%;
+}
+
+.breakdown-value {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #1a1a1a;
+}
+</style>

--- a/ui/components/diversification/config-dialog.test.ts
+++ b/ui/components/diversification/config-dialog.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, VueWrapper } from '@vue/test-utils'
+import { h } from 'vue'
+import ConfigDialog from './config-dialog.vue'
+
+vi.mock('bootstrap', () => {
+  return {
+    Modal: class {
+      show = vi.fn()
+      hide = vi.fn()
+      dispose = vi.fn()
+    },
+  }
+})
+
+vi.mock('@guolao/vue-monaco-editor', () => ({
+  VueMonacoEditor: {
+    name: 'VueMonacoEditor',
+    props: ['value', 'language', 'options', 'theme'],
+    setup(props: { value: string }) {
+      return () => h('div', { class: 'mock-monaco-editor' }, props.value)
+    },
+  },
+}))
+
+describe('ConfigDialog', () => {
+  const defaultConfig = {
+    allocations: [
+      { instrumentId: 1, value: 60 },
+      { instrumentId: 2, value: 40 },
+    ],
+    inputMode: 'percentage' as const,
+  }
+
+  const validEtfIds = new Set([1, 2, 3])
+
+  const defaultProps = {
+    modelValue: false,
+    mode: 'export' as const,
+    config: defaultConfig,
+    validEtfIds,
+    modalId: 'testModal',
+  }
+
+  let wrapper: VueWrapper
+
+  beforeEach(() => {
+    const modalElement = document.createElement('div')
+    modalElement.id = 'testModal'
+    document.body.appendChild(modalElement)
+  })
+
+  afterEach(() => {
+    wrapper?.unmount()
+    const modalElement = document.getElementById('testModal')
+    if (modalElement) {
+      document.body.removeChild(modalElement)
+    }
+  })
+
+  describe('export mode', () => {
+    it('should render export title', () => {
+      wrapper = mount(ConfigDialog, { props: defaultProps })
+      expect(wrapper.text()).toContain('Export Configuration')
+    })
+
+    it('should show config preview in export mode', () => {
+      wrapper = mount(ConfigDialog, { props: defaultProps })
+      expect(wrapper.find('.editor-container').exists()).toBe(true)
+      expect(wrapper.find('.mock-monaco-editor').text()).toContain('instrumentId')
+    })
+
+    it('should render Download button in export mode', () => {
+      wrapper = mount(ConfigDialog, { props: defaultProps })
+      expect(wrapper.text()).toContain('Download')
+    })
+
+    it('should emit export and update:modelValue when download is clicked', async () => {
+      const createObjectURL = vi.fn(() => 'blob:test')
+      const revokeObjectURL = vi.fn()
+      global.URL.createObjectURL = createObjectURL
+      global.URL.revokeObjectURL = revokeObjectURL
+
+      wrapper = mount(ConfigDialog, { props: { ...defaultProps, modelValue: true } })
+      const downloadBtn = wrapper.findAll('button').find(b => b.text() === 'Download')
+      await downloadBtn?.trigger('click')
+
+      expect(wrapper.emitted('export')).toHaveLength(1)
+      expect(wrapper.emitted('update:modelValue')).toContainEqual([false])
+    })
+  })
+
+  describe('import mode', () => {
+    const importProps = { ...defaultProps, mode: 'import' as const }
+
+    it('should render import title', () => {
+      wrapper = mount(ConfigDialog, { props: importProps })
+      expect(wrapper.text()).toContain('Import Configuration')
+    })
+
+    it('should show file drop zone initially', () => {
+      wrapper = mount(ConfigDialog, { props: importProps })
+      expect(wrapper.find('.file-drop-zone').exists()).toBe(true)
+      expect(wrapper.text()).toContain('Click to select or drag a JSON file here')
+    })
+
+    it('should have hidden file input', () => {
+      wrapper = mount(ConfigDialog, { props: importProps })
+      const fileInput = wrapper.find('input[type="file"]')
+      expect(fileInput.exists()).toBe(true)
+      expect(fileInput.attributes('accept')).toBe('.json')
+    })
+
+    it('should render Import button disabled initially', () => {
+      wrapper = mount(ConfigDialog, { props: importProps })
+      const importBtn = wrapper.findAll('button').find(b => b.text() === 'Import')
+      expect(importBtn?.attributes('disabled')).toBeDefined()
+    })
+
+    it('should process valid JSON file', async () => {
+      wrapper = mount(ConfigDialog, { props: importProps })
+      const fileInput = wrapper.find('input[type="file"]')
+
+      const testData = {
+        allocations: [{ instrumentId: 1, value: 100 }],
+        inputMode: 'percentage',
+      }
+      const file = new File([JSON.stringify(testData)], 'test.json', { type: 'application/json' })
+      Object.defineProperty(fileInput.element, 'files', { value: [file] })
+      await fileInput.trigger('change')
+      await new Promise(resolve => setTimeout(resolve, 50))
+
+      expect(wrapper.find('.import-preview').exists()).toBe(true)
+      expect(wrapper.text()).toContain('Preview of configuration to import')
+    })
+
+    it('should show error for invalid JSON', async () => {
+      wrapper = mount(ConfigDialog, { props: importProps })
+      const fileInput = wrapper.find('input[type="file"]')
+
+      const file = new File(['invalid json'], 'test.json', { type: 'application/json' })
+      Object.defineProperty(fileInput.element, 'files', { value: [file] })
+      await fileInput.trigger('change')
+      await new Promise(resolve => setTimeout(resolve, 50))
+
+      expect(wrapper.text()).toContain('Invalid JSON file')
+    })
+
+    it('should show error when JSON is missing required fields', async () => {
+      wrapper = mount(ConfigDialog, { props: importProps })
+      const fileInput = wrapper.find('input[type="file"]')
+
+      const file = new File(['{"someField": "value"}'], 'test.json', { type: 'application/json' })
+      Object.defineProperty(fileInput.element, 'files', { value: [file] })
+      await fileInput.trigger('change')
+      await new Promise(resolve => setTimeout(resolve, 50))
+
+      expect(wrapper.text()).toContain('Invalid configuration file format')
+    })
+
+    it('should show warning when some ETFs are not available', async () => {
+      const limitedValidIds = new Set([1])
+      wrapper = mount(ConfigDialog, {
+        props: { ...importProps, validEtfIds: limitedValidIds },
+      })
+      const fileInput = wrapper.find('input[type="file"]')
+
+      const testData = {
+        allocations: [
+          { instrumentId: 1, value: 50 },
+          { instrumentId: 999, value: 50 },
+        ],
+        inputMode: 'percentage',
+      }
+      const file = new File([JSON.stringify(testData)], 'test.json', { type: 'application/json' })
+      Object.defineProperty(fileInput.element, 'files', { value: [file] })
+      await fileInput.trigger('change')
+      await new Promise(resolve => setTimeout(resolve, 50))
+
+      expect(wrapper.text()).toContain('1 ETF(s) were removed because they are not available')
+    })
+
+    it('should emit import event with data when Import is clicked', async () => {
+      wrapper = mount(ConfigDialog, { props: importProps })
+      const fileInput = wrapper.find('input[type="file"]')
+
+      const testData = {
+        allocations: [{ instrumentId: 1, value: 100 }],
+        inputMode: 'percentage',
+      }
+      const file = new File([JSON.stringify(testData)], 'test.json', { type: 'application/json' })
+      Object.defineProperty(fileInput.element, 'files', { value: [file] })
+      await fileInput.trigger('change')
+      await new Promise(resolve => setTimeout(resolve, 50))
+
+      const importBtn = wrapper.findAll('button').find(b => b.text() === 'Import')
+      await importBtn?.trigger('click')
+
+      expect(wrapper.emitted('import')).toBeTruthy()
+      expect(wrapper.emitted('import')?.[0][0]).toEqual(testData)
+    })
+
+    it('should reset import state when Choose Different File is clicked', async () => {
+      wrapper = mount(ConfigDialog, { props: importProps })
+      const fileInput = wrapper.find('input[type="file"]')
+
+      const testData = {
+        allocations: [{ instrumentId: 1, value: 100 }],
+        inputMode: 'percentage',
+      }
+      const file = new File([JSON.stringify(testData)], 'test.json', { type: 'application/json' })
+      Object.defineProperty(fileInput.element, 'files', { value: [file] })
+      await fileInput.trigger('change')
+      await new Promise(resolve => setTimeout(resolve, 50))
+
+      expect(wrapper.find('.import-preview').exists()).toBe(true)
+
+      const resetBtn = wrapper.findAll('button').find(b => b.text() === 'Choose Different File')
+      await resetBtn?.trigger('click')
+
+      expect(wrapper.find('.file-drop-zone').exists()).toBe(true)
+      expect(wrapper.find('.import-preview').exists()).toBe(false)
+    })
+  })
+
+  describe('common functionality', () => {
+    it('should emit update:modelValue false when Cancel is clicked', async () => {
+      wrapper = mount(ConfigDialog, { props: defaultProps })
+      const cancelBtn = wrapper.findAll('button').find(b => b.text() === 'Cancel')
+      await cancelBtn?.trigger('click')
+
+      expect(wrapper.emitted('update:modelValue')).toContainEqual([false])
+    })
+
+    it('should emit update:modelValue false when close button is clicked', async () => {
+      wrapper = mount(ConfigDialog, { props: defaultProps })
+      const closeBtn = wrapper.find('.btn-close')
+      await closeBtn.trigger('click')
+
+      expect(wrapper.emitted('update:modelValue')).toContainEqual([false])
+    })
+  })
+})

--- a/ui/components/diversification/config-dialog.vue
+++ b/ui/components/diversification/config-dialog.vue
@@ -1,0 +1,303 @@
+<template>
+  <div
+    class="modal fade"
+    :id="modalId"
+    tabindex="-1"
+    :aria-labelledby="`${modalId}Label`"
+    aria-hidden="true"
+    @click.self="close"
+  >
+    <div class="modal-dialog modal-lg">
+      <div class="modal-content" @click.stop>
+        <div class="modal-header">
+          <h5 class="modal-title" :id="`${modalId}Label`">
+            {{ mode === 'export' ? 'Export Configuration' : 'Import Configuration' }}
+          </h5>
+          <button type="button" class="btn-close" @click="close" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <template v-if="mode === 'export'">
+            <p class="text-muted small mb-2">
+              Download your current ETF allocation configuration as a JSON file.
+            </p>
+            <div class="editor-container">
+              <VueMonacoEditor
+                v-model:value="exportContent"
+                language="json"
+                :options="editorOptions"
+                theme="vs"
+              />
+            </div>
+          </template>
+          <template v-else>
+            <div v-if="!importedData" class="import-area">
+              <p class="text-muted small mb-3">
+                Select a JSON configuration file to import your ETF allocation.
+              </p>
+              <div
+                class="file-drop-zone"
+                @click="triggerFileInput"
+                @dragover.prevent
+                @drop.prevent="onFileDrop"
+              >
+                <input
+                  ref="fileInput"
+                  type="file"
+                  accept=".json"
+                  class="d-none"
+                  @change="onFileSelected"
+                />
+                <div class="drop-content">
+                  <div class="drop-icon">+</div>
+                  <div>Click to select or drag a JSON file here</div>
+                </div>
+              </div>
+              <div v-if="importError" class="alert alert-danger mt-3 mb-0">
+                {{ importError }}
+              </div>
+            </div>
+            <div v-else class="import-preview">
+              <p class="text-muted small mb-2">Preview of configuration to import:</p>
+              <div class="editor-container">
+                <VueMonacoEditor
+                  v-model:value="importContent"
+                  language="json"
+                  :options="editorOptions"
+                  theme="vs"
+                />
+              </div>
+              <div v-if="validationWarning" class="alert alert-warning mt-3 mb-0">
+                {{ validationWarning }}
+              </div>
+            </div>
+          </template>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="dialog-btn" @click="close">Cancel</button>
+          <template v-if="mode === 'export'">
+            <button type="button" class="dialog-btn primary" @click="downloadConfig">
+              Download
+            </button>
+          </template>
+          <template v-else>
+            <button v-if="importedData" type="button" class="dialog-btn" @click="resetImport">
+              Choose Different File
+            </button>
+            <button
+              type="button"
+              class="dialog-btn primary"
+              :disabled="!importedData"
+              @click="confirmImport"
+            >
+              Import
+            </button>
+          </template>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
+import { Modal } from 'bootstrap'
+import { VueMonacoEditor } from '@guolao/vue-monaco-editor'
+
+interface AllocationInput {
+  instrumentId: number
+  value: number
+}
+
+interface ConfigData {
+  allocations: AllocationInput[]
+  inputMode: 'percentage' | 'amount'
+}
+
+interface Props {
+  modelValue: boolean
+  mode: 'export' | 'import'
+  config: ConfigData
+  validEtfIds: Set<number>
+  modalId?: string
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  modalId: 'configDialog',
+})
+
+const emit = defineEmits<{
+  'update:modelValue': [value: boolean]
+  export: []
+  import: [data: ConfigData]
+}>()
+
+const editorOptions = {
+  readOnly: true,
+  minimap: { enabled: false },
+  scrollBeyondLastLine: false,
+  lineNumbers: 'on' as const,
+  folding: true,
+  automaticLayout: true,
+  fontSize: 13,
+  fontFamily: "ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace",
+  renderLineHighlight: 'none' as const,
+  stickyScroll: { enabled: false },
+  overviewRulerLanes: 0,
+  hideCursorInOverviewRuler: true,
+  overviewRulerBorder: false,
+  scrollbar: {
+    vertical: 'auto' as const,
+    horizontal: 'auto' as const,
+  },
+}
+
+let modalInstance: Modal | null = null
+const fileInput = ref<HTMLInputElement | null>(null)
+const importedData = ref<ConfigData | null>(null)
+const importError = ref('')
+const validationWarning = ref('')
+
+const exportContent = computed(() => JSON.stringify(props.config, null, 2))
+
+const importContent = computed(() =>
+  importedData.value ? JSON.stringify(importedData.value, null, 2) : ''
+)
+
+onMounted(() => {
+  const modalElement = document.getElementById(props.modalId)
+  if (modalElement) {
+    modalInstance = new Modal(modalElement, { backdrop: 'static', keyboard: false })
+    modalElement.addEventListener('hidden.bs.modal', () => {
+      emit('update:modelValue', false)
+      resetImport()
+    })
+  }
+})
+
+onUnmounted(() => {
+  modalInstance?.dispose()
+})
+
+watch(
+  () => props.modelValue,
+  newValue => {
+    if (modalInstance) {
+      if (newValue) {
+        modalInstance.show()
+      } else {
+        modalInstance.hide()
+      }
+    }
+  }
+)
+
+const close = () => {
+  emit('update:modelValue', false)
+}
+
+const downloadConfig = () => {
+  const blob = new Blob([JSON.stringify(props.config, null, 2)], { type: 'application/json' })
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = 'diversification-config.json'
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+  URL.revokeObjectURL(url)
+  emit('export')
+  close()
+}
+
+const triggerFileInput = () => {
+  fileInput.value?.click()
+}
+
+const onFileDrop = (event: DragEvent) => {
+  const file = event.dataTransfer?.files[0]
+  if (file) processFile(file)
+}
+
+const onFileSelected = (event: Event) => {
+  const target = event.target as HTMLInputElement
+  const file = target.files?.[0]
+  if (file) processFile(file)
+  target.value = ''
+}
+
+const processFile = (file: File) => {
+  importError.value = ''
+  validationWarning.value = ''
+  const reader = new FileReader()
+  reader.onload = e => {
+    try {
+      const data = JSON.parse(e.target?.result as string) as ConfigData
+      if (!data.allocations || !data.inputMode) {
+        importError.value = 'Invalid configuration file format'
+        return
+      }
+      const validAllocations = data.allocations.filter(
+        a => a.instrumentId === 0 || props.validEtfIds.has(a.instrumentId)
+      )
+      if (validAllocations.length === 0) {
+        importError.value = 'No valid ETFs found in the configuration'
+        return
+      }
+      if (validAllocations.length < data.allocations.length) {
+        validationWarning.value = `${data.allocations.length - validAllocations.length} ETF(s) were removed because they are not available`
+      }
+      importedData.value = { allocations: validAllocations, inputMode: data.inputMode }
+    } catch {
+      importError.value = 'Invalid JSON file'
+    }
+  }
+  reader.readAsText(file)
+}
+
+const resetImport = () => {
+  importedData.value = null
+  importError.value = ''
+  validationWarning.value = ''
+}
+
+const confirmImport = () => {
+  if (importedData.value) {
+    emit('import', importedData.value)
+    close()
+  }
+}
+</script>
+
+<style scoped>
+.editor-container {
+  height: 400px;
+  border: 1px solid #d0d7de;
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.file-drop-zone {
+  border: 2px dashed #dee2e6;
+  border-radius: 0.5rem;
+  padding: 2rem;
+  text-align: center;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.file-drop-zone:hover {
+  border-color: #0d6efd;
+  background: #f8f9fa;
+}
+
+.drop-content {
+  color: #6c757d;
+}
+
+.drop-icon {
+  font-size: 2rem;
+  font-weight: 300;
+  color: #adb5bd;
+  margin-bottom: 0.5rem;
+}
+</style>

--- a/ui/components/diversification/diversification-calculator.test.ts
+++ b/ui/components/diversification/diversification-calculator.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { h, ref } from 'vue'
+import DiversificationCalculator from './diversification-calculator.vue'
+
+vi.mock('@tanstack/vue-query', () => ({
+  useQuery: vi.fn(() => ({
+    data: ref([
+      {
+        instrumentId: 1,
+        symbol: 'VWCE',
+        name: 'Vanguard FTSE All-World',
+        allocation: 0,
+        ter: 0.22,
+        annualReturn: 12.5,
+        currentPrice: 120.5,
+      },
+      {
+        instrumentId: 2,
+        symbol: 'VUAA',
+        name: 'Vanguard S&P 500',
+        allocation: 0,
+        ter: 0.07,
+        annualReturn: 15.0,
+        currentPrice: 95.3,
+      },
+    ]),
+    isLoading: ref(false),
+    dataUpdatedAt: ref(Date.now()),
+  })),
+}))
+
+vi.mock('../../services/diversification-service', () => ({
+  diversificationService: {
+    getAvailableEtfs: vi.fn(),
+    calculate: vi.fn(),
+  },
+}))
+
+vi.mock('../../services/instruments-service', () => ({
+  instrumentsService: {
+    getAll: vi.fn(),
+  },
+}))
+
+vi.mock('@vueuse/core', () => ({
+  useDebounceFn: vi.fn((fn: () => void) => fn),
+  useNow: vi.fn(() => ({ value: new Date() })),
+}))
+
+vi.mock('bootstrap', () => ({
+  Modal: vi.fn().mockImplementation(() => ({
+    show: vi.fn(),
+    hide: vi.fn(),
+    dispose: vi.fn(),
+  })),
+}))
+
+vi.mock('@guolao/vue-monaco-editor', () => ({
+  VueMonacoEditor: {
+    name: 'VueMonacoEditor',
+    props: ['value', 'language', 'options', 'theme'],
+    setup(props: { value: string }) {
+      return () => h('div', { class: 'mock-monaco-editor' }, props.value)
+    },
+  },
+}))
+
+describe('DiversificationCalculator', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+  })
+
+  describe('rendering', () => {
+    it('should render calculator title', () => {
+      const wrapper = mount(DiversificationCalculator)
+      expect(wrapper.text()).toContain('Diversification Calculator')
+    })
+
+    it('should render description text', () => {
+      const wrapper = mount(DiversificationCalculator)
+      expect(wrapper.text()).toContain('Plan your ETF allocation')
+    })
+
+    it('should render AllocationTable component', () => {
+      const wrapper = mount(DiversificationCalculator)
+      expect(wrapper.findComponent({ name: 'AllocationTable' }).exists()).toBe(true)
+    })
+
+    it('should show last updated text when data is available', () => {
+      const wrapper = mount(DiversificationCalculator)
+      expect(wrapper.find('.last-updated').exists()).toBe(true)
+    })
+  })
+
+  describe('loading state', () => {
+    it('should not show spinner when not loading ETFs', () => {
+      const wrapper = mount(DiversificationCalculator)
+      expect(wrapper.find('.spinner-border').exists()).toBe(false)
+    })
+  })
+
+  describe('error handling', () => {
+    it('should not show error alert when no error', () => {
+      const wrapper = mount(DiversificationCalculator)
+      expect(wrapper.find('.alert-danger').exists()).toBe(false)
+    })
+  })
+
+  describe('results display', () => {
+    it('should not show results section when no result', () => {
+      const wrapper = mount(DiversificationCalculator)
+      expect(wrapper.find('.results-section').exists()).toBe(false)
+    })
+  })
+
+  describe('config dialogs', () => {
+    it('should have export dialog component', () => {
+      const wrapper = mount(DiversificationCalculator)
+      const configDialogs = wrapper.findAllComponents({ name: 'ConfigDialog' })
+      expect(configDialogs.length).toBeGreaterThanOrEqual(1)
+    })
+
+    it('should have import dialog component', () => {
+      const wrapper = mount(DiversificationCalculator)
+      const configDialogs = wrapper.findAllComponents({ name: 'ConfigDialog' })
+      expect(configDialogs.length).toBe(2)
+    })
+  })
+
+  describe('allocation operations', () => {
+    it('should emit events from allocation table', () => {
+      const wrapper = mount(DiversificationCalculator)
+      const allocationTable = wrapper.findComponent({ name: 'AllocationTable' })
+      expect(allocationTable.exists()).toBe(true)
+    })
+  })
+})

--- a/ui/components/diversification/diversification-calculator.vue
+++ b/ui/components/diversification/diversification-calculator.vue
@@ -1,0 +1,363 @@
+<template>
+  <div class="diversification-container">
+    <div class="mb-4">
+      <div class="d-flex justify-content-between align-items-start">
+        <div>
+          <h2 class="mb-0">Diversification Calculator</h2>
+          <p class="text-muted mb-0">
+            Plan your ETF allocation and see the combined diversification analysis
+          </p>
+        </div>
+        <div v-if="lastUpdatedText" class="last-updated">Updated {{ lastUpdatedText }}</div>
+      </div>
+    </div>
+
+    <div v-if="isLoadingEtfs" class="text-center py-4">
+      <div class="spinner-border text-primary" role="status">
+        <span class="visually-hidden">Loading...</span>
+      </div>
+    </div>
+
+    <template v-else>
+      <AllocationTable
+        :allocations="allocations"
+        :input-mode="inputMode"
+        :available-etfs="etfList"
+        :is-loading-portfolio="isLoadingPortfolio"
+        class="mb-4"
+        @update:input-mode="inputMode = $event"
+        @update:allocation="updateAllocation"
+        @add="addAllocation"
+        @remove="removeAllocation"
+        @clear="clearAllocations"
+        @load-portfolio="loadFromPortfolio"
+        @export="exportConfiguration"
+        @import="importConfiguration"
+      />
+
+      <div v-if="result" class="results-section">
+        <DiversificationStats
+          :weighted-ter="result.weightedTer"
+          :weighted-annual-return="result.weightedAnnualReturn"
+          :total-unique-holdings="result.totalUniqueHoldings"
+          :top10-percentage="result.concentration.top10Percentage"
+        />
+
+        <div class="row g-4">
+          <div class="col-lg-4">
+            <BreakdownCard title="Top Holdings" :items="holdingsBreakdown" />
+          </div>
+          <div class="col-lg-4">
+            <BreakdownCard title="Sectors" :items="sectorsBreakdown" />
+          </div>
+          <div class="col-lg-4">
+            <BreakdownCard title="Countries" :items="countriesBreakdown" />
+          </div>
+        </div>
+      </div>
+
+      <div v-if="isCalculating" class="text-center py-4">
+        <div class="spinner-border text-primary" role="status">
+          <span class="visually-hidden">Calculating...</span>
+        </div>
+      </div>
+
+      <div v-if="error" class="alert alert-danger mt-3">
+        {{ error }}
+      </div>
+    </template>
+
+    <ConfigDialog
+      v-model="showExportDialog"
+      mode="export"
+      :config="currentConfig"
+      :valid-etf-ids="validEtfIds"
+      modal-id="exportConfigDialog"
+      @export="onExportComplete"
+    />
+
+    <ConfigDialog
+      v-model="showImportDialog"
+      mode="import"
+      :config="currentConfig"
+      :valid-etf-ids="validEtfIds"
+      modal-id="importConfigDialog"
+      @import="onImportComplete"
+    />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref, computed, watch } from 'vue'
+import { useDebounceFn, useNow } from '@vueuse/core'
+import { useQuery } from '@tanstack/vue-query'
+import { diversificationService } from '../../services/diversification-service'
+import { instrumentsService } from '../../services/instruments-service'
+import { REFETCH_INTERVALS } from '../../constants'
+import { useDiversificationFormatters } from '../../composables/use-diversification-formatters'
+import AllocationTable from './allocation-table.vue'
+import DiversificationStats from './diversification-stats.vue'
+import BreakdownCard from './breakdown-card.vue'
+import ConfigDialog from './config-dialog.vue'
+import type { DiversificationCalculatorResponseDto } from '../../models/generated/domain-models'
+
+interface AllocationInput {
+  instrumentId: number
+  value: number
+}
+
+interface CachedState {
+  allocations: AllocationInput[]
+  inputMode: 'percentage' | 'amount'
+}
+
+const STORAGE_KEY = 'diversification-calculator-state'
+
+const loadFromStorage = (): CachedState | null => {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (!stored) return null
+    return JSON.parse(stored) as CachedState
+  } catch {
+    return null
+  }
+}
+
+const saveToStorage = (state: CachedState): void => {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
+  } catch {
+    /* ignore storage errors */
+  }
+}
+
+const { formatRelativeTime } = useDiversificationFormatters()
+
+const {
+  data: availableEtfs,
+  isLoading: isLoadingEtfs,
+  dataUpdatedAt,
+} = useQuery({
+  queryKey: ['diversification-etfs'],
+  queryFn: diversificationService.getAvailableEtfs,
+  refetchInterval: REFETCH_INTERVALS.DIVERSIFICATION_ETFS,
+  staleTime: REFETCH_INTERVALS.DIVERSIFICATION_ETFS,
+})
+
+const now = useNow({ interval: 60000 })
+const lastUpdatedText = computed(() => {
+  if (!dataUpdatedAt.value) return ''
+  return formatRelativeTime(dataUpdatedAt.value, now.value.getTime())
+})
+
+const allocations = ref<AllocationInput[]>([{ instrumentId: 0, value: 0 }])
+const inputMode = ref<'percentage' | 'amount'>('percentage')
+const isCalculating = ref(false)
+const isLoadingPortfolio = ref(false)
+const error = ref('')
+const result = ref<DiversificationCalculatorResponseDto | null>(null)
+const isInitialized = ref(false)
+const showExportDialog = ref(false)
+const showImportDialog = ref(false)
+
+const etfList = computed(() => availableEtfs.value ?? [])
+
+const validEtfIds = computed(() => new Set(etfList.value.map(e => e.instrumentId)))
+
+const currentConfig = computed(() => ({
+  allocations: allocations.value,
+  inputMode: inputMode.value,
+}))
+
+const holdingsBreakdown = computed(
+  () =>
+    result.value?.holdings.map(h => ({ key: h.name, name: h.name, percentage: h.percentage })) ?? []
+)
+
+const sectorsBreakdown = computed(
+  () =>
+    result.value?.sectors.map(s => ({ key: s.sector, name: s.sector, percentage: s.percentage })) ??
+    []
+)
+
+const countriesBreakdown = computed(
+  () =>
+    result.value?.countries.map(c => ({
+      key: c.countryName,
+      name: c.countryName,
+      percentage: c.percentage,
+    })) ?? []
+)
+
+const addAllocation = () => {
+  allocations.value.push({ instrumentId: 0, value: 0 })
+}
+
+const removeAllocation = (index: number) => {
+  if (allocations.value.length > 1) {
+    allocations.value.splice(index, 1)
+    onAllocationChange()
+  }
+}
+
+const updateAllocation = (index: number, allocation: AllocationInput) => {
+  allocations.value[index] = allocation
+  onAllocationChange()
+}
+
+const getErrorMessage = (e: unknown): string => {
+  if (e instanceof Error) {
+    if (e.message.includes('Network Error') || e.message.includes('fetch')) {
+      return 'Unable to connect to the server. Please check your internet connection and try again.'
+    }
+    if (e.message.includes('timeout')) {
+      return 'The request timed out. Please try again.'
+    }
+    if (e.message.includes('500') || e.message.includes('Internal Server Error')) {
+      return 'A server error occurred. Please try again later.'
+    }
+    return e.message
+  }
+  return 'An unexpected error occurred. Please try again.'
+}
+
+const calculateDiversification = async () => {
+  const validAllocations = allocations.value.filter(a => a.instrumentId > 0 && a.value > 0)
+  if (validAllocations.length < 1) {
+    result.value = null
+    return
+  }
+  isCalculating.value = true
+  error.value = ''
+  try {
+    const requestAllocations = validAllocations.map(a => ({
+      instrumentId: a.instrumentId,
+      percentage: a.value,
+    }))
+    result.value = await diversificationService.calculate(requestAllocations)
+  } catch (e) {
+    error.value = getErrorMessage(e)
+    result.value = null
+  } finally {
+    isCalculating.value = false
+  }
+}
+
+const debouncedCalculate = useDebounceFn(calculateDiversification, 500)
+
+const persistState = (): void => {
+  saveToStorage({
+    allocations: allocations.value,
+    inputMode: inputMode.value,
+  })
+}
+
+const onAllocationChange = () => {
+  persistState()
+  debouncedCalculate()
+}
+
+const loadFromPortfolio = async () => {
+  isLoadingPortfolio.value = true
+  error.value = ''
+  try {
+    const response = await instrumentsService.getAll()
+    const etfIds = new Set(etfList.value.map(e => e.instrumentId))
+    const portfolioEtfs = response.instruments.filter(
+      i => i.id !== null && etfIds.has(i.id) && (i.currentValue ?? 0) > 0
+    )
+    if (portfolioEtfs.length === 0) {
+      error.value = 'No ETFs found in your portfolio'
+      return
+    }
+    const totalValue = portfolioEtfs.reduce((sum, i) => sum + (i.currentValue ?? 0), 0)
+    allocations.value = portfolioEtfs
+      .filter((i): i is typeof i & { id: number } => i.id !== null)
+      .map(i => ({
+        instrumentId: i.id,
+        value:
+          inputMode.value === 'percentage'
+            ? Math.round(((i.currentValue ?? 0) / totalValue) * 1000) / 10
+            : Math.round(i.currentValue ?? 0),
+      }))
+    persistState()
+    debouncedCalculate()
+  } catch (e) {
+    error.value = getErrorMessage(e)
+  } finally {
+    isLoadingPortfolio.value = false
+  }
+}
+
+const clearAllocations = () => {
+  allocations.value = [{ instrumentId: 0, value: 0 }]
+  result.value = null
+  persistState()
+}
+
+const exportConfiguration = () => {
+  showExportDialog.value = true
+}
+
+const importConfiguration = () => {
+  showImportDialog.value = true
+}
+
+const onExportComplete = () => {
+  showExportDialog.value = false
+}
+
+const onImportComplete = (data: CachedState) => {
+  allocations.value = data.allocations
+  inputMode.value = data.inputMode
+  persistState()
+  debouncedCalculate()
+}
+
+watch(inputMode, () => {
+  persistState()
+  debouncedCalculate()
+})
+
+watch(
+  availableEtfs,
+  newEtfs => {
+    if (!newEtfs || newEtfs.length === 0 || isInitialized.value) return
+    isInitialized.value = true
+    const cached = loadFromStorage()
+    if (!cached) return
+    const validIds = new Set(newEtfs.map(e => e.instrumentId))
+    const validAllocations = cached.allocations.filter(
+      a => a.instrumentId === 0 || validIds.has(a.instrumentId)
+    )
+    if (validAllocations.length === 0) return
+    allocations.value = validAllocations
+    inputMode.value = cached.inputMode
+    debouncedCalculate()
+  },
+  { immediate: true }
+)
+</script>
+
+<style scoped>
+.diversification-container {
+  max-width: min(1350px, 91vw);
+  margin: 0 auto;
+  padding: 1.5rem;
+}
+
+.last-updated {
+  font-size: 0.75rem;
+  color: #6b7280;
+  background: #f9fafb;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+  white-space: nowrap;
+}
+
+@media (max-width: 768px) {
+  .diversification-container {
+    padding: 1rem;
+  }
+}
+</style>

--- a/ui/components/diversification/diversification-stats.test.ts
+++ b/ui/components/diversification/diversification-stats.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import DiversificationStats from './diversification-stats.vue'
+
+describe('DiversificationStats', () => {
+  const defaultProps = {
+    weightedTer: 0.22,
+    weightedAnnualReturn: 0.12,
+    totalUniqueHoldings: 3500,
+    top10Percentage: 18.5,
+  }
+
+  describe('rendering', () => {
+    it('should render all four stat cards', () => {
+      const wrapper = mount(DiversificationStats, { props: defaultProps })
+      const statCards = wrapper.findAll('.stat-card')
+      expect(statCards).toHaveLength(4)
+    })
+
+    it('should display stat labels correctly', () => {
+      const wrapper = mount(DiversificationStats, { props: defaultProps })
+      const labels = wrapper.findAll('.stat-label')
+      expect(labels[0].text()).toBe('Weighted TER')
+      expect(labels[1].text()).toBe('Weighted Return')
+      expect(labels[2].text()).toBe('Unique Holdings')
+      expect(labels[3].text()).toBe('Top 10 Concentration')
+    })
+  })
+
+  describe('weighted TER formatting', () => {
+    it('should format weighted TER with 3 decimal places', () => {
+      const wrapper = mount(DiversificationStats, { props: defaultProps })
+      const values = wrapper.findAll('.stat-value')
+      expect(values[0].text()).toBe('0.220%')
+    })
+
+    it('should handle zero TER', () => {
+      const wrapper = mount(DiversificationStats, {
+        props: { ...defaultProps, weightedTer: 0 },
+      })
+      const values = wrapper.findAll('.stat-value')
+      expect(values[0].text()).toBe('0.000%')
+    })
+  })
+
+  describe('weighted annual return formatting', () => {
+    it('should format annual return as percentage', () => {
+      const wrapper = mount(DiversificationStats, { props: defaultProps })
+      const values = wrapper.findAll('.stat-value')
+      expect(values[1].text()).toBe('12.00%')
+    })
+
+    it('should handle negative annual return', () => {
+      const wrapper = mount(DiversificationStats, {
+        props: { ...defaultProps, weightedAnnualReturn: -0.05 },
+      })
+      const values = wrapper.findAll('.stat-value')
+      expect(values[1].text()).toBe('-5.00%')
+    })
+
+    it('should handle zero annual return', () => {
+      const wrapper = mount(DiversificationStats, {
+        props: { ...defaultProps, weightedAnnualReturn: 0 },
+      })
+      const values = wrapper.findAll('.stat-value')
+      expect(values[1].text()).toBe('0.00%')
+    })
+  })
+
+  describe('unique holdings formatting', () => {
+    it('should format unique holdings with locale string', () => {
+      const wrapper = mount(DiversificationStats, { props: defaultProps })
+      const values = wrapper.findAll('.stat-value')
+      expect(values[2].text()).toBe('3,500')
+    })
+
+    it('should handle small number of holdings', () => {
+      const wrapper = mount(DiversificationStats, {
+        props: { ...defaultProps, totalUniqueHoldings: 50 },
+      })
+      const values = wrapper.findAll('.stat-value')
+      expect(values[2].text()).toBe('50')
+    })
+
+    it('should handle zero holdings', () => {
+      const wrapper = mount(DiversificationStats, {
+        props: { ...defaultProps, totalUniqueHoldings: 0 },
+      })
+      const values = wrapper.findAll('.stat-value')
+      expect(values[2].text()).toBe('0')
+    })
+  })
+
+  describe('top 10 concentration formatting', () => {
+    it('should format concentration as percentage', () => {
+      const wrapper = mount(DiversificationStats, { props: defaultProps })
+      const values = wrapper.findAll('.stat-value')
+      expect(values[3].text()).toBe('18.50%')
+    })
+
+    it('should handle high concentration', () => {
+      const wrapper = mount(DiversificationStats, {
+        props: { ...defaultProps, top10Percentage: 75.25 },
+      })
+      const values = wrapper.findAll('.stat-value')
+      expect(values[3].text()).toBe('75.25%')
+    })
+
+    it('should handle zero concentration', () => {
+      const wrapper = mount(DiversificationStats, {
+        props: { ...defaultProps, top10Percentage: 0 },
+      })
+      const values = wrapper.findAll('.stat-value')
+      expect(values[3].text()).toBe('0.00%')
+    })
+  })
+})

--- a/ui/components/diversification/diversification-stats.vue
+++ b/ui/components/diversification/diversification-stats.vue
@@ -1,0 +1,80 @@
+<template>
+  <div class="summary-cards mb-4">
+    <div class="row g-3">
+      <div class="col-md-3 col-6">
+        <div class="stat-card">
+          <div class="stat-label">Weighted TER</div>
+          <div class="stat-value">{{ formatTer(weightedTer, 3) }}</div>
+        </div>
+      </div>
+      <div class="col-md-3 col-6">
+        <div class="stat-card">
+          <div class="stat-label">Weighted Return</div>
+          <div class="stat-value">{{ formatReturn(weightedAnnualReturn) }}</div>
+        </div>
+      </div>
+      <div class="col-md-3 col-6">
+        <div class="stat-card">
+          <div class="stat-label">Unique Holdings</div>
+          <div class="stat-value">{{ totalUniqueHoldings.toLocaleString() }}</div>
+        </div>
+      </div>
+      <div class="col-md-3 col-6">
+        <div class="stat-card">
+          <div class="stat-label">Top 10 Concentration</div>
+          <div class="stat-value">{{ formatPercentage(top10Percentage) }}</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { useDiversificationFormatters } from '../../composables/use-diversification-formatters'
+
+defineProps<{
+  weightedTer: number
+  weightedAnnualReturn: number
+  totalUniqueHoldings: number
+  top10Percentage: number
+}>()
+
+const { formatTer, formatReturn, formatPercentage } = useDiversificationFormatters()
+</script>
+
+<style scoped>
+.stat-card {
+  background: white;
+  border: 1px solid #e0e0e0;
+  padding: 1rem 1.5rem;
+  border-radius: 0.5rem;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  text-align: center;
+}
+
+.stat-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: #6c757d;
+  font-weight: 500;
+  margin-bottom: 0.25rem;
+}
+
+.stat-value {
+  font-size: 1.5rem;
+  font-weight: 700;
+  line-height: 1.2;
+  color: #1a1a1a;
+}
+
+@media (max-width: 768px) {
+  .stat-card {
+    padding: 0.75rem;
+  }
+
+  .stat-value {
+    font-size: 1.25rem;
+  }
+}
+</style>

--- a/ui/components/nav-bar.vue
+++ b/ui/components/nav-bar.vue
@@ -34,6 +34,7 @@ const routes = ref([
   { path: '/instruments', name: 'Instruments' },
   { path: '/transactions', name: 'Transactions' },
   { path: '/etf-breakdown', name: 'ETF Breakdown' },
+  { path: '/diversification', name: 'Diversification' },
 ])
 
 const { data: buildInfo } = useQuery({

--- a/ui/components/portfolio-summary.vue
+++ b/ui/components/portfolio-summary.vue
@@ -173,7 +173,7 @@ const handleRecalculate = async () => {
       'This will delete all current summary data and recalculate it from scratch. This operation may take some time. Continue?',
     confirmText: 'Recalculate',
     cancelText: 'Cancel',
-    confirmClass: 'btn-warning',
+    confirmClass: 'btn-primary',
   })
 
   if (shouldProceed) {

--- a/ui/components/shared/confirm-dialog.test.ts
+++ b/ui/components/shared/confirm-dialog.test.ts
@@ -71,7 +71,7 @@ describe('ConfirmDialog', () => {
 
       expect(wrapper.find('.modal-title').text()).toBe('Confirm')
       expect(wrapper.find('.modal-body p').text()).toBe('Are you sure?')
-      expect(wrapper.find('.btn-secondary').text()).toBe('Cancel')
+      expect(wrapper.find('[data-testid="confirmDialogCancelButton"]').text()).toBe('Cancel')
       expect(wrapper.findAll('button').filter(b => b.text() === 'Confirm')).toHaveLength(1)
     })
 
@@ -86,7 +86,7 @@ describe('ConfirmDialog', () => {
 
       expect(wrapper.find('.modal-title').text()).toBe('Delete Item')
       expect(wrapper.find('.modal-body p').text()).toBe('This action cannot be undone.')
-      expect(wrapper.find('.btn-secondary').text()).toBe('Keep')
+      expect(wrapper.find('[data-testid="confirmDialogCancelButton"]').text()).toBe('Keep')
       expect(wrapper.findAll('button').filter(b => b.text() === 'Delete')).toHaveLength(1)
     })
 
@@ -97,7 +97,7 @@ describe('ConfirmDialog', () => {
       })
 
       const confirmButton = wrapper.findAll('button').filter(b => b.text() === 'Confirm')[0]
-      expect(confirmButton.classes()).toContain('btn-danger')
+      expect(confirmButton.classes()).toContain('danger')
     })
   })
 
@@ -117,7 +117,7 @@ describe('ConfirmDialog', () => {
     it('should emit cancel event when cancel button clicked', async () => {
       const wrapper = createWrapper({ modelValue: true })
 
-      const cancelButton = wrapper.find('.btn-secondary')
+      const cancelButton = wrapper.find('[data-testid="confirmDialogCancelButton"]')
       await cancelButton.trigger('click')
 
       expect(wrapper.emitted('cancel')).toBeTruthy()

--- a/ui/components/shared/confirm-dialog.vue
+++ b/ui/components/shared/confirm-dialog.vue
@@ -21,7 +21,7 @@
         <div class="modal-footer">
           <button
             type="button"
-            class="btn btn-secondary"
+            class="dialog-btn"
             @click="cancel"
             data-testid="confirmDialogCancelButton"
           >
@@ -29,8 +29,11 @@
           </button>
           <button
             type="button"
-            class="btn"
-            :class="confirmClass"
+            class="dialog-btn"
+            :class="{
+              primary: confirmClass === 'btn-primary',
+              danger: confirmClass === 'btn-danger',
+            }"
             @click="confirm"
             data-testid="confirmDialogConfirmButton"
           >

--- a/ui/composables/use-diversification-formatters.test.ts
+++ b/ui/composables/use-diversification-formatters.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from 'vitest'
+import { useDiversificationFormatters } from './use-diversification-formatters'
+
+describe('useDiversificationFormatters', () => {
+  const {
+    formatPrice,
+    formatTer,
+    formatReturn,
+    formatPercentage,
+    formatCurrency,
+    formatRelativeTime,
+  } = useDiversificationFormatters()
+
+  describe('formatPrice', () => {
+    it('should return dash for null value', () => {
+      expect(formatPrice(null)).toBe('-')
+    })
+
+    it('should format positive price with euro symbol', () => {
+      expect(formatPrice(120.5)).toBe('€120.50')
+    })
+
+    it('should format zero price', () => {
+      expect(formatPrice(0)).toBe('€0.00')
+    })
+
+    it('should format price with two decimal places', () => {
+      expect(formatPrice(99.999)).toBe('€100.00')
+    })
+
+    it('should format large price', () => {
+      expect(formatPrice(12345.67)).toBe('€12345.67')
+    })
+  })
+
+  describe('formatTer', () => {
+    it('should return dash for null value', () => {
+      expect(formatTer(null)).toBe('-')
+    })
+
+    it('should format TER with default two decimals', () => {
+      expect(formatTer(0.22)).toBe('0.22%')
+    })
+
+    it('should format TER with custom decimals', () => {
+      expect(formatTer(0.22, 3)).toBe('0.220%')
+    })
+
+    it('should format zero TER', () => {
+      expect(formatTer(0)).toBe('0.00%')
+    })
+
+    it('should format TER with rounding', () => {
+      expect(formatTer(0.225, 2)).toBe('0.23%')
+    })
+  })
+
+  describe('formatReturn', () => {
+    it('should return dash for null value', () => {
+      expect(formatReturn(null)).toBe('-')
+    })
+
+    it('should format positive return as percentage', () => {
+      expect(formatReturn(0.12)).toBe('12.00%')
+    })
+
+    it('should format negative return', () => {
+      expect(formatReturn(-0.05)).toBe('-5.00%')
+    })
+
+    it('should format zero return', () => {
+      expect(formatReturn(0)).toBe('0.00%')
+    })
+
+    it('should format small decimal return', () => {
+      expect(formatReturn(0.0015)).toBe('0.15%')
+    })
+  })
+
+  describe('formatPercentage', () => {
+    it('should format percentage with two decimals', () => {
+      expect(formatPercentage(25.5)).toBe('25.50%')
+    })
+
+    it('should format zero percentage', () => {
+      expect(formatPercentage(0)).toBe('0.00%')
+    })
+
+    it('should format large percentage', () => {
+      expect(formatPercentage(100)).toBe('100.00%')
+    })
+
+    it('should format percentage with rounding', () => {
+      expect(formatPercentage(33.333)).toBe('33.33%')
+    })
+  })
+
+  describe('formatCurrency', () => {
+    it('should format currency with euro symbol', () => {
+      const result = formatCurrency(1000)
+      expect(result).toContain('1,000')
+      expect(result).toContain('€')
+    })
+
+    it('should format zero amount', () => {
+      const result = formatCurrency(0)
+      expect(result).toContain('0')
+    })
+
+    it('should format large amount with thousands separator', () => {
+      const result = formatCurrency(1234567)
+      expect(result).toContain('1,234,567')
+    })
+
+    it('should round to whole numbers', () => {
+      const result = formatCurrency(1500.99)
+      expect(result).toContain('1,501')
+    })
+  })
+
+  describe('formatRelativeTime', () => {
+    it('should return just now for less than 1 minute', () => {
+      const now = Date.now()
+      expect(formatRelativeTime(now - 30000, now)).toBe('just now')
+    })
+
+    it('should return 1 min ago for exactly 1 minute', () => {
+      const now = Date.now()
+      expect(formatRelativeTime(now - 60000, now)).toBe('1 min ago')
+    })
+
+    it('should return minutes ago for less than 1 hour', () => {
+      const now = Date.now()
+      expect(formatRelativeTime(now - 5 * 60000, now)).toBe('5 min ago')
+    })
+
+    it('should return 1 hour ago for exactly 1 hour', () => {
+      const now = Date.now()
+      expect(formatRelativeTime(now - 60 * 60000, now)).toBe('1 hour ago')
+    })
+
+    it('should return hours ago for more than 1 hour', () => {
+      const now = Date.now()
+      expect(formatRelativeTime(now - 3 * 60 * 60000, now)).toBe('3 hours ago')
+    })
+
+    it('should handle edge case at 59 minutes', () => {
+      const now = Date.now()
+      expect(formatRelativeTime(now - 59 * 60000, now)).toBe('59 min ago')
+    })
+  })
+})

--- a/ui/composables/use-diversification-formatters.ts
+++ b/ui/composables/use-diversification-formatters.ts
@@ -1,0 +1,46 @@
+export const useDiversificationFormatters = () => {
+  const formatPrice = (value: number | null): string => {
+    if (value === null) return '-'
+    return `€${value.toFixed(2)}`
+  }
+
+  const formatTer = (value: number | null, decimals: number = 2): string => {
+    if (value === null) return '-'
+    return `${value.toFixed(decimals)}%`
+  }
+
+  const formatReturn = (value: number | null): string => {
+    if (value === null) return '-'
+    return `${(value * 100).toFixed(2)}%`
+  }
+
+  const formatPercentage = (value: number): string => `${value.toFixed(2)}%`
+
+  const formatCurrency = (value: number): string =>
+    new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'EUR',
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    }).format(value)
+
+  const formatRelativeTime = (timestampMs: number, nowMs: number): string => {
+    const diffMs = nowMs - timestampMs
+    const diffMinutes = Math.floor(diffMs / 60000)
+    if (diffMinutes < 1) return 'just now'
+    if (diffMinutes === 1) return '1 min ago'
+    if (diffMinutes < 60) return `${diffMinutes} min ago`
+    const diffHours = Math.floor(diffMinutes / 60)
+    if (diffHours === 1) return '1 hour ago'
+    return `${diffHours} hours ago`
+  }
+
+  return {
+    formatPrice,
+    formatTer,
+    formatReturn,
+    formatPercentage,
+    formatCurrency,
+    formatRelativeTime,
+  }
+}

--- a/ui/constants/api.ts
+++ b/ui/constants/api.ts
@@ -6,6 +6,7 @@ export const API_ENDPOINTS = {
   PORTFOLIO_SUMMARY_CURRENT: '/portfolio-summary/current',
   PORTFOLIO_SUMMARY_RECALCULATE: '/portfolio-summary/recalculate',
   ETF_BREAKDOWN: '/etf-breakdown',
+  DIVERSIFICATION: '/diversification',
   ENUMS: '/enums',
   LOGOS: '/logos',
   CALCULATOR: '/calculator',
@@ -14,4 +15,5 @@ export const API_ENDPOINTS = {
 
 export const REFETCH_INTERVALS = {
   INSTRUMENTS: 2000,
+  DIVERSIFICATION_ETFS: 60 * 60 * 1000,
 } as const

--- a/ui/models/generated/domain-models.ts
+++ b/ui/models/generated/domain-models.ts
@@ -1,5 +1,5 @@
 /* tslint:disable */
-/* eslint-disable */
+ 
 // Generated using typescript-generator (timestamp removed to prevent git churn)
 
 /**
@@ -124,12 +124,70 @@ export interface CalculationResult extends Serializable {
     total: number;
 }
 
+export interface DiversificationCalculatorRequestDto {
+    allocations: AllocationDto[];
+}
+
+export interface DiversificationCalculatorResponseDto extends Serializable {
+    weightedTer: number;
+    weightedAnnualReturn: number;
+    totalUniqueHoldings: number;
+    etfDetails: EtfDetailDto[];
+    holdings: DiversificationHoldingDto[];
+    sectors: DiversificationSectorDto[];
+    countries: DiversificationCountryDto[];
+    concentration: ConcentrationDto;
+}
+
 export interface Serializable {
 }
 
 export interface CashFlow extends Serializable {
     amount: number;
     date: DateAsString;
+}
+
+export interface AllocationDto {
+    instrumentId: number;
+    percentage: number;
+}
+
+export interface EtfDetailDto extends Serializable {
+    instrumentId: number;
+    symbol: string;
+    name: string;
+    allocation: number;
+    ter: number | null;
+    annualReturn: number | null;
+    currentPrice: number | null;
+}
+
+export interface DiversificationHoldingDto extends Serializable {
+    name: string;
+    ticker: string | null;
+    percentage: number;
+    inEtfs: string;
+}
+
+export interface DiversificationSectorDto extends Serializable {
+    sector: string;
+    percentage: number;
+}
+
+export interface DiversificationCountryDto extends Serializable {
+    countryCode: string | null;
+    countryName: string;
+    percentage: number;
+}
+
+export interface ConcentrationDto extends Serializable {
+    top10Percentage: number;
+    largestPosition: LargestPositionDto | null;
+}
+
+export interface LargestPositionDto extends Serializable {
+    name: string;
+    percentage: number;
 }
 
 type DateAsString = string;

--- a/ui/router/index.ts
+++ b/ui/router/index.ts
@@ -4,6 +4,7 @@ import TransactionsView from '../components/transactions/transactions-view.vue'
 import PortfolioSummaryDto from '../components/portfolio-summary.vue'
 import Calculator from '../components/calculator.vue'
 import EtfBreakdown from '../components/etf/etf-breakdown.vue'
+import DiversificationCalculator from '../components/diversification/diversification-calculator.vue'
 
 const routes: Array<RouteRecordRaw> = [
   {
@@ -25,6 +26,11 @@ const routes: Array<RouteRecordRaw> = [
     path: '/etf-breakdown',
     name: 'ETF Breakdown',
     component: EtfBreakdown,
+  },
+  {
+    path: '/diversification',
+    name: 'Diversification',
+    component: DiversificationCalculator,
   },
   {
     path: '/calculator',

--- a/ui/services/diversification-service.test.ts
+++ b/ui/services/diversification-service.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { diversificationService } from './diversification-service'
+import { httpClient } from '../utils/http-client'
+
+vi.mock('../utils/http-client', () => ({
+  httpClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}))
+
+describe('diversificationService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('getAvailableEtfs', () => {
+    it('should fetch available etfs', async () => {
+      const mockEtfs = [
+        {
+          instrumentId: 1,
+          symbol: 'VWCE',
+          name: 'Vanguard FTSE All-World',
+          allocation: 0,
+          ter: 0.22,
+          annualReturn: 0.12,
+          currentPrice: 120.5,
+        },
+        {
+          instrumentId: 2,
+          symbol: 'VUAA',
+          name: 'Vanguard S&P 500',
+          allocation: 0,
+          ter: 0.07,
+          annualReturn: 0.15,
+          currentPrice: 95.3,
+        },
+      ]
+      vi.mocked(httpClient.get).mockResolvedValueOnce({ data: mockEtfs })
+
+      const result = await diversificationService.getAvailableEtfs()
+
+      expect(httpClient.get).toHaveBeenCalledWith('/diversification/available-etfs')
+      expect(result).toEqual(mockEtfs)
+    })
+
+    it('should handle empty response', async () => {
+      vi.mocked(httpClient.get).mockResolvedValueOnce({ data: [] })
+
+      const result = await diversificationService.getAvailableEtfs()
+
+      expect(httpClient.get).toHaveBeenCalledWith('/diversification/available-etfs')
+      expect(result).toEqual([])
+    })
+
+    it('should propagate errors', async () => {
+      const error = new Error('Network error')
+      vi.mocked(httpClient.get).mockRejectedValueOnce(error)
+
+      await expect(diversificationService.getAvailableEtfs()).rejects.toThrow('Network error')
+    })
+  })
+
+  describe('calculate', () => {
+    it('should calculate diversification with single allocation', async () => {
+      const allocations = [{ instrumentId: 1, percentage: 100 }]
+      const mockResponse = {
+        weightedTer: 0.22,
+        weightedAnnualReturn: 0.12,
+        totalUniqueHoldings: 3500,
+        etfDetails: [
+          {
+            instrumentId: 1,
+            symbol: 'VWCE',
+            name: 'Vanguard FTSE All-World',
+            allocation: 100,
+            ter: 0.22,
+            annualReturn: 0.12,
+            currentPrice: 120.5,
+          },
+        ],
+        holdings: [
+          { name: 'Apple Inc', ticker: 'AAPL', percentage: 5.5, inEtfs: 'VWCE' },
+          { name: 'Microsoft Corp', ticker: 'MSFT', percentage: 4.8, inEtfs: 'VWCE' },
+        ],
+        sectors: [
+          { sector: 'Technology', percentage: 25.5 },
+          { sector: 'Financials', percentage: 15.2 },
+        ],
+        countries: [
+          { countryCode: 'US', countryName: 'United States', percentage: 60.5 },
+          { countryCode: 'JP', countryName: 'Japan', percentage: 6.2 },
+        ],
+        concentration: {
+          top10Percentage: 18.5,
+          largestPosition: { name: 'Apple Inc', percentage: 5.5 },
+        },
+      }
+      vi.mocked(httpClient.post).mockResolvedValueOnce({ data: mockResponse })
+
+      const result = await diversificationService.calculate(allocations)
+
+      expect(httpClient.post).toHaveBeenCalledWith('/diversification/calculate', { allocations })
+      expect(result).toEqual(mockResponse)
+    })
+
+    it('should calculate diversification with multiple allocations', async () => {
+      const allocations = [
+        { instrumentId: 1, percentage: 60 },
+        { instrumentId: 2, percentage: 40 },
+      ]
+      const mockResponse = {
+        weightedTer: 0.16,
+        weightedAnnualReturn: 0.132,
+        totalUniqueHoldings: 4000,
+        etfDetails: [
+          {
+            instrumentId: 1,
+            symbol: 'VWCE',
+            name: 'Vanguard FTSE All-World',
+            allocation: 60,
+            ter: 0.22,
+            annualReturn: 0.12,
+            currentPrice: 120.5,
+          },
+          {
+            instrumentId: 2,
+            symbol: 'VUAA',
+            name: 'Vanguard S&P 500',
+            allocation: 40,
+            ter: 0.07,
+            annualReturn: 0.15,
+            currentPrice: 95.3,
+          },
+        ],
+        holdings: [],
+        sectors: [],
+        countries: [],
+        concentration: {
+          top10Percentage: 20.0,
+          largestPosition: null,
+        },
+      }
+      vi.mocked(httpClient.post).mockResolvedValueOnce({ data: mockResponse })
+
+      const result = await diversificationService.calculate(allocations)
+
+      expect(httpClient.post).toHaveBeenCalledWith('/diversification/calculate', { allocations })
+      expect(result.weightedTer).toBe(0.16)
+      expect(result.etfDetails).toHaveLength(2)
+    })
+
+    it('should handle empty allocations', async () => {
+      const allocations: { instrumentId: number; percentage: number }[] = []
+      const mockResponse = {
+        weightedTer: 0,
+        weightedAnnualReturn: 0,
+        totalUniqueHoldings: 0,
+        etfDetails: [],
+        holdings: [],
+        sectors: [],
+        countries: [],
+        concentration: {
+          top10Percentage: 0,
+          largestPosition: null,
+        },
+      }
+      vi.mocked(httpClient.post).mockResolvedValueOnce({ data: mockResponse })
+
+      const result = await diversificationService.calculate(allocations)
+
+      expect(httpClient.post).toHaveBeenCalledWith('/diversification/calculate', { allocations })
+      expect(result.totalUniqueHoldings).toBe(0)
+    })
+
+    it('should propagate errors on calculate', async () => {
+      const error = new Error('Calculation failed')
+      vi.mocked(httpClient.post).mockRejectedValueOnce(error)
+
+      await expect(
+        diversificationService.calculate([{ instrumentId: 1, percentage: 100 }])
+      ).rejects.toThrow('Calculation failed')
+    })
+
+    it('should handle server validation errors', async () => {
+      const error = new Error('Invalid allocation percentages')
+      vi.mocked(httpClient.post).mockRejectedValueOnce(error)
+
+      await expect(
+        diversificationService.calculate([{ instrumentId: -1, percentage: 150 }])
+      ).rejects.toThrow('Invalid allocation percentages')
+    })
+  })
+})

--- a/ui/services/diversification-service.ts
+++ b/ui/services/diversification-service.ts
@@ -1,0 +1,21 @@
+import { httpClient } from '../utils/http-client'
+import type {
+  AllocationDto,
+  DiversificationCalculatorResponseDto,
+  EtfDetailDto,
+} from '../models/generated/domain-models'
+import { API_ENDPOINTS } from '../constants'
+
+export const diversificationService = {
+  getAvailableEtfs: () =>
+    httpClient
+      .get<EtfDetailDto[]>(`${API_ENDPOINTS.DIVERSIFICATION}/available-etfs`)
+      .then(res => res.data),
+
+  calculate: (allocations: AllocationDto[]) =>
+    httpClient
+      .post<DiversificationCalculatorResponseDto>(`${API_ENDPOINTS.DIVERSIFICATION}/calculate`, {
+        allocations,
+      })
+      .then(res => res.data),
+}

--- a/ui/styles/_dialog.scss
+++ b/ui/styles/_dialog.scss
@@ -1,0 +1,52 @@
+.dialog-btn {
+  padding: 0.5rem 1rem;
+  border: 1px solid #e2e8f0;
+  background: white;
+  color: #6b7280;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.12s ease;
+  white-space: nowrap;
+
+  &:hover:not(:disabled) {
+    background: #f8fafc;
+    border-color: #cbd5e1;
+    color: #4b5563;
+  }
+
+  &:active:not(:disabled) {
+    background: #f1f5f9;
+    transform: scale(0.98);
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  &.primary {
+    background: #4b5563;
+    color: white;
+    border-color: #4b5563;
+
+    &:hover:not(:disabled) {
+      background: #374151;
+      border-color: #374151;
+      color: white;
+    }
+  }
+
+  &.danger {
+    background: #dc2626;
+    color: white;
+    border-color: #dc2626;
+
+    &:hover:not(:disabled) {
+      background: #b91c1c;
+      border-color: #b91c1c;
+      color: white;
+    }
+  }
+}

--- a/ui/styles/main.scss
+++ b/ui/styles/main.scss
@@ -7,3 +7,4 @@
 @import 'framework/bootstrap';
 @import 'app';
 @import 'modern-enhancements';
+@import 'dialog';


### PR DESCRIPTION
## Summary

- Add diversification calculator to plan ETF portfolio allocations
- Calculate weighted TER and weighted annual return based on allocation percentages
- Show combined holdings breakdown across selected ETFs
- Display sector and geographic distribution
- Show concentration metrics (top 10 holdings percentage)

Closes #1226

## Test plan

- [ ] Navigate to `/diversification` route
- [ ] Select multiple ETFs from the dropdown
- [ ] Enter allocation percentages (should sum to 100%)
- [ ] Verify weighted TER and annual return calculations
- [ ] Verify holdings, sectors, and countries tables show aggregated data
- [ ] Test amount input mode (toggle to EUR amounts)
- [ ] Run all backend tests: `./gradlew test`
- [ ] Run all frontend tests: `npm test`