### PR TITLE
Shorten Annual Return header to Annual in Diversification table

### DIFF
--- a/ui/components/diversification/allocation-table.test.ts
+++ b/ui/components/diversification/allocation-table.test.ts
@@ -56,7 +56,7 @@ describe('AllocationTable', () => {
       expect(headers[1].text()).toContain('Name')
       expect(headers[2].text()).toContain('Price')
       expect(headers[3].text()).toContain('TER')
-      expect(headers[4].text()).toContain('Annual Return')
+      expect(headers[4].text()).toContain('Annual')
     })
 
     it('should show Allocation % header in percentage mode', () => {

--- a/ui/components/diversification/allocation-table.vue
+++ b/ui/components/diversification/allocation-table.vue
@@ -151,7 +151,7 @@
             </th>
             <th class="sortable" @click="toggleSort('annualReturn')">
               <span class="th-content">
-                Annual Return
+                Annual
                 <span class="sort-indicator" :class="getSortIndicatorClass('annualReturn')">
                   <i class="sort-arrow-up">▲</i>
                   <i class="sort-arrow-down">▼</i>


### PR DESCRIPTION
## Summary
- Shorten table header from 'Annual Return' to 'Annual' for better visual consistency

## Test plan
- [ ] Verify Diversification tab displays 'Annual' column header
- [ ] Verify sorting still works on the Annual column
- [ ] Verify all tests pass

Closes #1241