### PR TITLE
Add Vanguard FTSE Developed Europe ETF (VWCG) instrument

### DIFF
--- a/src/main/kotlin/ee/tenman/portfolio/ft/HistoricalPricesService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/ft/HistoricalPricesService.kt
@@ -42,6 +42,7 @@ private val TICKERS: Map<String, String> =
     "IS3S:GER:EUR" to "79062420",
     "AIFS:GER:EUR" to "950573165",
     "EUDF:GER:EUR" to "971028046",
+    "VWCG:GER:EUR" to "544533916",
   )
 
 private val REQUEST_DATE_FORMATTER: DateTimeFormatter =

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -205,6 +205,8 @@ scraping:
         uuid: "1efb76c2-b6a1-6638-914d-2d7971d10ab6"
       - symbol: "EUDF:GER:EUR"
         uuid: "1efffda3-1025-6a5a-b5c1-0d0aba27fa65"
+      - symbol: "VWCG:GER:EUR"
+        uuid: "1eda4008-ca32-66dc-b60a-654bcfbd8ac3"
 
 cloudflare-bypass-proxy:
   url: ${CLOUDFLARE_BYPASS_PROXY_URL:${TRADING212_PROXY_URL:http://localhost:3000}}

--- a/src/main/resources/db/migration/V202602041654__add_vwcg_instrument.sql
+++ b/src/main/resources/db/migration/V202602041654__add_vwcg_instrument.sql
@@ -1,0 +1,23 @@
+INSERT INTO instrument (
+    symbol,
+    name,
+    instrument_category,
+    base_currency,
+    provider_name,
+    provider_external_id,
+    current_price,
+    created_at,
+    updated_at,
+    version
+) VALUES (
+    'VWCG:GER:EUR',
+    'Vanguard FTSE Developed Europe',
+    'ETF',
+    'EUR',
+    'LIGHTYEAR',
+    '1eda4008-ca32-66dc-b60a-654bcfbd8ac3',
+    0,
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP,
+    0
+);


### PR DESCRIPTION
## Summary

- Add database migration for VWCG:GER:EUR instrument
- Configure Lightyear UUID for price fetching
- Add FT.com ID mapping for historical prices

## Test plan

- [ ] Migration creates the instrument record
- [ ] Lightyear price fetching works for VWCG
- [ ] FT.com historical prices can be retrieved
- [ ] Application starts successfully

Closes #1296