### PR TITLE
Add iShares EURO STOXX Banks 30-15 (EXA1) instrument

### DIFF
--- a/src/main/kotlin/ee/tenman/portfolio/ft/HistoricalPricesService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/ft/HistoricalPricesService.kt
@@ -48,6 +48,7 @@ private val TICKERS: Map<String, String> =
     "2B7C:GER:EUR" to "402853488",
     "ESIF:GER:EUR" to "630031922",
     "WEBN:GER:EUR" to "894412378",
+    "EXA1:AEX:EUR" to "694104976",
   )
 
 private val REQUEST_DATE_FORMATTER: DateTimeFormatter =

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -219,6 +219,8 @@ scraping:
         uuid: "1f0322ce-3f65-61a8-8e2f-83bff54ace68"
       - symbol: "WEBN:GER:EUR"
         uuid: "1ef66ace-af0a-6d75-ab3f-c9f7567377e0"
+      - symbol: "EXA1:AEX:EUR"
+        uuid: "1ef5a0f9-9cfa-6753-9ec2-5b729cca6424"
 
 cloudflare-bypass-proxy:
   url: ${CLOUDFLARE_BYPASS_PROXY_URL:${TRADING212_PROXY_URL:http://localhost:3000}}

--- a/src/main/resources/db/migration/V202604141000__add_exa1_instrument.sql
+++ b/src/main/resources/db/migration/V202604141000__add_exa1_instrument.sql
@@ -1,0 +1,23 @@
+INSERT INTO instrument (
+    symbol,
+    name,
+    instrument_category,
+    base_currency,
+    provider_name,
+    provider_external_id,
+    current_price,
+    created_at,
+    updated_at,
+    version
+) VALUES (
+    'EXA1:AEX:EUR',
+    'iShares EURO STOXX Banks 30-15',
+    'ETF',
+    'EUR',
+    'LIGHTYEAR',
+    '1ef5a0f9-9cfa-6753-9ec2-5b729cca6424',
+    0,
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP,
+    0
+);


### PR DESCRIPTION
## Summary
- Add `EXA1:AEX:EUR` (iShares EURO STOXX Banks 30-15 ETF) as a new Lightyear-provided instrument via Flyway migration `V202604141000`.
- Register the FT historical-prices symbol id `694104976` so markets.ft.com historical data resolves for EXA1.
- Register the Lightyear UUID `1ef5a0f9-9cfa-6753-9ec2-5b729cca6424` in `scraping.lightyear.etfs` so live price and holdings lookups skip the web-fallback UUID resolver.

## Test plan
- [x] `./gradlew compileKotlin` succeeds
- [x] `./gradlew test --tests "*HistoricalPrices*" --tests "*LightyearPrice*" --tests "*Instrument*"` — 150 tests pass
- [x] `./gradlew bootRun` applies Flyway migration `V202604141000__add_exa1_instrument` cleanly
- [x] `SELECT * FROM instrument WHERE symbol = 'EXA1:AEX:EUR'` returns one row with the expected UUID and name
- [x] `GET /api/instruments` returns EXA1 with `providerName=LIGHTYEAR`, `baseCurrency=EUR`, `category=ETF`