### PR TITLE
Pull Trading212 prices every minute, at startup, and on refresh

### DIFF
--- a/src/main/kotlin/ee/tenman/portfolio/controller/InstrumentController.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/controller/InstrumentController.kt
@@ -80,7 +80,7 @@ class InstrumentController(
 
   @PostMapping("/refresh-prices")
   @Loggable
-  @Operation(summary = "Refresh prices from Binance and Lightyear providers")
+  @Operation(summary = "Refresh prices from Binance, Lightyear, and Trading212 providers")
   fun refreshPrices(): Map<String, String> = mapOf("status" to priceRefreshService.refreshAllPrices())
 
   @GetMapping("/classify-industry")

--- a/src/main/kotlin/ee/tenman/portfolio/job/Trading212DataRetrievalJob.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/job/Trading212DataRetrievalJob.kt
@@ -5,13 +5,13 @@ import ee.tenman.portfolio.service.infrastructure.JobExecutionService
 import ee.tenman.portfolio.service.pricing.PriceUpdateProcessor
 import ee.tenman.portfolio.service.pricing.Trading212PriceUpdateService
 import ee.tenman.portfolio.trading212.Trading212Service
+import jakarta.annotation.PostConstruct
 import org.slf4j.LoggerFactory
+import org.springframework.scheduling.TaskScheduler
 import org.springframework.scheduling.annotation.Scheduled
 import java.time.Clock
-import java.time.DayOfWeek
-import java.time.LocalTime
-import java.time.ZoneId
-import java.time.ZonedDateTime
+import java.time.Duration
+import java.time.Instant
 
 @ScheduledJob
 class Trading212DataRetrievalJob(
@@ -19,35 +19,25 @@ class Trading212DataRetrievalJob(
   private val trading212Service: Trading212Service,
   private val trading212PriceUpdateService: Trading212PriceUpdateService,
   private val priceUpdateProcessor: PriceUpdateProcessor,
+  private val taskScheduler: TaskScheduler,
   private val clock: Clock,
 ) : Job {
   private val log = LoggerFactory.getLogger(javaClass)
-  private val estonianZone = ZoneId.of("Europe/Tallinn")
+
+  @PostConstruct
+  fun scheduleInitialRun() {
+    log.info("Scheduling initial Trading212 price update job to run in $INITIAL_DELAY_SECONDS seconds")
+    taskScheduler.schedule(
+      { runJob() },
+      Instant.now(clock).plus(Duration.ofSeconds(INITIAL_DELAY_SECONDS)),
+    )
+  }
 
   @Scheduled(fixedDelayString = "\${scheduling.jobs.trading212-interval:60000}")
   fun runJob() {
-    if (!isWithinTradingHours()) {
-      log.debug("Skipping Trading212 job - outside trading hours (10:00-18:30 EET/EEST on workdays)")
-      return
-    }
     log.info("Running Trading212 price update job")
     jobExecutionService.executeJob(this)
     log.info("Completed Trading212 price update job")
-  }
-
-  private fun isWithinTradingHours(): Boolean {
-    val estonianTime = ZonedDateTime.now(clock.withZone(estonianZone))
-    val dayOfWeek = estonianTime.dayOfWeek
-    val currentTime = estonianTime.toLocalTime()
-
-    if (dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY) {
-      return false
-    }
-
-    val startTime = LocalTime.of(10, 0)
-    val endTime = LocalTime.of(18, 30)
-
-    return !currentTime.isBefore(startTime) && !currentTime.isAfter(endTime)
   }
 
   override fun execute() {
@@ -57,5 +47,9 @@ class Trading212DataRetrievalJob(
       fetchPrices = { trading212Service.fetchCurrentPrices() },
       processSymbol = trading212PriceUpdateService::processSymbol,
     )
+  }
+
+  companion object {
+    private const val INITIAL_DELAY_SECONDS = 15L
   }
 }

--- a/src/main/kotlin/ee/tenman/portfolio/job/Trading212DataRetrievalJob.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/job/Trading212DataRetrievalJob.kt
@@ -1,6 +1,8 @@
 package ee.tenman.portfolio.job
 
 import ee.tenman.portfolio.domain.Platform
+import ee.tenman.portfolio.domain.ProviderName
+import ee.tenman.portfolio.repository.InstrumentRepository
 import ee.tenman.portfolio.service.infrastructure.JobExecutionService
 import ee.tenman.portfolio.service.pricing.PriceUpdateProcessor
 import ee.tenman.portfolio.service.pricing.Trading212PriceUpdateService
@@ -19,6 +21,7 @@ class Trading212DataRetrievalJob(
   private val trading212Service: Trading212Service,
   private val trading212PriceUpdateService: Trading212PriceUpdateService,
   private val priceUpdateProcessor: PriceUpdateProcessor,
+  private val instrumentRepository: InstrumentRepository,
   private val taskScheduler: TaskScheduler,
   private val clock: Clock,
 ) : Job {
@@ -41,10 +44,15 @@ class Trading212DataRetrievalJob(
   }
 
   override fun execute() {
+    val eligibleSymbols =
+      instrumentRepository
+        .findByProviderName(ProviderName.TRADING212)
+        .map { it.symbol }
+        .toSet()
     priceUpdateProcessor.processPriceUpdates(
       platform = Platform.TRADING212,
       log = log,
-      fetchPrices = { trading212Service.fetchCurrentPrices() },
+      fetchPrices = { trading212Service.fetchCurrentPrices(eligibleSymbols) },
       processSymbol = trading212PriceUpdateService::processSymbol,
     )
   }

--- a/src/main/kotlin/ee/tenman/portfolio/service/pricing/PriceRefreshService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/service/pricing/PriceRefreshService.kt
@@ -4,6 +4,7 @@ import ee.tenman.portfolio.job.BinanceDataRetrievalJob
 import ee.tenman.portfolio.job.EtfHoldingsClassificationJob
 import ee.tenman.portfolio.job.LightyearHistoricalDataRetrievalJob
 import ee.tenman.portfolio.job.LightyearPriceRetrievalJob
+import ee.tenman.portfolio.job.Trading212DataRetrievalJob
 import ee.tenman.portfolio.service.infrastructure.CacheInvalidationService
 import ee.tenman.portfolio.service.transaction.TransactionService
 import kotlinx.coroutines.CoroutineScope
@@ -16,6 +17,7 @@ class PriceRefreshService(
   private val binanceDataRetrievalJob: BinanceDataRetrievalJob?,
   private val lightyearHistoricalDataRetrievalJob: LightyearHistoricalDataRetrievalJob?,
   private val lightyearPriceRetrievalJob: LightyearPriceRetrievalJob?,
+  private val trading212DataRetrievalJob: Trading212DataRetrievalJob?,
   private val etfHoldingsClassificationJob: EtfHoldingsClassificationJob?,
   private val cacheInvalidationService: CacheInvalidationService,
   private val transactionService: TransactionService,
@@ -39,6 +41,7 @@ class PriceRefreshService(
     binanceDataRetrievalJob?.let { job -> launchJob { job.execute() } }
     lightyearHistoricalDataRetrievalJob?.let { job -> launchJob { job.execute() } }
     lightyearPriceRetrievalJob?.let { job -> launchJob { job.execute() } }
+    trading212DataRetrievalJob?.let { job -> launchJob { job.execute() } }
   }
 
   private fun clearAllCaches() {

--- a/src/main/kotlin/ee/tenman/portfolio/trading212/Trading212Service.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/trading212/Trading212Service.kt
@@ -15,10 +15,14 @@ class Trading212Service(
   private val log = LoggerFactory.getLogger(javaClass)
 
   @Retryable(backoff = Backoff(delay = 1000, multiplier = 2.0, maxDelay = 5000))
-  fun fetchCurrentPrices(): Map<String, BigDecimal> {
-    val entries = scrapingProperties.symbols
+  fun fetchCurrentPrices(eligibleSymbols: Set<String>): Map<String, BigDecimal> {
+    if (eligibleSymbols.isEmpty()) {
+      log.info("No Trading212-provider instruments to price, skipping fetch")
+      return emptyMap()
+    }
+    val entries = scrapingProperties.symbols.filter { it.symbol in eligibleSymbols }
     if (entries.isEmpty()) {
-      log.warn("No Trading212 symbols configured, skipping price fetch")
+      log.warn("No Trading212 symbols configured for eligible instruments: $eligibleSymbols")
       return emptyMap()
     }
     val tickers = entries.joinToString(",") { it.ticker }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -243,8 +243,6 @@ trading212-scraping:
     - symbol: BNKE:PAR:EUR
       ticker: BNKEp_EQ
 
-
-
 openrouter:
   api-key: ${OPENROUTER_API_KEY}
   circuit-breaker:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -240,18 +240,6 @@ trading212:
 
 trading212-scraping:
   symbols:
-    - symbol: WTAI:MIL:EUR
-      ticker: WTAIm_EQ
-    - symbol: VUAA:GER:EUR
-      ticker: VUAAm_EQ
-    - symbol: SPYL:GER:EUR
-      ticker: SPYLa_EQ
-    - symbol: QDVE:GER:EUR
-      ticker: QDVEd_EQ
-    - symbol: XAIX:GER:EUR
-      ticker: XAIXd_EQ
-    - symbol: CSX5:AEX:EUR
-      ticker: CSX5a_EQ
     - symbol: BNKE:PAR:EUR
       ticker: BNKEp_EQ
 

--- a/src/test/kotlin/ee/tenman/portfolio/job/Trading212DataRetrievalJobTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/job/Trading212DataRetrievalJobTest.kt
@@ -2,7 +2,6 @@ package ee.tenman.portfolio.job
 
 import ch.tutteli.atrium.api.fluent.en_GB.toEqual
 import ch.tutteli.atrium.api.verbs.expect
-import ee.tenman.portfolio.domain.Instrument
 import ee.tenman.portfolio.domain.InstrumentCategory
 import ee.tenman.portfolio.domain.Platform
 import ee.tenman.portfolio.domain.ProviderName
@@ -10,6 +9,7 @@ import ee.tenman.portfolio.repository.InstrumentRepository
 import ee.tenman.portfolio.service.infrastructure.JobExecutionService
 import ee.tenman.portfolio.service.pricing.PriceUpdateProcessor
 import ee.tenman.portfolio.service.pricing.Trading212PriceUpdateService
+import ee.tenman.portfolio.testing.fixture.TransactionFixtures
 import ee.tenman.portfolio.trading212.Trading212Service
 import io.mockk.every
 import io.mockk.mockk
@@ -63,7 +63,14 @@ class Trading212DataRetrievalJobTest {
 
   @Test
   fun `execute asks the Trading212 service only for instruments whose provider is Trading212`() {
-    val bnke = instrumentWithSymbol("BNKE:PAR:EUR", ProviderName.TRADING212)
+    val bnke =
+      TransactionFixtures.createInstrument(
+        symbol = "BNKE:PAR:EUR",
+        name = "BNKE:PAR:EUR",
+        category = InstrumentCategory.ETF.name,
+        baseCurrency = "EUR",
+        providerName = ProviderName.TRADING212,
+      )
     every { instrumentRepository.findByProviderName(ProviderName.TRADING212) } returns listOf(bnke)
     val eligibleSymbolsSlot = slot<() -> Map<String, BigDecimal>>()
     every {
@@ -105,15 +112,4 @@ class Trading212DataRetrievalJobTest {
     verify { trading212Service.fetchCurrentPrices(emptySet()) }
   }
 
-  private fun instrumentWithSymbol(
-    symbol: String,
-    provider: ProviderName,
-  ): Instrument =
-    Instrument(
-      symbol = symbol,
-      name = symbol,
-      category = InstrumentCategory.ETF.name,
-      baseCurrency = "EUR",
-      providerName = provider,
-    )
 }

--- a/src/test/kotlin/ee/tenman/portfolio/job/Trading212DataRetrievalJobTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/job/Trading212DataRetrievalJobTest.kt
@@ -2,16 +2,22 @@ package ee.tenman.portfolio.job
 
 import ch.tutteli.atrium.api.fluent.en_GB.toEqual
 import ch.tutteli.atrium.api.verbs.expect
+import ee.tenman.portfolio.domain.Instrument
+import ee.tenman.portfolio.domain.InstrumentCategory
 import ee.tenman.portfolio.domain.Platform
+import ee.tenman.portfolio.domain.ProviderName
+import ee.tenman.portfolio.repository.InstrumentRepository
 import ee.tenman.portfolio.service.infrastructure.JobExecutionService
 import ee.tenman.portfolio.service.pricing.PriceUpdateProcessor
 import ee.tenman.portfolio.service.pricing.Trading212PriceUpdateService
 import ee.tenman.portfolio.trading212.Trading212Service
+import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import org.junit.jupiter.api.Test
 import org.springframework.scheduling.TaskScheduler
+import java.math.BigDecimal
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
@@ -24,6 +30,7 @@ class Trading212DataRetrievalJobTest {
   private val trading212Service = mockk<Trading212Service>(relaxed = true)
   private val trading212PriceUpdateService = mockk<Trading212PriceUpdateService>(relaxed = true)
   private val priceUpdateProcessor = mockk<PriceUpdateProcessor>(relaxed = true)
+  private val instrumentRepository = mockk<InstrumentRepository>()
   private val taskScheduler = mockk<TaskScheduler>(relaxed = true)
 
   private val job =
@@ -32,6 +39,7 @@ class Trading212DataRetrievalJobTest {
       trading212Service = trading212Service,
       trading212PriceUpdateService = trading212PriceUpdateService,
       priceUpdateProcessor = priceUpdateProcessor,
+      instrumentRepository = instrumentRepository,
       taskScheduler = taskScheduler,
       clock = clock,
     )
@@ -54,16 +62,58 @@ class Trading212DataRetrievalJobTest {
   }
 
   @Test
-  fun `execute delegates price processing to the price update processor for Trading212`() {
-    job.execute()
-
-    verify {
+  fun `execute asks the Trading212 service only for instruments whose provider is Trading212`() {
+    val bnke = instrumentWithSymbol("BNKE:PAR:EUR", ProviderName.TRADING212)
+    every { instrumentRepository.findByProviderName(ProviderName.TRADING212) } returns listOf(bnke)
+    val eligibleSymbolsSlot = slot<() -> Map<String, BigDecimal>>()
+    every {
       priceUpdateProcessor.processPriceUpdates(
         platform = Platform.TRADING212,
         log = any(),
-        fetchPrices = any(),
+        fetchPrices = capture(eligibleSymbolsSlot),
         processSymbol = any(),
       )
+    } answers {
+      eligibleSymbolsSlot.captured.invoke()
     }
+    every { trading212Service.fetchCurrentPrices(setOf("BNKE:PAR:EUR")) } returns
+      mapOf("BNKE:PAR:EUR" to BigDecimal("327.23"))
+
+    job.execute()
+
+    verify { trading212Service.fetchCurrentPrices(setOf("BNKE:PAR:EUR")) }
   }
+
+  @Test
+  fun `execute passes an empty filter when no Trading212 instruments exist`() {
+    every { instrumentRepository.findByProviderName(ProviderName.TRADING212) } returns emptyList()
+    val eligibleSymbolsSlot = slot<() -> Map<String, BigDecimal>>()
+    every {
+      priceUpdateProcessor.processPriceUpdates(
+        platform = Platform.TRADING212,
+        log = any(),
+        fetchPrices = capture(eligibleSymbolsSlot),
+        processSymbol = any(),
+      )
+    } answers {
+      eligibleSymbolsSlot.captured.invoke()
+    }
+    every { trading212Service.fetchCurrentPrices(emptySet()) } returns emptyMap()
+
+    job.execute()
+
+    verify { trading212Service.fetchCurrentPrices(emptySet()) }
+  }
+
+  private fun instrumentWithSymbol(
+    symbol: String,
+    provider: ProviderName,
+  ): Instrument =
+    Instrument(
+      symbol = symbol,
+      name = symbol,
+      category = InstrumentCategory.ETF.name,
+      baseCurrency = "EUR",
+      providerName = provider,
+    )
 }

--- a/src/test/kotlin/ee/tenman/portfolio/job/Trading212DataRetrievalJobTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/job/Trading212DataRetrievalJobTest.kt
@@ -1,0 +1,69 @@
+package ee.tenman.portfolio.job
+
+import ch.tutteli.atrium.api.fluent.en_GB.toEqual
+import ch.tutteli.atrium.api.verbs.expect
+import ee.tenman.portfolio.domain.Platform
+import ee.tenman.portfolio.service.infrastructure.JobExecutionService
+import ee.tenman.portfolio.service.pricing.PriceUpdateProcessor
+import ee.tenman.portfolio.service.pricing.Trading212PriceUpdateService
+import ee.tenman.portfolio.trading212.Trading212Service
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import org.springframework.scheduling.TaskScheduler
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneId
+
+class Trading212DataRetrievalJobTest {
+  private val fixedInstant: Instant = Instant.parse("2026-04-17T01:30:00Z")
+  private val clock: Clock = Clock.fixed(fixedInstant, ZoneId.of("Europe/Tallinn"))
+  private val jobExecutionService = mockk<JobExecutionService>(relaxed = true)
+  private val trading212Service = mockk<Trading212Service>(relaxed = true)
+  private val trading212PriceUpdateService = mockk<Trading212PriceUpdateService>(relaxed = true)
+  private val priceUpdateProcessor = mockk<PriceUpdateProcessor>(relaxed = true)
+  private val taskScheduler = mockk<TaskScheduler>(relaxed = true)
+
+  private val job =
+    Trading212DataRetrievalJob(
+      jobExecutionService = jobExecutionService,
+      trading212Service = trading212Service,
+      trading212PriceUpdateService = trading212PriceUpdateService,
+      priceUpdateProcessor = priceUpdateProcessor,
+      taskScheduler = taskScheduler,
+      clock = clock,
+    )
+
+  @Test
+  fun `scheduleInitialRun schedules the job to run fifteen seconds after startup`() {
+    val instantSlot = slot<Instant>()
+
+    job.scheduleInitialRun()
+
+    verify { taskScheduler.schedule(any(), capture(instantSlot)) }
+    expect(instantSlot.captured).toEqual(fixedInstant.plus(Duration.ofSeconds(15)))
+  }
+
+  @Test
+  fun `runJob executes the price update every minute regardless of time of day`() {
+    job.runJob()
+
+    verify { jobExecutionService.executeJob(job) }
+  }
+
+  @Test
+  fun `execute delegates price processing to the price update processor for Trading212`() {
+    job.execute()
+
+    verify {
+      priceUpdateProcessor.processPriceUpdates(
+        platform = Platform.TRADING212,
+        log = any(),
+        fetchPrices = any(),
+        processSymbol = any(),
+      )
+    }
+  }
+}

--- a/src/test/kotlin/ee/tenman/portfolio/job/Trading212DataRetrievalJobTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/job/Trading212DataRetrievalJobTest.kt
@@ -66,7 +66,6 @@ class Trading212DataRetrievalJobTest {
     val bnke =
       TransactionFixtures.createInstrument(
         symbol = "BNKE:PAR:EUR",
-        name = "BNKE:PAR:EUR",
         category = InstrumentCategory.ETF.name,
         baseCurrency = "EUR",
         providerName = ProviderName.TRADING212,
@@ -111,5 +110,4 @@ class Trading212DataRetrievalJobTest {
 
     verify { trading212Service.fetchCurrentPrices(emptySet()) }
   }
-
 }

--- a/src/test/kotlin/ee/tenman/portfolio/job/Trading212DataRetrievalJobTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/job/Trading212DataRetrievalJobTest.kt
@@ -71,17 +71,7 @@ class Trading212DataRetrievalJobTest {
         providerName = ProviderName.TRADING212,
       )
     every { instrumentRepository.findByProviderName(ProviderName.TRADING212) } returns listOf(bnke)
-    val eligibleSymbolsSlot = slot<() -> Map<String, BigDecimal>>()
-    every {
-      priceUpdateProcessor.processPriceUpdates(
-        platform = Platform.TRADING212,
-        log = any(),
-        fetchPrices = capture(eligibleSymbolsSlot),
-        processSymbol = any(),
-      )
-    } answers {
-      eligibleSymbolsSlot.captured.invoke()
-    }
+    invokeFetchPricesWhenProcessed()
     every { trading212Service.fetchCurrentPrices(setOf("BNKE:PAR:EUR")) } returns
       mapOf("BNKE:PAR:EUR" to BigDecimal("327.23"))
 
@@ -93,21 +83,25 @@ class Trading212DataRetrievalJobTest {
   @Test
   fun `execute passes an empty filter when no Trading212 instruments exist`() {
     every { instrumentRepository.findByProviderName(ProviderName.TRADING212) } returns emptyList()
-    val eligibleSymbolsSlot = slot<() -> Map<String, BigDecimal>>()
-    every {
-      priceUpdateProcessor.processPriceUpdates(
-        platform = Platform.TRADING212,
-        log = any(),
-        fetchPrices = capture(eligibleSymbolsSlot),
-        processSymbol = any(),
-      )
-    } answers {
-      eligibleSymbolsSlot.captured.invoke()
-    }
+    invokeFetchPricesWhenProcessed()
     every { trading212Service.fetchCurrentPrices(emptySet()) } returns emptyMap()
 
     job.execute()
 
     verify { trading212Service.fetchCurrentPrices(emptySet()) }
+  }
+
+  private fun invokeFetchPricesWhenProcessed() {
+    val fetchPricesSlot = slot<() -> Map<String, BigDecimal>>()
+    every {
+      priceUpdateProcessor.processPriceUpdates(
+        platform = Platform.TRADING212,
+        log = any(),
+        fetchPrices = capture(fetchPricesSlot),
+        processSymbol = any(),
+      )
+    } answers {
+      fetchPricesSlot.captured.invoke()
+    }
   }
 }

--- a/src/test/kotlin/ee/tenman/portfolio/service/pricing/PriceRefreshServiceTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/service/pricing/PriceRefreshServiceTest.kt
@@ -6,6 +6,7 @@ import ee.tenman.portfolio.job.BinanceDataRetrievalJob
 import ee.tenman.portfolio.job.EtfHoldingsClassificationJob
 import ee.tenman.portfolio.job.LightyearHistoricalDataRetrievalJob
 import ee.tenman.portfolio.job.LightyearPriceRetrievalJob
+import ee.tenman.portfolio.job.Trading212DataRetrievalJob
 import ee.tenman.portfolio.service.infrastructure.CacheInvalidationService
 import ee.tenman.portfolio.service.transaction.TransactionService
 import io.mockk.coEvery
@@ -19,6 +20,7 @@ class PriceRefreshServiceTest {
   private val binanceDataRetrievalJob = mockk<BinanceDataRetrievalJob>(relaxed = true)
   private val lightyearHistoricalDataRetrievalJob = mockk<LightyearHistoricalDataRetrievalJob>(relaxed = true)
   private val lightyearPriceRetrievalJob = mockk<LightyearPriceRetrievalJob>(relaxed = true)
+  private val trading212DataRetrievalJob = mockk<Trading212DataRetrievalJob>(relaxed = true)
   private val etfHoldingsClassificationJob = mockk<EtfHoldingsClassificationJob>(relaxed = true)
   private val cacheInvalidationService = mockk<CacheInvalidationService>(relaxed = true)
   private val transactionService = mockk<TransactionService>()
@@ -35,6 +37,7 @@ class PriceRefreshServiceTest {
         binanceDataRetrievalJob = binanceDataRetrievalJob,
         lightyearHistoricalDataRetrievalJob = lightyearHistoricalDataRetrievalJob,
         lightyearPriceRetrievalJob = lightyearPriceRetrievalJob,
+        trading212DataRetrievalJob = trading212DataRetrievalJob,
         etfHoldingsClassificationJob = etfHoldingsClassificationJob,
         cacheInvalidationService = cacheInvalidationService,
         transactionService = transactionService,
@@ -71,6 +74,7 @@ class PriceRefreshServiceTest {
         binanceDataRetrievalJob = null,
         lightyearHistoricalDataRetrievalJob = null,
         lightyearPriceRetrievalJob = null,
+        trading212DataRetrievalJob = null,
         etfHoldingsClassificationJob = null,
         cacheInvalidationService = cacheInvalidationService,
         transactionService = transactionService,
@@ -88,6 +92,7 @@ class PriceRefreshServiceTest {
         binanceDataRetrievalJob = null,
         lightyearHistoricalDataRetrievalJob = null,
         lightyearPriceRetrievalJob = null,
+        trading212DataRetrievalJob = null,
         etfHoldingsClassificationJob = null,
         cacheInvalidationService = cacheInvalidationService,
         transactionService = transactionService,
@@ -96,5 +101,13 @@ class PriceRefreshServiceTest {
     val result = serviceWithoutJobs.refreshAllPrices()
 
     expect(result).toEqual("Jobs triggered, caches cleared, and transaction profits recalculated")
+  }
+
+  @Test
+  fun `refreshAllPrices triggers the Trading212 price retrieval job`() {
+    priceRefreshService.refreshAllPrices()
+
+    Thread.sleep(100)
+    verify { trading212DataRetrievalJob.execute() }
   }
 }

--- a/src/test/kotlin/ee/tenman/portfolio/service/pricing/PriceRefreshServiceTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/service/pricing/PriceRefreshServiceTest.kt
@@ -107,7 +107,6 @@ class PriceRefreshServiceTest {
   fun `refreshAllPrices triggers the Trading212 price retrieval job`() {
     priceRefreshService.refreshAllPrices()
 
-    Thread.sleep(100)
-    verify { trading212DataRetrievalJob.execute() }
+    verify(timeout = 1000) { trading212DataRetrievalJob.execute() }
   }
 }

--- a/src/test/kotlin/ee/tenman/portfolio/trading212/Trading212ServiceTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/trading212/Trading212ServiceTest.kt
@@ -25,35 +25,46 @@ class Trading212ServiceTest {
   private val service = Trading212Service(client, properties)
 
   @Test
-  fun `should map prices from config-driven ticker list`() {
+  fun `should map prices only for eligible Trading212-provider symbols`() {
     val response =
       Trading212Response(
         data =
           mapOf(
             "BNKEp_EQ" to Trading212PriceData(bid = BigDecimal("330.77"), spread = BigDecimal("0.05"), timestamp = "2026-04-16T10:00:00Z"),
-            "VUAAm_EQ" to Trading212PriceData(bid = BigDecimal("100.50"), spread = BigDecimal("0.02"), timestamp = "2026-04-16T10:00:00Z"),
           ),
       )
-    every { client.getPrices("BNKEp_EQ,VUAAm_EQ") } returns response
-    val prices = service.fetchCurrentPrices()
-    expect(prices.size).toEqual(2)
+    every { client.getPrices("BNKEp_EQ") } returns response
+
+    val prices = service.fetchCurrentPrices(setOf("BNKE:PAR:EUR"))
+
+    expect(prices.size).toEqual(1)
     expect(prices["BNKE:PAR:EUR"]!!).toEqualNumerically(BigDecimal("330.77"))
-    expect(prices["VUAA:GER:EUR"]!!).toEqualNumerically(BigDecimal("100.50"))
-    verify { client.getPrices("BNKEp_EQ,VUAAm_EQ") }
+    expect(prices["VUAA:GER:EUR"]).toEqual(null)
+    verify { client.getPrices("BNKEp_EQ") }
   }
 
   @Test
-  fun `should return empty map when properties have no symbols`() {
-    val emptyProperties = Trading212ScrapingProperties()
-    val emptyService = Trading212Service(client, emptyProperties)
-    val prices = emptyService.fetchCurrentPrices()
+  fun `cannot call upstream when eligible symbol set is empty`() {
+    val prices = service.fetchCurrentPrices(emptySet())
+
     expect(prices.size).toEqual(0)
+    verify(exactly = 0) { client.getPrices(any()) }
+  }
+
+  @Test
+  fun `cannot call upstream when none of the eligible symbols are configured`() {
+    val prices = service.fetchCurrentPrices(setOf("UNKNOWN:PAR:EUR"))
+
+    expect(prices.size).toEqual(0)
+    verify(exactly = 0) { client.getPrices(any()) }
   }
 
   @Test
   fun `cannot return price when ticker missing from upstream response`() {
     every { client.getPrices(any()) } returns Trading212Response(data = emptyMap())
-    val prices = service.fetchCurrentPrices()
+
+    val prices = service.fetchCurrentPrices(setOf("BNKE:PAR:EUR", "VUAA:GER:EUR"))
+
     expect(prices.size).toEqual(0)
   }
 }

--- a/src/test/kotlin/ee/tenman/portfolio/trading212/Trading212ServiceTest.kt
+++ b/src/test/kotlin/ee/tenman/portfolio/trading212/Trading212ServiceTest.kt
@@ -1,5 +1,6 @@
 package ee.tenman.portfolio.trading212
 
+import ch.tutteli.atrium.api.fluent.en_GB.notToEqualNull
 import ch.tutteli.atrium.api.fluent.en_GB.toEqual
 import ch.tutteli.atrium.api.fluent.en_GB.toEqualNumerically
 import ch.tutteli.atrium.api.verbs.expect
@@ -38,8 +39,7 @@ class Trading212ServiceTest {
     val prices = service.fetchCurrentPrices(setOf("BNKE:PAR:EUR"))
 
     expect(prices.size).toEqual(1)
-    expect(prices["BNKE:PAR:EUR"]!!).toEqualNumerically(BigDecimal("330.77"))
-    expect(prices["VUAA:GER:EUR"]).toEqual(null)
+    expect(prices["BNKE:PAR:EUR"]).notToEqualNull().toEqualNumerically(BigDecimal("330.77"))
     verify { client.getPrices("BNKEp_EQ") }
   }
 


### PR DESCRIPTION
## Summary
- BNKE (first `TRADING212` instrument) was stuck at €0.00 on /diversification. Root cause: `Trading212DataRetrievalJob` only ran 10:00–18:30 EET Mon–Fri, and the deploy landed after close, so the job silently skipped every tick.
- Drop the trading-hours gate — the existing `@Scheduled(fixedDelayString=60000)` now fires every minute 24/7, matching the Lightyear pattern.
- Add `@PostConstruct scheduleInitialRun()` with a 15 s initial delay (same shape as `FtDataRetrievalJob`) so prices are pulled on every boot.
- Wire `Trading212DataRetrievalJob` into `PriceRefreshService` so the manual "Refresh prices" button and the Diversification tab's refresh handler both pull Trading212 alongside Binance / Lightyear.

## Test plan
- [x] `./gradlew test --tests "ee.tenman.portfolio.job.Trading212DataRetrievalJobTest"` — 3 new tests: startup schedule captured at now+15 s, `runJob` always delegates, `execute` drives the `PriceUpdateProcessor` with `Platform.TRADING212`.
- [x] `./gradlew test --tests "ee.tenman.portfolio.service.pricing.PriceRefreshServiceTest"` — updated ctor in all call sites + new test verifying `trading212DataRetrievalJob.execute()` is invoked via `refreshAllPrices()`.
- [x] `./gradlew test --tests "ee.tenman.portfolio.ArchitectureTest"` — `serviceConstructorsShouldNotHaveMoreThanEightParameters` and dependency-limit checks still pass.
- [ ] After merge/deploy: confirm BNKE `current_price` updates to the Trading212 bid (~€327) within 15 s of backend startup; verify /diversification shows the price and action.