### PR TITLE
Add platform-aware rebalancing to diversification calculator

### DIFF
--- a/src/main/kotlin/ee/tenman/portfolio/domain/DiversificationConfigData.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/domain/DiversificationConfigData.kt
@@ -3,4 +3,7 @@ package ee.tenman.portfolio.domain
 data class DiversificationConfigData(
   val allocations: List<DiversificationAllocationData>,
   val inputMode: InputMode,
+  val selectedPlatform: String? = null,
+  val optimizeEnabled: Boolean = false,
+  val totalInvestment: Double = 0.0,
 )

--- a/src/main/kotlin/ee/tenman/portfolio/dto/DiversificationConfigDto.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/dto/DiversificationConfigDto.kt
@@ -11,6 +11,9 @@ data class DiversificationConfigDto(
   val allocations: List<DiversificationConfigAllocationDto>,
   @field:Pattern(regexp = "percentage|amount", message = "Input mode must be 'percentage' or 'amount'")
   val inputMode: String,
+  val selectedPlatform: String? = null,
+  val optimizeEnabled: Boolean = false,
+  val totalInvestment: Double = 0.0,
 ) : Serializable {
   companion object {
     private const val serialVersionUID: Long = 1L

--- a/src/main/kotlin/ee/tenman/portfolio/service/diversification/DiversificationConfigService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/service/diversification/DiversificationConfigService.kt
@@ -35,6 +35,9 @@ class DiversificationConfigService(
     DiversificationConfigDto(
       allocations = configData.allocations.map { it.toDto() },
       inputMode = configData.inputMode.name.lowercase(),
+      selectedPlatform = configData.selectedPlatform,
+      optimizeEnabled = configData.optimizeEnabled,
+      totalInvestment = configData.totalInvestment,
     )
 
   private fun DiversificationAllocationData.toDto() =
@@ -47,6 +50,9 @@ class DiversificationConfigService(
     DiversificationConfigData(
       allocations = allocations.map { it.toAllocationData() },
       inputMode = InputMode.fromString(inputMode),
+      selectedPlatform = selectedPlatform,
+      optimizeEnabled = optimizeEnabled,
+      totalInvestment = totalInvestment,
     )
 
   private fun DiversificationConfigAllocationDto.toAllocationData() =

--- a/ui/components/diversification/allocation-table.vue
+++ b/ui/components/diversification/allocation-table.vue
@@ -25,8 +25,27 @@
         </div>
       </div>
       <div v-if="inputMode === 'percentage'" class="investment-row">
+        <div v-if="availablePlatforms.length > 0" class="platform-selector">
+          <label class="d-none d-md-inline">Platform</label>
+          <select
+            class="form-select form-select-sm"
+            :value="selectedPlatform ?? ''"
+            @change="onPlatformChange"
+          >
+            <option value="">All platforms</option>
+            <option v-for="p in availablePlatforms" :key="p" :value="p">
+              {{ formatPlatformName(p) }}
+            </option>
+          </select>
+        </div>
+        <div v-if="showRebalanceColumns" class="current-holdings">
+          <label class="d-none d-md-inline">Current</label>
+          <span class="holdings-value">€{{ currentHoldingsTotal.toFixed(2) }}</span>
+        </div>
         <div class="total-investment-input">
-          <label class="d-none d-md-inline">Total to invest</label>
+          <label class="d-none d-md-inline">
+            {{ showRebalanceColumns ? 'New investment' : 'Total to invest' }}
+          </label>
           <div class="input-group input-group-sm">
             <span class="input-group-text">€</span>
             <input
@@ -43,9 +62,10 @@
         <div v-if="showInvestmentColumns" class="optimize-toggle">
           <input
             id="optimizeAllocation"
-            v-model="optimizeEnabled"
+            :checked="optimizeEnabled"
             type="checkbox"
             class="form-check-input"
+            @change="emit('update:optimizeEnabled', ($event.target as HTMLInputElement).checked)"
           />
           <label for="optimizeAllocation" class="form-check-label">Optimize</label>
         </div>
@@ -62,12 +82,27 @@
         :input-mode="inputMode"
         :total-investment="totalInvestment"
         :disable-remove="allocations.length <= 1"
+        :show-rebalance-mode="!!showRebalanceColumns"
+        :is-buy="showRebalanceColumns ? getRebalanceData(allocation).isBuy : true"
         :computed-units="
-          getUnits(allocation.instrumentId, allocation.value, getEtfPrice(allocation.instrumentId))
+          showRebalanceColumns
+            ? getRebalanceData(allocation).units
+            : getUnits(
+                allocation.instrumentId,
+                allocation.value,
+                getEtfPrice(allocation.instrumentId)
+              )
         "
         :computed-unused="
-          getUnused(allocation.instrumentId, allocation.value, getEtfPrice(allocation.instrumentId))
+          showRebalanceColumns
+            ? undefined
+            : getUnused(
+                allocation.instrumentId,
+                allocation.value,
+                getEtfPrice(allocation.instrumentId)
+              )
         "
+        :after-percent="showRebalanceColumns ? getAfterPercent(allocation) : undefined"
         @update:allocation="updateAllocationAtIndex(index, $event)"
         @remove="$emit('remove', index)"
       />
@@ -78,30 +113,125 @@
       <table class="table table-sm allocation-table">
         <thead>
           <tr>
-            <th>ETF</th>
-            <th>Name</th>
-            <th>Price</th>
-            <th>TER</th>
-            <th>Annual Return</th>
-            <th style="width: 150px">
-              {{ inputMode === 'percentage' ? 'Allocation %' : 'Amount EUR' }}
+            <th class="sortable" @click="toggleSort('symbol')">
+              <span class="th-content">
+                ETF
+                <span class="sort-indicator" :class="getSortIndicatorClass('symbol')">
+                  <i class="sort-arrow-up">▲</i>
+                  <i class="sort-arrow-down">▼</i>
+                </span>
+              </span>
             </th>
-            <th v-if="showInvestmentColumns" style="width: 70px">Units</th>
-            <th v-if="showInvestmentColumns" style="width: 90px">Unused</th>
+            <th class="sortable" @click="toggleSort('name')">
+              <span class="th-content">
+                Name
+                <span class="sort-indicator" :class="getSortIndicatorClass('name')">
+                  <i class="sort-arrow-up">▲</i>
+                  <i class="sort-arrow-down">▼</i>
+                </span>
+              </span>
+            </th>
+            <th class="sortable" @click="toggleSort('price')">
+              <span class="th-content">
+                Price
+                <span class="sort-indicator" :class="getSortIndicatorClass('price')">
+                  <i class="sort-arrow-up">▲</i>
+                  <i class="sort-arrow-down">▼</i>
+                </span>
+              </span>
+            </th>
+            <th class="sortable" @click="toggleSort('ter')">
+              <span class="th-content">
+                TER
+                <span class="sort-indicator" :class="getSortIndicatorClass('ter')">
+                  <i class="sort-arrow-up">▲</i>
+                  <i class="sort-arrow-down">▼</i>
+                </span>
+              </span>
+            </th>
+            <th class="sortable" @click="toggleSort('annualReturn')">
+              <span class="th-content">
+                Annual Return
+                <span class="sort-indicator" :class="getSortIndicatorClass('annualReturn')">
+                  <i class="sort-arrow-up">▲</i>
+                  <i class="sort-arrow-down">▼</i>
+                </span>
+              </span>
+            </th>
+            <th
+              v-if="showRebalanceColumns"
+              class="sortable"
+              style="width: 130px"
+              @click="toggleSort('currentPercent')"
+            >
+              <span class="th-content">
+                Current
+                <span class="sort-indicator" :class="getSortIndicatorClass('currentPercent')">
+                  <i class="sort-arrow-up">▲</i>
+                  <i class="sort-arrow-down">▼</i>
+                </span>
+              </span>
+            </th>
+            <th class="sortable" style="width: 150px" @click="toggleSort('value')">
+              <span class="th-content">
+                {{
+                  inputMode === 'percentage'
+                    ? showRebalanceColumns
+                      ? 'Target %'
+                      : 'Allocation %'
+                    : 'Amount EUR'
+                }}
+                <span class="sort-indicator" :class="getSortIndicatorClass('value')">
+                  <i class="sort-arrow-up">▲</i>
+                  <i class="sort-arrow-down">▼</i>
+                </span>
+              </span>
+            </th>
+            <th
+              v-if="showInvestmentColumns || showRebalanceActionColumn"
+              class="sortable"
+              style="width: 90px"
+              @click="toggleSort('units')"
+            >
+              <span class="th-content">
+                {{ showRebalanceColumns ? 'Action' : 'Units' }}
+                <span class="sort-indicator" :class="getSortIndicatorClass('units')">
+                  <i class="sort-arrow-up">▲</i>
+                  <i class="sort-arrow-down">▼</i>
+                </span>
+              </span>
+            </th>
+            <th
+              v-if="showInvestmentColumns || showRebalanceActionColumn"
+              class="sortable"
+              style="width: 90px"
+              @click="toggleSort('afterPercent')"
+            >
+              <span class="th-content">
+                {{ showRebalanceColumns ? 'After %' : 'Unused' }}
+                <span class="sort-indicator" :class="getSortIndicatorClass('afterPercent')">
+                  <i class="sort-arrow-up">▲</i>
+                  <i class="sort-arrow-down">▼</i>
+                </span>
+              </span>
+            </th>
             <th style="width: 50px"></th>
           </tr>
         </thead>
         <tbody>
-          <tr v-for="(allocation, index) in allocations" :key="index">
+          <tr
+            v-for="allocation in sortedAllocations"
+            :key="allocation.instrumentId || getOriginalIndex(allocation)"
+          >
             <td>
               <select
                 :value="allocation.instrumentId"
                 class="form-select form-select-sm"
-                @change="onInstrumentChange(index, $event)"
+                @change="onInstrumentChange(getOriginalIndex(allocation), $event)"
               >
                 <option :value="0" disabled>Select ETF</option>
                 <option
-                  v-for="etf in availableEtfsForRow(index)"
+                  v-for="etf in availableEtfsForRow(getOriginalIndex(allocation))"
                   :key="etf.instrumentId"
                   :value="etf.instrumentId"
                 >
@@ -117,6 +247,12 @@
             <td class="text-muted small">
               {{ formatReturn(getEtfReturn(allocation.instrumentId)) }}
             </td>
+            <td v-if="showRebalanceColumns" class="text-muted small">
+              €{{ (allocation.currentValue ?? 0).toFixed(2) }}
+              <span class="current-percent">
+                ({{ getRebalanceData(allocation).currentPercent.toFixed(1) }}%)
+              </span>
+            </td>
             <td>
               <input
                 :value="allocation.value"
@@ -125,26 +261,43 @@
                 min="0"
                 :max="inputMode === 'percentage' ? 100 : undefined"
                 :step="inputMode === 'percentage' ? 1 : 100"
-                @input="onValueChange(index, $event)"
+                @input="onValueChange(getOriginalIndex(allocation), $event)"
               />
             </td>
-            <td v-if="showInvestmentColumns" class="text-muted small">
-              {{
-                formatUnits(
-                  allocation.instrumentId,
-                  allocation.value,
-                  getEtfPrice(allocation.instrumentId)
-                )
-              }}
+            <td v-if="showInvestmentColumns || showRebalanceActionColumn" class="small">
+              <template v-if="showRebalanceColumns">
+                <span
+                  v-if="getRebalanceData(allocation).units > 0"
+                  :class="getRebalanceData(allocation).isBuy ? 'text-success' : 'text-danger'"
+                >
+                  {{ getRebalanceData(allocation).isBuy ? 'Buy' : 'Sell' }}
+                  {{ getRebalanceData(allocation).units }}
+                </span>
+                <span v-else class="text-muted">-</span>
+              </template>
+              <template v-else>
+                {{
+                  formatUnits(
+                    allocation.instrumentId,
+                    allocation.value,
+                    getEtfPrice(allocation.instrumentId)
+                  )
+                }}
+              </template>
             </td>
-            <td v-if="showInvestmentColumns" class="text-muted small">
-              {{
-                formatUnused(
-                  allocation.instrumentId,
-                  allocation.value,
-                  getEtfPrice(allocation.instrumentId)
-                )
-              }}
+            <td v-if="showInvestmentColumns || showRebalanceActionColumn" class="text-muted small">
+              <template v-if="showRebalanceColumns">
+                {{ getAfterPercent(allocation).toFixed(1) }}%
+              </template>
+              <template v-else>
+                {{
+                  formatUnused(
+                    allocation.instrumentId,
+                    allocation.value,
+                    getEtfPrice(allocation.instrumentId)
+                  )
+                }}
+              </template>
             </td>
             <td>
               <button
@@ -152,7 +305,7 @@
                 class="remove-btn"
                 aria-label="Remove allocation"
                 :disabled="allocations.length <= 1"
-                @click="$emit('remove', index)"
+                @click="$emit('remove', getOriginalIndex(allocation))"
               >
                 &times;
               </button>
@@ -238,7 +391,7 @@
             </span>
           </span>
         </div>
-        <div v-if="showInvestmentColumns" class="total-row">
+        <div v-if="showInvestmentColumns || showRebalanceActionColumn" class="total-row">
           <span class="total-label">Total Unused</span>
           <span class="total-value text-muted">€{{ totalUnused.toFixed(2) }}</span>
         </div>
@@ -249,11 +402,23 @@
 
 <script lang="ts" setup>
 import { computed } from 'vue'
-import { useLocalStorage } from '@vueuse/core'
 import { formatTer, formatReturn, formatCurrencyWithSymbol } from '../../utils/formatters'
+import { formatPlatformName } from '../../utils/platform-utils'
+import { useSortableTable } from '../../composables/use-sortable-table'
 import AllocationCard from './allocation-card.vue'
 import type { EtfDetailDto } from '../../models/generated/domain-models'
 import type { AllocationInput } from './types'
+
+interface AllocationWithData extends AllocationInput {
+  symbol: string
+  name: string
+  price: number | null
+  ter: number | null
+  annualReturn: number | null
+  currentPercent: number
+  units: number
+  afterPercent: number
+}
 
 const props = defineProps<{
   allocations: AllocationInput[]
@@ -261,12 +426,18 @@ const props = defineProps<{
   availableEtfs: EtfDetailDto[]
   isLoadingPortfolio: boolean
   totalInvestment: number
+  selectedPlatform: string | null
+  availablePlatforms: string[]
+  currentHoldingsTotal: number
+  optimizeEnabled: boolean
 }>()
 
 const emit = defineEmits<{
   'update:inputMode': ['percentage' | 'amount']
   'update:allocation': [index: number, allocation: AllocationInput]
   'update:totalInvestment': [value: number]
+  'update:selectedPlatform': [value: string | null]
+  'update:optimizeEnabled': [value: boolean]
   add: []
   remove: [index: number]
   clear: []
@@ -296,23 +467,166 @@ const availableEtfsForRow = (rowIndex: number) => {
   return props.availableEtfs.filter(etf => !selectedIds.includes(etf.instrumentId))
 }
 
-const getEtfName = (instrumentId: number): string =>
-  props.availableEtfs.find(e => e.instrumentId === instrumentId)?.name || ''
+const findEtf = (instrumentId: number) =>
+  props.availableEtfs.find(e => e.instrumentId === instrumentId)
 
-const getEtfTer = (instrumentId: number): number | null =>
-  props.availableEtfs.find(e => e.instrumentId === instrumentId)?.ter ?? null
-
-const getEtfReturn = (instrumentId: number): number | null =>
-  props.availableEtfs.find(e => e.instrumentId === instrumentId)?.annualReturn ?? null
-
-const getEtfPrice = (instrumentId: number): number | null =>
-  props.availableEtfs.find(e => e.instrumentId === instrumentId)?.currentPrice ?? null
+const getEtfName = (instrumentId: number) => findEtf(instrumentId)?.name || ''
+const getEtfTer = (instrumentId: number) => findEtf(instrumentId)?.ter ?? null
+const getEtfReturn = (instrumentId: number) => findEtf(instrumentId)?.annualReturn ?? null
+const getEtfPrice = (instrumentId: number) => findEtf(instrumentId)?.currentPrice ?? null
+const getEtfSymbol = (instrumentId: number) => findEtf(instrumentId)?.symbol || ''
 
 const showInvestmentColumns = computed(
   () => props.inputMode === 'percentage' && props.totalInvestment > 0
 )
 
-const optimizeEnabled = useLocalStorage('diversification-optimize', false)
+const showRebalanceColumns = computed(() => !!props.selectedPlatform)
+
+const showRebalanceActionColumn = computed(
+  () => showRebalanceColumns.value && (props.totalInvestment > 0 || props.currentHoldingsTotal > 0)
+)
+
+const allocationsWithData = computed<AllocationWithData[]>(() =>
+  props.allocations.map(a => {
+    const base = getBaseRebalanceData(a)
+    return {
+      ...a,
+      symbol: getEtfSymbol(a.instrumentId),
+      name: getEtfName(a.instrumentId),
+      price: getEtfPrice(a.instrumentId),
+      ter: getEtfTer(a.instrumentId),
+      annualReturn: getEtfReturn(a.instrumentId),
+      currentPercent: base.currentPercent,
+      units: base.units,
+      afterPercent: getAfterPercentForSort(a),
+    }
+  })
+)
+
+const { sortedItems, sortState, toggleSort } = useSortableTable(
+  allocationsWithData,
+  undefined,
+  'asc'
+)
+
+const sortedAllocations = computed(() =>
+  sortedItems.value.map(item => {
+    const original = props.allocations.find(a => a.instrumentId === item.instrumentId)
+    return original ?? item
+  })
+)
+
+const getSortIndicatorClass = (key: string) => ({
+  active: sortState.value.key === key,
+  asc: sortState.value.key === key && sortState.value.direction === 'asc',
+  desc: sortState.value.key === key && sortState.value.direction === 'desc',
+})
+
+const getOriginalIndex = (allocation: AllocationInput): number =>
+  props.allocations.findIndex(a => a.instrumentId === allocation.instrumentId || a === allocation)
+
+const getBaseRebalanceData = (allocation: AllocationInput) => {
+  const price = getEtfPrice(allocation.instrumentId)
+  const currentValue = allocation.currentValue ?? 0
+  const currentPercent =
+    props.currentHoldingsTotal > 0 ? (currentValue / props.currentHoldingsTotal) * 100 : 0
+  const targetPortfolio = props.currentHoldingsTotal + props.totalInvestment
+  const targetValue = (targetPortfolio * allocation.value) / 100
+  const difference = targetValue - currentValue
+  const isBuy = difference >= 0
+  const absoluteDifference = Math.abs(difference)
+  const units = price && price > 0 ? Math.floor(absoluteDifference / price) : 0
+  const actualAmount = units * (price ?? 0)
+  const unused = absoluteDifference - actualAmount
+  return { currentValue, currentPercent, targetValue, difference, isBuy, units, unused, price }
+}
+
+type RebalanceData = ReturnType<typeof getBaseRebalanceData>
+
+const calcAfterValue = (allocation: AllocationInput, data: RebalanceData): number => {
+  const currentValue = allocation.currentValue ?? 0
+  const tradeValue = data.units * (data.price ?? 0)
+  return data.isBuy ? currentValue + tradeValue : currentValue - tradeValue
+}
+
+const calcTotalAfterValue = (getData: (a: AllocationInput) => RebalanceData) =>
+  props.allocations.reduce((sum, a) => sum + calcAfterValue(a, getData(a)), 0)
+
+const totalAfterValueForSort = computed(() => calcTotalAfterValue(getBaseRebalanceData))
+
+const getAfterPercentForSort = (allocation: AllocationInput): number => {
+  if (totalAfterValueForSort.value <= 0) return 0
+  const afterValue = calcAfterValue(allocation, getBaseRebalanceData(allocation))
+  return (afterValue / totalAfterValueForSort.value) * 100
+}
+
+const onPlatformChange = (event: Event) => {
+  const target = event.target as HTMLSelectElement
+  emit('update:selectedPlatform', target.value || null)
+}
+
+const getRebalanceData = (allocation: AllocationInput): RebalanceData => {
+  const base = getBaseRebalanceData(allocation)
+  if (!props.optimizeEnabled || !optimizedRebalance.value.has(allocation.instrumentId)) {
+    return base
+  }
+  const optimized = optimizedRebalance.value.get(allocation.instrumentId)!
+  const actualAmount = optimized.units * (base.price ?? 0)
+  const unused = Math.abs(base.difference) - actualAmount
+  return { ...base, units: optimized.units, isBuy: optimized.isBuy, unused: Math.max(0, unused) }
+}
+
+const totalAfterValue = computed(() => calcTotalAfterValue(getRebalanceData))
+
+const getAfterPercent = (allocation: AllocationInput): number => {
+  if (totalAfterValue.value <= 0) return 0
+  const afterValue = calcAfterValue(allocation, getRebalanceData(allocation))
+  return (afterValue / totalAfterValue.value) * 100
+}
+
+const optimizedRebalanceResult = computed(() => {
+  const emptyResult = {
+    allocations: new Map<number, { units: number; isBuy: boolean }>(),
+    totalRemaining: 0,
+  }
+  if (!showRebalanceColumns.value || !props.optimizeEnabled) {
+    return emptyResult
+  }
+  const validAllocations = props.allocations.filter(a => a.instrumentId > 0 && a.value > 0)
+  if (validAllocations.length === 0) return emptyResult
+  const buyAllocations = validAllocations
+    .map(a => ({ ...getBaseRebalanceData(a), id: a.instrumentId }))
+    .filter(d => d.isBuy && d.difference > 0)
+  if (buyAllocations.length === 0) {
+    const result = new Map(
+      validAllocations.map(a => {
+        const base = getBaseRebalanceData(a)
+        return [a.instrumentId, { units: base.units, isBuy: base.isBuy }]
+      })
+    )
+    return { allocations: result, totalRemaining: 0 }
+  }
+  let totalUnused = buyAllocations.reduce((sum, d) => sum + d.unused, 0)
+  const result = new Map(
+    validAllocations.map(a => {
+      const base = getBaseRebalanceData(a)
+      return [a.instrumentId, { units: base.units, isBuy: base.isBuy }]
+    })
+  )
+  const sortedByRemainder = [...buyAllocations]
+    .filter(d => d.price && d.price > 0)
+    .sort((a, b) => b.unused - a.unused)
+  for (const fund of sortedByRemainder) {
+    if (fund.price && fund.price <= totalUnused) {
+      const current = result.get(fund.id)!
+      result.set(fund.id, { ...current, units: current.units + 1 })
+      totalUnused -= fund.price
+    }
+  }
+  return { allocations: result, totalRemaining: Math.max(0, totalUnused) }
+})
+
+const optimizedRebalance = computed(() => optimizedRebalanceResult.value.allocations)
 
 const calculateBaseInvestment = (percentage: number, price: number | null) => {
   if (!percentage || !price || price <= 0 || props.totalInvestment <= 0) {
@@ -325,7 +639,7 @@ const calculateBaseInvestment = (percentage: number, price: number | null) => {
 }
 
 const optimizedAllocation = computed(() => {
-  if (!showInvestmentColumns.value || !optimizeEnabled.value) return new Map<number, number>()
+  if (!showInvestmentColumns.value || !props.optimizeEnabled) return new Map<number, number>()
   const validAllocations = props.allocations.filter(a => a.instrumentId > 0 && a.value > 0)
   if (validAllocations.length === 0) return new Map<number, number>()
   const fundData = validAllocations.map(allocation => {
@@ -385,7 +699,7 @@ const optimizedAllocation = computed(() => {
 })
 
 const getUnits = (instrumentId: number, percentage: number, price: number | null): number => {
-  if (optimizeEnabled.value && optimizedAllocation.value.has(instrumentId)) {
+  if (props.optimizeEnabled && optimizedAllocation.value.has(instrumentId)) {
     return optimizedAllocation.value.get(instrumentId) ?? 0
   }
   return calculateBaseInvestment(percentage, price).units
@@ -411,7 +725,16 @@ const formatUnused = (instrumentId: number, percentage: number, price: number | 
 }
 
 const totalUnused = computed(() => {
-  if (!showInvestmentColumns.value) return 0
+  if (!showInvestmentColumns.value && !showRebalanceActionColumn.value) return 0
+  if (showRebalanceColumns.value && props.optimizeEnabled) {
+    return optimizedRebalanceResult.value.totalRemaining
+  }
+  if (showRebalanceColumns.value) {
+    return props.allocations.reduce((sum, allocation) => {
+      const data = getRebalanceData(allocation)
+      return sum + (data.units > 0 ? data.unused : 0)
+    }, 0)
+  }
   return props.allocations.reduce((sum, allocation) => {
     const price = getEtfPrice(allocation.instrumentId)
     const unused = getUnused(allocation.instrumentId, allocation.value, price)
@@ -474,6 +797,56 @@ const onTotalInvestmentChange = (event: Event) => {
 
 .allocation-table {
   margin-bottom: 1rem;
+}
+
+.allocation-table th.sortable {
+  cursor: pointer;
+  user-select: none;
+}
+
+.allocation-table th.sortable:hover {
+  background-color: var(--bs-gray-100);
+}
+
+.th-content {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.sort-indicator {
+  display: inline-flex;
+  flex-direction: column;
+  font-size: 0.5rem;
+  line-height: 1;
+  opacity: 0.3;
+  margin-left: 0.25rem;
+}
+
+.sort-indicator.active {
+  opacity: 1;
+}
+
+.sort-indicator .sort-arrow-up,
+.sort-indicator .sort-arrow-down {
+  display: block;
+  transition: opacity 0.15s ease;
+}
+
+.sort-indicator.asc .sort-arrow-up {
+  opacity: 1;
+}
+
+.sort-indicator.asc .sort-arrow-down {
+  opacity: 0.3;
+}
+
+.sort-indicator.desc .sort-arrow-up {
+  opacity: 0.3;
+}
+
+.sort-indicator.desc .sort-arrow-down {
+  opacity: 1;
 }
 
 .allocation-table th {
@@ -624,6 +997,46 @@ const onTotalInvestmentChange = (event: Event) => {
   border-color: var(--bs-gray-700);
 }
 
+.platform-selector {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.platform-selector label {
+  font-size: 0.75rem;
+  color: var(--bs-gray-600);
+  white-space: nowrap;
+}
+
+.platform-selector .form-select {
+  width: 130px;
+  font-size: 0.875rem;
+}
+
+.current-holdings {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.current-holdings label {
+  font-size: 0.75rem;
+  color: var(--bs-gray-600);
+  white-space: nowrap;
+}
+
+.holdings-value {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--bs-gray-800);
+}
+
+.current-percent {
+  color: var(--bs-gray-500);
+  margin-left: 0.25rem;
+}
+
 .total-investment-input {
   display: flex;
   align-items: center;
@@ -710,12 +1123,39 @@ const onTotalInvestmentChange = (event: Event) => {
   }
 
   .investment-row {
-    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+  }
+
+  .platform-selector {
+    flex: 1;
+    min-width: 120px;
+  }
+
+  .platform-selector .form-select {
+    width: 100%;
+  }
+
+  .current-holdings {
+    flex-shrink: 0;
+  }
+
+  .current-holdings .holdings-value {
+    font-size: 0.8125rem;
+  }
+
+  .total-investment-input {
+    flex: 1;
+    min-width: 100px;
   }
 
   .total-investment-input .input-group {
-    min-width: 140px;
+    width: 100%;
     flex-wrap: nowrap;
+  }
+
+  .optimize-toggle {
+    flex-shrink: 0;
   }
 
   .allocation-footer {
@@ -729,6 +1169,31 @@ const onTotalInvestmentChange = (event: Event) => {
 
   .total-row {
     justify-content: center;
+  }
+}
+
+@media (max-width: 480px) {
+  .investment-row {
+    gap: 0.5rem;
+  }
+
+  .platform-selector {
+    flex-basis: calc(50% - 0.25rem);
+    min-width: 0;
+  }
+
+  .current-holdings {
+    flex-basis: calc(50% - 0.25rem);
+    justify-content: flex-end;
+  }
+
+  .total-investment-input {
+    flex-basis: calc(70% - 0.25rem);
+  }
+
+  .optimize-toggle {
+    flex-basis: calc(30% - 0.25rem);
+    justify-content: flex-end;
   }
 }
 </style>

--- a/ui/components/diversification/diversification-calculator.test.ts
+++ b/ui/components/diversification/diversification-calculator.test.ts
@@ -76,9 +76,9 @@ describe('DiversificationCalculator', () => {
   })
 
   describe('rendering', () => {
-    it('should render calculator title', () => {
+    it('should render title', () => {
       const wrapper = mount(DiversificationCalculator)
-      expect(wrapper.text()).toContain('Diversification Calculator')
+      expect(wrapper.text()).toContain('Diversification')
     })
 
     it('should render AllocationTable component', () => {

--- a/ui/components/diversification/types.ts
+++ b/ui/components/diversification/types.ts
@@ -1,9 +1,13 @@
 export interface AllocationInput {
   instrumentId: number
   value: number
+  currentValue?: number
 }
 
 export interface CachedState {
   allocations: AllocationInput[]
   inputMode: 'percentage' | 'amount'
+  selectedPlatform?: string | null
+  optimizeEnabled?: boolean
+  totalInvestment?: number
 }


### PR DESCRIPTION
## Summary
- Add platform selector dropdown to filter portfolio by trading platform (LHV, Lightyear, etc.)
- Show current holdings value and percentage for selected platform
- Calculate units to buy/sell to reach target allocations based on current holdings
- Display rebalancing columns: Current, Target %, Action (Buy/Sell), After %
- Persist selectedPlatform, optimizeEnabled, and totalInvestment in database
- Include all settings in export/import configuration
- Add sortable column headers (click to sort by ETF, Name, Price, TER, etc.)
- Use shared `formatPlatformName` utility from platform-utils.ts
- Add 12 new tests for platform rebalancing functionality

## Test plan
- [x] Select a platform from the dropdown
- [x] Click "Load from Portfolio" to load ETFs from the selected platform
- [x] Verify current holdings value is displayed
- [x] Verify current value and percentage columns show correct values
- [x] Enter a new investment amount
- [x] Verify Action column shows correct Buy/Sell with units
- [x] Verify After % column shows projected allocation
- [x] Change target allocations and verify calculations update
- [x] Switch platforms and verify data reloads correctly
- [x] Click column headers to sort allocations
- [x] Export and import configuration - verify all settings preserved
- [x] Refresh page - verify settings are restored from database
- [x] Test mobile view shows current value in metrics
- [x] Run `npm test` - all 792 tests pass
- [x] Run `npm run lint-format` - passes