### PR TITLE
Add LSMC Amundi MSCI Semiconductors instrument

### DIFF
--- a/src/main/kotlin/ee/tenman/portfolio/ft/HistoricalPricesService.kt
+++ b/src/main/kotlin/ee/tenman/portfolio/ft/HistoricalPricesService.kt
@@ -50,6 +50,7 @@ private val TICKERS: Map<String, String> =
     "WEBN:GER:EUR" to "894412378",
     "EXA1:AEX:EUR" to "694104976",
     "BNKE:PAR:EUR" to "70266227",
+    "LSMC:GER:EUR" to "13193608",
   )
 
 private val REQUEST_DATE_FORMATTER: DateTimeFormatter =

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -227,6 +227,8 @@ scraping:
         uuid: "1ef66ace-af0a-6d75-ab3f-c9f7567377e0"
       - symbol: "EXA1:AEX:EUR"
         uuid: "1ef5a0f9-9cfa-6753-9ec2-5b729cca6424"
+      - symbol: "LSMC:GER:EUR"
+        uuid: "1f117a42-27d7-6c28-875d-f55796e57885"
 
 cloudflare-bypass-proxy:
   url: ${CLOUDFLARE_BYPASS_PROXY_URL:${TRADING212_PROXY_URL:http://localhost:3000}}

--- a/src/main/resources/db/migration/V202604191000__add_lsmc_instrument.sql
+++ b/src/main/resources/db/migration/V202604191000__add_lsmc_instrument.sql
@@ -1,0 +1,23 @@
+INSERT INTO instrument (
+    symbol,
+    name,
+    instrument_category,
+    base_currency,
+    provider_name,
+    provider_external_id,
+    current_price,
+    created_at,
+    updated_at,
+    version
+) VALUES (
+    'LSMC:GER:EUR',
+    'Amundi MSCI Semiconductors',
+    'ETF',
+    'EUR',
+    'LIGHTYEAR',
+    '1f117a42-27d7-6c28-875d-f55796e57885',
+    0,
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP,
+    0
+);


### PR DESCRIPTION
## Summary
- Register Amundi MSCI Semiconductors (LSMC, XETRA) as a new ETF instrument
- Provider external ID (Lightyear UUID): `1f117a42-27d7-6c28-875d-f55796e57885`
- FT markets ID for historical price fetch: `13193608`

## Changes
- Flyway migration `V202604191000__add_lsmc_instrument.sql` inserts the instrument
- `HistoricalPricesService.TICKERS` maps `LSMC:GER:EUR` → `13193608` for FT price retrieval
- `scraping.lightyear.etfs` in `application.yml` registers LSMC for Lightyear price scraping

## Test plan
- [ ] Flyway migration applies cleanly on startup
- [ ] Lightyear price retrieval job picks up LSMC and populates `daily_price`
- [ ] FT data retrieval job populates historical prices for LSMC
- [ ] Instrument appears in the UI instrument list