### PR TITLE
Add LHV/Swedbank Apr 17 transactions and rename BNKE

### DIFF
--- a/src/main/resources/db/migration/V202604171000__lhv_etf_buys_apr17.sql
+++ b/src/main/resources/db/migration/V202604171000__lhv_etf_buys_apr17.sql
@@ -1,0 +1,10 @@
+INSERT INTO portfolio_transaction (instrument_id, transaction_type, quantity, price, transaction_date, platform, commission)
+VALUES
+    ((SELECT id FROM instrument WHERE symbol = 'AIFS:GER:EUR'), 'BUY', 5, 7.174, '2026-04-17', 'LHV', 0),
+    ((SELECT id FROM instrument WHERE symbol = 'DFEN:GER:EUR'), 'BUY', 1, 59.30, '2026-04-17', 'LHV', 0),
+    ((SELECT id FROM instrument WHERE symbol = 'BNKE:PAR:EUR'), 'BUY', 1, 327.60, '2026-04-17', 'LHV', 0),
+    ((SELECT id FROM instrument WHERE symbol = 'DFND:PAR:EUR'), 'BUY', 5, 8.351, '2026-04-17', 'LHV', 0),
+    ((SELECT id FROM instrument WHERE symbol = 'WTAI:MIL:EUR'), 'BUY', 1, 82.32, '2026-04-17', 'LHV', 0),
+    ((SELECT id FROM instrument WHERE symbol = 'XNAS:GER:EUR'), 'BUY', 1, 51.80, '2026-04-17', 'LHV', 0),
+    ((SELECT id FROM instrument WHERE symbol = 'AIFS:GER:EUR'), 'BUY', 4, 7.173, '2026-04-17', 'LHV', 0),
+    ((SELECT id FROM instrument WHERE symbol = 'EUR'), 'SELL', 627.34, 1, '2026-04-17', 'LHV', 0);

--- a/src/main/resources/db/migration/V202604171100__swedbank_sell_qdve_apr17.sql
+++ b/src/main/resources/db/migration/V202604171100__swedbank_sell_qdve_apr17.sql
@@ -1,0 +1,4 @@
+INSERT INTO portfolio_transaction (instrument_id, transaction_type, quantity, price, transaction_date, platform, commission)
+VALUES
+    ((SELECT id FROM instrument WHERE symbol = 'QDVE:GER:EUR'), 'SELL', 76, 36.725, '2026-04-17', 'SWEDBANK', 3.91),
+    ((SELECT id FROM instrument WHERE symbol = 'EUR'), 'BUY', 2787.19, 1, '2026-04-17', 'SWEDBANK', 0);

--- a/src/main/resources/db/migration/V202604171200__rename_bnke_instrument.sql
+++ b/src/main/resources/db/migration/V202604171200__rename_bnke_instrument.sql
@@ -1,0 +1,1 @@
+UPDATE instrument SET name = 'Amundi Euro Stoxx Banks' WHERE symbol = 'BNKE:PAR:EUR';


### PR DESCRIPTION
## Summary
- LHV: 7 ETF buys on 2026-04-17 (AIFS, DFEN, BNKE, DFND, WTAI, XNAS) totalling 627.34 EUR, plus explicit `SELL EUR 627.34` to reconcile cash balance from 631.55 → 4.21 EUR
- Swedbank: QDVE sell of 76 shares @ 36.725 with 3.91 EUR commission, resulting in +2787.19 EUR net cash (matches prior Swedbank sell convention)
- Rename BNKE:PAR:EUR display name from "Amundi Euro Stoxx Banks UCITS ETF Acc" to "Amundi Euro Stoxx Banks"

## Test plan
- [ ] Verify Flyway applies all three migrations cleanly on startup
- [ ] Confirm LHV EUR balance equals 4.21 after migration
- [ ] Confirm Swedbank EUR balance equals 2787.19 after migration
- [ ] Confirm BNKE:PAR:EUR name is "Amundi Euro Stoxx Banks" in the UI