### PR TITLE
Add LHV EUR cash deposit of 628.52 on Apr 15

### DIFF
--- a/src/main/resources/db/migration/V202604151400__add_lhv_eur_cash_apr15.sql
+++ b/src/main/resources/db/migration/V202604151400__add_lhv_eur_cash_apr15.sql
@@ -1,0 +1,2 @@
+INSERT INTO portfolio_transaction (instrument_id, transaction_type, quantity, price, transaction_date, platform, commission)
+VALUES ((SELECT id FROM instrument WHERE symbol = 'EUR'), 'BUY', 628.52, 1, '2026-04-15', 'LHV', 0);


### PR DESCRIPTION
## Summary
Records €628.52 cash received to LHV on 2026-04-15.

## Test plan
- [ ] Migration applies cleanly via Flyway
- [ ] LHV cash balance reflects the new €628.52 deposit