### PR TITLE
Add WisdomTree Europe Defence ETF (EUDF) instrument

### DIFF
--- a/src/main/kotlin/ee/tenman/portfolio/ft/HistoricalPricesService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/ft/HistoricalPricesService.kt
@@ -41,6 +41,7 @@ private val TICKERS: Map<String, String> =
     "DFND:PAR:EUR" to "913527044",
     "IS3S:GER:EUR" to "79062420",
     "AIFS:GER:EUR" to "950573165",
+    "EUDF:GER:EUR" to "971028046",
   )
 
 private val REQUEST_DATE_FORMATTER: DateTimeFormatter =

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -203,6 +203,8 @@ scraping:
         uuid: "1ef3aa4c-5f26-6cf0-8eba-bb4404220dad"
       - symbol: "AIFS:GER:EUR"
         uuid: "1efb76c2-b6a1-6638-914d-2d7971d10ab6"
+      - symbol: "EUDF:GER:EUR"
+        uuid: "1efffda3-1025-6a5a-b5c1-0d0aba27fa65"
 
 cloudflare-bypass-proxy:
   url: ${CLOUDFLARE_BYPASS_PROXY_URL:${TRADING212_PROXY_URL:http://localhost:3000}}

--- a/src/main/resources/db/migration/V202601281513__add_eudf_instrument.sql
+++ b/src/main/resources/db/migration/V202601281513__add_eudf_instrument.sql
@@ -1,0 +1,23 @@
+INSERT INTO instrument (
+    symbol,
+    name,
+    instrument_category,
+    base_currency,
+    provider_name,
+    provider_external_id,
+    current_price,
+    created_at,
+    updated_at,
+    version
+) VALUES (
+    'EUDF:GER:EUR',
+    'WisdomTree Europe Defence',
+    'ETF',
+    'EUR',
+    'LIGHTYEAR',
+    '1efffda3-1025-6a5a-b5c1-0d0aba27fa65',
+    0,
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP,
+    0
+);


### PR DESCRIPTION
## Summary

- Add database migration for EUDF:GER:EUR instrument with Lightyear UUID
- Configure Lightyear UUID in application.yml for price fetching
- Add FT.com ID mapping in HistoricalPricesService.kt for historical prices

Closes #1245

## Test plan

- [ ] Migration runs successfully
- [ ] Instrument appears in instruments list
- [ ] Lightyear price fetching works
- [ ] FT.com historical prices are retrieved