### PR TITLE
Add Karpathy behavioral principles to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,8 +93,6 @@ Auto-generates TypeScript types from Kotlin DTOs to `ui/models/generated/domain-
 
 ## Behavioral Principles
 
-https://x.com/karpathy/status/2015883857489522876
-
 ### 1. Think Before Coding
 
 Don't assume. Don't hide confusion. Don't reflexively agree.
@@ -104,6 +102,7 @@ Don't assume. Don't hide confusion. Don't reflexively agree.
 - If a simpler approach exists, say so. Push back when warranted, even against the user.
 - If something is unclear, stop. Name what's confusing. Ask.
 - Surface tradeoffs and inconsistencies instead of agreeing reflexively.
+- For non-trivial work, state the plan before editing code (use plan mode or inline).
 
 ### 2. Simplicity First
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,7 @@ Auto-generates TypeScript types from Kotlin DTOs to `ui/models/generated/domain-
 Four principles to reduce common coding mistakes (adapted from [Karpathy's observations](https://x.com/karpathy/status/2015883857489522876)). Bias toward caution over speed — use judgment on trivial tasks.
 
 ### 1. Think Before Coding
-Don't assume. Don't hide confusion. Don't be sycophantic.
+Don't assume. Don't hide confusion. Don't reflexively agree.
 - State assumptions explicitly. If uncertain, ask.
 - If multiple interpretations exist, present them — don't pick silently.
 - If a simpler approach exists, say so. Push back when warranted, even against the user.
@@ -116,7 +116,7 @@ Test: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
 
 ### 3. Surgical Changes
 Touch only what you must. Clean up only your own mess.
-- Don't "improve" adjacent code, comments, or formatting.
+- Don't "improve" adjacent code, comments, or formatting as part of an unrelated change.
 - Don't refactor things that aren't broken.
 - Match existing style, even if you'd do it differently.
 - Don't change or remove code/comments you don't understand, even if they look orthogonal.
@@ -141,7 +141,7 @@ For multi-step tasks, state a brief plan:
 
 Strong success criteria let the agent loop independently via tools (tests, type checkers, browser MCP, lint). Weak criteria ("make it work") require constant clarification.
 
-**Anti-pattern examples:** See `~/.claude/docs/karpathy-examples.md` for concrete before/after code diffs.
+**Anti-pattern examples (optional):** See `~/.claude/docs/karpathy-examples.md` for concrete before/after code diffs. Maintainer-local reference — not required to follow the principles above.
 
 ## Core Development Philosophy
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,58 @@ Auto-generates TypeScript types from Kotlin DTOs to `ui/models/generated/domain-
 - Types auto-regenerate on `./gradlew compileKotlin` or `./gradlew build`
 - Post-processing removes timestamps and unexports DateAsString (for knip compatibility)
 
+## Behavioral Principles
+
+Four principles to reduce common coding mistakes (adapted from [Karpathy's observations](https://x.com/karpathy/status/2015883857489522876)). Bias toward caution over speed — use judgment on trivial tasks.
+
+### 1. Think Before Coding
+Don't assume. Don't hide confusion. Don't be sycophantic.
+- State assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them — don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted, even against the user.
+- If something is unclear, stop. Name what's confusing. Ask.
+- Surface tradeoffs and inconsistencies instead of agreeing reflexively.
+
+### 2. Simplicity First
+Minimum code that solves the problem. Nothing speculative.
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If 200 lines could be 50, rewrite it. If asked "couldn't you just do X?", do it.
+- For optimization: write the naive-but-correct version first, then optimize while preserving correctness.
+
+Test: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+### 3. Surgical Changes
+Touch only what you must. Clean up only your own mess.
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- Don't change or remove code/comments you don't understand, even if they look orthogonal.
+- If you notice unrelated dead code, mention it — don't delete it.
+- Remove imports/variables YOUR changes made unused; leave pre-existing dead code alone.
+
+Test: Every changed line should trace directly to the user's request.
+
+### 4. Goal-Driven Execution (Declarative > Imperative)
+Define success criteria. Loop until verified. Use stamina as leverage.
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+- "Optimize Y" → "Naive correct version → benchmark → optimize → verify no regression"
+
+For multi-step tasks, state a brief plan:
+
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+```
+
+Strong success criteria let the agent loop independently via tools (tests, type checkers, browser MCP, lint). Weak criteria ("make it work") require constant clarification.
+
+**Anti-pattern examples:** See `~/.claude/docs/karpathy-examples.md` for concrete before/after code diffs.
+
 ## Core Development Philosophy
 
 Do what has been asked; nothing more, nothing less.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,9 @@ Auto-generates TypeScript types from Kotlin DTOs to `ui/models/generated/domain-
 Four principles to reduce common coding mistakes (adapted from [Karpathy's observations](https://x.com/karpathy/status/2015883857489522876)). Bias toward caution over speed — use judgment on trivial tasks.
 
 ### 1. Think Before Coding
+
 Don't assume. Don't hide confusion. Don't reflexively agree.
+
 - State assumptions explicitly. If uncertain, ask.
 - If multiple interpretations exist, present them — don't pick silently.
 - If a simpler approach exists, say so. Push back when warranted, even against the user.
@@ -104,7 +106,9 @@ Don't assume. Don't hide confusion. Don't reflexively agree.
 - Surface tradeoffs and inconsistencies instead of agreeing reflexively.
 
 ### 2. Simplicity First
+
 Minimum code that solves the problem. Nothing speculative.
+
 - No features beyond what was asked.
 - No abstractions for single-use code.
 - No "flexibility" or "configurability" that wasn't requested.
@@ -115,7 +119,9 @@ Minimum code that solves the problem. Nothing speculative.
 Test: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
 
 ### 3. Surgical Changes
+
 Touch only what you must. Clean up only your own mess.
+
 - Don't "improve" adjacent code, comments, or formatting as part of an unrelated change.
 - Don't refactor things that aren't broken.
 - Match existing style, even if you'd do it differently.
@@ -126,7 +132,9 @@ Touch only what you must. Clean up only your own mess.
 Test: Every changed line should trace directly to the user's request.
 
 ### 4. Goal-Driven Execution (Declarative > Imperative)
+
 Define success criteria. Loop until verified. Use stamina as leverage.
+
 - "Add validation" → "Write tests for invalid inputs, then make them pass"
 - "Fix the bug" → "Write a test that reproduces it, then make it pass"
 - "Refactor X" → "Ensure tests pass before and after"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,7 +122,6 @@ Test: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
 Touch only what you must. Clean up only your own mess.
 
 - Don't "improve" adjacent code, comments, or formatting as part of an unrelated change.
-- Don't refactor things that aren't broken.
 - Match existing style, even if you'd do it differently.
 - Don't change or remove code/comments you don't understand, even if they look orthogonal.
 - If you notice unrelated dead code, mention it — don't delete it.
@@ -152,7 +151,6 @@ Strong success criteria let the agent loop independently via tools (tests, type 
 
 ## Core Development Philosophy
 
-Do what has been asked; nothing more, nothing less.
 NEVER create files unless they're absolutely necessary for achieving your goal.
 ALWAYS prefer editing an existing file to creating a new one.
 NEVER proactively create documentation files (\*.md) or README files. Only create documentation files if explicitly requested by the User.
@@ -234,8 +232,6 @@ ALWAYS follow the existing file naming patterns in the codebase:
 
 - All CI workflows must pass before code changes may be reviewed
 - The existing code structure must not be changed without a strong reason
-- Every bug must be reproduced by a unit test before being fixed
-- Every new feature must be covered by a unit test before it is implemented
 - Minor inconsistencies and typos in the existing code may be fixed
 
 ## Git Commit Conventions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ Auto-generates TypeScript types from Kotlin DTOs to `ui/models/generated/domain-
 
 ## Behavioral Principles
 
-Four principles to reduce common coding mistakes (adapted from [Karpathy's observations](https://x.com/karpathy/status/2015883857489522876)). Bias toward caution over speed — use judgment on trivial tasks.
+https://x.com/karpathy/status/2015883857489522876
 
 ### 1. Think Before Coding
 


### PR DESCRIPTION
## Summary
- Adds a **Behavioral Principles** section to `CLAUDE.md` derived from [Karpathy's observations on LLM coding pitfalls](https://x.com/karpathy/status/2015883857489522876)
- Four principles: Think Before Coding, Simplicity First, Surgical Changes, Goal-Driven Execution
- Extends the original with anti-sycophancy guidance, naive-first optimization, "don't touch code you don't understand", and declarative framing
- Links to local anti-pattern examples at `~/.claude/docs/karpathy-examples.md`

## Why
To reduce common LLM coding mistakes on this repo: wrong assumptions, overcomplication, drive-by refactoring, and vague success criteria. Placed right before the existing Core Development Philosophy so behavioral rules are grouped together.

## Test plan
- [ ] Review the new section reads clearly and doesn't conflict with existing Core Development Philosophy / Clean Code Standards
- [ ] Verify the anchor and section order look right in rendered markdown on GitHub